### PR TITLE
test(api): cover types, deepcopy, scheme registration

### DIFF
--- a/api/go.mod
+++ b/api/go.mod
@@ -2,19 +2,26 @@ module github.com/qvest-digital/mxl-k8s/api
 
 go 1.26.0
 
-require k8s.io/apimachinery v0.36.1
+require (
+	github.com/google/go-cmp v0.7.0
+	github.com/stretchr/testify v1.11.1
+	k8s.io/apimachinery v0.36.1
+)
 
 require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -1,0 +1,108 @@
+package v1alpha1
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// allProviders is the closed set of MxlFabricsProvider values accepted by
+// the CRD validation (kubebuilder:validation:Enum on the type). When
+// libmxl-fabrics gains a provider, both the enum and this slice grow
+// together; the tests below pin that invariant.
+var allProviders = []MxlFabricsProvider{
+	ProviderAuto,
+	ProviderTCP,
+	ProviderVerbs,
+	ProviderEFA,
+	ProviderSHM,
+}
+
+func TestFlowIDPattern_Matches(t *testing.T) {
+	re := regexp.MustCompile(FlowIDPattern)
+
+	cases := []struct {
+		name  string
+		input string
+		match bool
+	}{
+		{"canonical lower", "1bcad0e1-3d2d-4d3a-8f1d-9c8c2a2f4f01", true},
+		{"all zeros", "00000000-0000-0000-0000-000000000000", true},
+		{"all f", "ffffffff-ffff-ffff-ffff-ffffffffffff", true},
+		{"uppercase rejected", "1BCAD0E1-3D2D-4D3A-8F1D-9C8C2A2F4F01", false},
+		{"mixed case rejected", "1BCAD0e1-3d2d-4d3a-8f1d-9c8c2a2f4f01", false},
+		{"missing hyphens", "1bcad0e13d2d4d3a8f1d9c8c2a2f4f01", false},
+		{"wrong group sizes", "1bcad0e-13d2d-4d3a-8f1d-9c8c2a2f4f01", false},
+		{"extra group", "1bcad0e1-3d2d-4d3a-8f1d-9c8c2a2f4f01-extra", false},
+		{"trailing whitespace", "1bcad0e1-3d2d-4d3a-8f1d-9c8c2a2f4f01 ", false},
+		{"leading whitespace", " 1bcad0e1-3d2d-4d3a-8f1d-9c8c2a2f4f01", false},
+		{"non-hex chars", "1bcad0e1-3d2d-4d3a-8f1d-9c8c2a2f4f0g", false},
+		{"empty", "", false},
+		{"too short", "1bcad0e1-3d2d-4d3a-8f1d", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.match, re.MatchString(tc.input))
+		})
+	}
+}
+
+func TestMxlFabricsProvider_KnownValues(t *testing.T) {
+	t.Run("each provider stringifies to its const", func(t *testing.T) {
+		expected := map[MxlFabricsProvider]string{
+			ProviderAuto:  "auto",
+			ProviderTCP:   "tcp",
+			ProviderVerbs: "verbs",
+			ProviderEFA:   "efa",
+			ProviderSHM:   "shm",
+		}
+		for p, want := range expected {
+			assert.Equal(t, want, string(p), "provider %q", p)
+		}
+	})
+
+	t.Run("allProviders is unique", func(t *testing.T) {
+		seen := map[MxlFabricsProvider]struct{}{}
+		for _, p := range allProviders {
+			_, dup := seen[p]
+			require.Falsef(t, dup, "duplicate provider %q in allProviders", p)
+			seen[p] = struct{}{}
+		}
+	})
+
+	t.Run("zero value is not a valid provider", func(t *testing.T) {
+		var zero MxlFabricsProvider
+		assert.NotContains(t, allProviders, zero,
+			"empty provider string must not be a valid CRD enum value; "+
+				"the operator relies on the kubebuilder default kicking in "+
+				"when the field is omitted")
+	})
+}
+
+func TestFlowPhaseConstants(t *testing.T) {
+	// Pin the wire format of every CRD phase. A typo in a const that
+	// flips the casing or drops a letter would cascade into stale CRs
+	// that the controllers no longer match against.
+	t.Run("MxlFlowLocationPhase", func(t *testing.T) {
+		assert.Equal(t, MxlFlowLocationPhase("Origin"), MxlFlowLocationOrigin)
+		assert.Equal(t, MxlFlowLocationPhase("Mirroring"), MxlFlowLocationMirroring)
+		assert.Equal(t, MxlFlowLocationPhase("Ready"), MxlFlowLocationReady)
+		assert.Equal(t, MxlFlowLocationPhase("Stale"), MxlFlowLocationStale)
+	})
+
+	t.Run("MxlReceiverPhase", func(t *testing.T) {
+		assert.Equal(t, MxlReceiverPhase("Pending"), MxlReceiverPending)
+		assert.Equal(t, MxlReceiverPhase("Bound"), MxlReceiverBound)
+		assert.Equal(t, MxlReceiverPhase("Failed"), MxlReceiverFailed)
+	})
+
+	t.Run("MxlFlowMirrorPhase", func(t *testing.T) {
+		assert.Equal(t, MxlFlowMirrorPhase("Pending"), MxlFlowMirrorPending)
+		assert.Equal(t, MxlFlowMirrorPhase("Materializing"), MxlFlowMirrorMaterializing)
+		assert.Equal(t, MxlFlowMirrorPhase("Ready"), MxlFlowMirrorReady)
+		assert.Equal(t, MxlFlowMirrorPhase("Failed"), MxlFlowMirrorFailed)
+	})
+}

--- a/api/v1alpha1/deepcopy_test.go
+++ b/api/v1alpha1/deepcopy_test.go
@@ -1,0 +1,299 @@
+package v1alpha1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// These tests guard against accidental shallow copies in the
+// controller-gen-emitted DeepCopyInto helpers. Any future hand-edit (or
+// controller-gen change) that drops the per-element copy of a slice or
+// map will let the original and the copy share backing storage; a
+// reconciler that mutates the copy will then leak into the cached
+// object. The tests provoke exactly that aliasing.
+
+func TestDeepCopy_MxlFlow_LocationsAreNotAliased(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	orig := &MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: "flow-a"},
+		Spec: MxlFlowSpec{
+			ID:         "11111111-2222-3333-4444-555555555555",
+			Definition: runtime.RawExtension{Raw: []byte(`{"id":"x"}`)},
+		},
+		Status: MxlFlowStatus{
+			Locations: []MxlFlowLocation{
+				{NodeName: "n1", Phase: MxlFlowLocationOrigin, LastObserved: &now},
+				{NodeName: "n2", Phase: MxlFlowLocationReady},
+			},
+			Conditions: []metav1.Condition{
+				{Type: "Available", Status: metav1.ConditionTrue, Reason: "Live"},
+			},
+		},
+	}
+
+	copy := orig.DeepCopy()
+	require.NotNil(t, copy)
+	require.NotSame(t, orig, copy)
+
+	// Mutate the original through every reference path that DeepCopy
+	// must have severed. Each mutation must NOT show up in the copy.
+	orig.Status.Locations[0].NodeName = "mutated"
+	orig.Status.Locations[1].Phase = MxlFlowLocationStale
+	orig.Status.Conditions[0].Reason = "Broken"
+	orig.Spec.Definition.Raw[0] = 'Z'
+
+	assert.Equal(t, "n1", copy.Status.Locations[0].NodeName)
+	assert.Equal(t, MxlFlowLocationReady, copy.Status.Locations[1].Phase)
+	assert.Equal(t, "Live", copy.Status.Conditions[0].Reason)
+	assert.Equal(t, byte('{'), copy.Spec.Definition.Raw[0])
+}
+
+func TestDeepCopy_MxlFlowMirror_StatusFieldsAreNotAliased(t *testing.T) {
+	orig := &MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Name: "m"},
+		Spec: MxlFlowMirrorSpec{
+			FlowID:     "11111111-2222-3333-4444-555555555555",
+			SourceNode: "n1",
+			TargetNode: "n2",
+			Provider:   ProviderTCP,
+			Requestor:  &PodRef{Name: "pod", Namespace: "ns"},
+		},
+		Status: MxlFlowMirrorStatus{
+			Phase:      MxlFlowMirrorReady,
+			TargetInfo: "info-a",
+			Conditions: []metav1.Condition{
+				{Type: "Materialized", Status: metav1.ConditionTrue},
+			},
+		},
+	}
+
+	copy := orig.DeepCopy()
+	require.NotNil(t, copy)
+
+	orig.Spec.Requestor.Name = "mutated"
+	orig.Status.Conditions[0].Type = "BrokenType"
+	orig.Status.Phase = MxlFlowMirrorFailed
+
+	assert.Equal(t, "pod", copy.Spec.Requestor.Name)
+	assert.Equal(t, "Materialized", copy.Status.Conditions[0].Type)
+	assert.Equal(t, MxlFlowMirrorReady, copy.Status.Phase)
+}
+
+func TestDeepCopy_MxlNodeCapabilities_ProvidersAreNotAliased(t *testing.T) {
+	orig := &MxlNodeCapabilities{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+		Spec:       MxlNodeCapabilitiesSpec{NodeName: "node-a"},
+		Status: MxlNodeCapabilitiesStatus{
+			Providers: []MxlFabricsProviderCapability{
+				{Name: ProviderTCP, Version: "1.2", DeviceCount: 1},
+				{Name: ProviderVerbs, Version: "3.4", DeviceCount: 2},
+			},
+		},
+	}
+
+	copy := orig.DeepCopy()
+	require.NotNil(t, copy)
+
+	orig.Status.Providers[0].DeviceCount = 99
+	orig.Status.Providers = append(orig.Status.Providers,
+		MxlFabricsProviderCapability{Name: ProviderEFA})
+
+	assert.Equal(t, int32(1), copy.Status.Providers[0].DeviceCount)
+	assert.Lenf(t, copy.Status.Providers, 2,
+		"appending to the original must not extend the copy")
+}
+
+func TestDeepCopy_MxlReceiver_PodSelectorAndRefAreNotAliased(t *testing.T) {
+	orig := &MxlReceiver{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "ns"},
+		Spec: MxlReceiverSpec{
+			FlowID:      "11111111-2222-3333-4444-555555555555",
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			Provider:    ProviderAuto,
+		},
+		Status: MxlReceiverStatus{
+			Phase:       MxlReceiverBound,
+			BoundMirror: &MirrorRef{Name: "m1", Namespace: "ns"},
+		},
+	}
+
+	copy := orig.DeepCopy()
+	require.NotNil(t, copy)
+
+	orig.Spec.PodSelector.MatchLabels["app"] = "mutated"
+	orig.Status.BoundMirror.Name = "mutated"
+
+	assert.Equal(t, "x", copy.Spec.PodSelector.MatchLabels["app"])
+	assert.Equal(t, "m1", copy.Status.BoundMirror.Name)
+}
+
+func TestDeepCopy_MxlDomain_StatusIsNotAliased(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	orig := &MxlDomain{
+		Spec: MxlDomainSpec{NodeName: "n1", HostPath: "/run/mxl/domain"},
+		Status: MxlDomainStatus{
+			CapacityBytes: 1 << 30,
+			FreeBytes:     1 << 20,
+			FanotifyReady: true,
+			LastSeen:      &now,
+			Conditions: []metav1.Condition{
+				{Type: "Ready", Status: metav1.ConditionTrue},
+			},
+		},
+	}
+
+	copy := orig.DeepCopy()
+	require.NotNil(t, copy)
+
+	orig.Status.LastSeen.Time = time.Time{}
+	orig.Status.Conditions[0].Status = metav1.ConditionFalse
+
+	assert.NotEqual(t, time.Time{}, copy.Status.LastSeen.Time)
+	assert.Equal(t, metav1.ConditionTrue, copy.Status.Conditions[0].Status)
+}
+
+func TestDeepCopy_Lists_ItemsAreNotAliased(t *testing.T) {
+	// One assertion per List type. controller-gen has historically
+	// emitted shallow Items copies when manually altered; if a list's
+	// Items slice ever shares backing storage with the source, mutating
+	// the source list leaks into the cached copy held by client-go.
+	cases := []struct {
+		name string
+		mut  func() (orig runtime.Object, copy runtime.Object)
+	}{
+		{"MxlFlowList", func() (runtime.Object, runtime.Object) {
+			o := &MxlFlowList{Items: []MxlFlow{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}}
+			c := o.DeepCopy()
+			o.Items[0].ObjectMeta.Name = "mutated"
+			return o, c
+		}},
+		{"MxlReceiverList", func() (runtime.Object, runtime.Object) {
+			o := &MxlReceiverList{Items: []MxlReceiver{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}}
+			c := o.DeepCopy()
+			o.Items[0].ObjectMeta.Name = "mutated"
+			return o, c
+		}},
+		{"MxlFlowMirrorList", func() (runtime.Object, runtime.Object) {
+			o := &MxlFlowMirrorList{Items: []MxlFlowMirror{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}}
+			c := o.DeepCopy()
+			o.Items[0].ObjectMeta.Name = "mutated"
+			return o, c
+		}},
+		{"MxlDomainList", func() (runtime.Object, runtime.Object) {
+			o := &MxlDomainList{Items: []MxlDomain{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}}
+			c := o.DeepCopy()
+			o.Items[0].ObjectMeta.Name = "mutated"
+			return o, c
+		}},
+		{"MxlNodeCapabilitiesList", func() (runtime.Object, runtime.Object) {
+			o := &MxlNodeCapabilitiesList{Items: []MxlNodeCapabilities{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}}
+			c := o.DeepCopy()
+			o.Items[0].ObjectMeta.Name = "mutated"
+			return o, c
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, c := tc.mut()
+			// Pull the copy's first item name through reflection-free
+			// type assertions for each concrete type.
+			switch v := c.(type) {
+			case *MxlFlowList:
+				assert.Equal(t, "a", v.Items[0].ObjectMeta.Name)
+			case *MxlReceiverList:
+				assert.Equal(t, "a", v.Items[0].ObjectMeta.Name)
+			case *MxlFlowMirrorList:
+				assert.Equal(t, "a", v.Items[0].ObjectMeta.Name)
+			case *MxlDomainList:
+				assert.Equal(t, "a", v.Items[0].ObjectMeta.Name)
+			case *MxlNodeCapabilitiesList:
+				assert.Equal(t, "a", v.Items[0].ObjectMeta.Name)
+			default:
+				t.Fatalf("unexpected list type %T", v)
+			}
+		})
+	}
+}
+
+func TestDeepCopy_RoundTrip_Equals(t *testing.T) {
+	// For each top-level kind: building an object, deep-copying it,
+	// and comparing the two with go-cmp must produce no diff. This
+	// catches any field that DeepCopyInto silently leaves unset (a
+	// regression class controller-gen has produced in the past when a
+	// new field is added to a type but the generator is not re-run).
+	cases := []runtime.Object{
+		&MxlFlow{
+			ObjectMeta: metav1.ObjectMeta{Name: "f"},
+			Spec: MxlFlowSpec{
+				ID:         "11111111-2222-3333-4444-555555555555",
+				Definition: runtime.RawExtension{Raw: []byte(`{"a":1}`)},
+			},
+			Status: MxlFlowStatus{
+				Locations: []MxlFlowLocation{{NodeName: "n", Phase: MxlFlowLocationOrigin}},
+			},
+		},
+		&MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns"},
+			Spec: MxlReceiverSpec{
+				FlowID:   "11111111-2222-3333-4444-555555555555",
+				PodRef:   &PodRef{Name: "p", Namespace: "ns", UID: "u"},
+				Provider: ProviderTCP,
+			},
+			Status: MxlReceiverStatus{
+				Phase:       MxlReceiverBound,
+				BoundMirror: &MirrorRef{Name: "m", Namespace: "ns"},
+			},
+		},
+		&MxlFlowMirror{
+			Spec: MxlFlowMirrorSpec{
+				FlowID:     "11111111-2222-3333-4444-555555555555",
+				SourceNode: "a",
+				TargetNode: "b",
+				Provider:   ProviderVerbs,
+			},
+			Status: MxlFlowMirrorStatus{Phase: MxlFlowMirrorReady, TargetInfo: "info"},
+		},
+		&MxlDomain{
+			Spec:   MxlDomainSpec{NodeName: "n", HostPath: "/run/mxl/domain"},
+			Status: MxlDomainStatus{CapacityBytes: 100, FreeBytes: 50, FanotifyReady: true},
+		},
+		&MxlNodeCapabilities{
+			Spec: MxlNodeCapabilitiesSpec{NodeName: "n"},
+			Status: MxlNodeCapabilitiesStatus{
+				Providers: []MxlFabricsProviderCapability{{Name: ProviderTCP, DeviceCount: 1}},
+			},
+		},
+	}
+	for _, in := range cases {
+		t.Run(typeName(in), func(t *testing.T) {
+			out := in.DeepCopyObject()
+			if diff := cmp.Diff(in, out); diff != "" {
+				t.Fatalf("DeepCopyObject diverged from source (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func typeName(o runtime.Object) string {
+	return o.GetObjectKind().GroupVersionKind().Kind + "_" + objAddrName(o)
+}
+
+func objAddrName(o runtime.Object) string {
+	type named interface {
+		GetName() string
+	}
+	if n, ok := o.(metav1.Object); ok {
+		return n.GetName()
+	}
+	if n, ok := o.(named); ok {
+		return n.GetName()
+	}
+	return "unnamed"
+}

--- a/api/v1alpha1/groupversion_info_test.go
+++ b/api/v1alpha1/groupversion_info_test.go
@@ -1,0 +1,133 @@
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// expectedKinds enumerates every CRD kind this package serves. The map
+// pairs the kind name (the value of the kubebuilder:resource marker's
+// effective Kind, i.e. the Go struct name) with a zero-valued instance
+// the test can register and look up. A new CRD added to the package
+// without an entry here fails the test, forcing the new type to be
+// added to addKnownTypes alongside this map.
+var expectedKinds = map[string]struct {
+	item runtime.Object
+	list runtime.Object
+}{
+	"MxlDomain":           {&MxlDomain{}, &MxlDomainList{}},
+	"MxlFlow":             {&MxlFlow{}, &MxlFlowList{}},
+	"MxlFlowMirror":       {&MxlFlowMirror{}, &MxlFlowMirrorList{}},
+	"MxlReceiver":         {&MxlReceiver{}, &MxlReceiverList{}},
+	"MxlNodeCapabilities": {&MxlNodeCapabilities{}, &MxlNodeCapabilitiesList{}},
+}
+
+func TestGroupVersion(t *testing.T) {
+	assert.Equal(t, "mxl.qvest-digital.com", GroupVersion.Group)
+	assert.Equal(t, "v1alpha1", GroupVersion.Version)
+}
+
+func TestAddToScheme_RegistersEveryKind(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, AddToScheme(scheme))
+
+	for kind, pair := range expectedKinds {
+		t.Run(kind, func(t *testing.T) {
+			gvk := schema.GroupVersionKind{
+				Group:   GroupVersion.Group,
+				Version: GroupVersion.Version,
+				Kind:    kind,
+			}
+			gvkList := schema.GroupVersionKind{
+				Group:   GroupVersion.Group,
+				Version: GroupVersion.Version,
+				Kind:    kind + "List",
+			}
+
+			assert.Truef(t, scheme.Recognizes(gvk),
+				"scheme did not register the %s kind; addKnownTypes "+
+					"likely lost the entry", kind)
+			assert.Truef(t, scheme.Recognizes(gvkList),
+				"scheme did not register the %sList kind", kind)
+
+			gvks, _, err := scheme.ObjectKinds(pair.item)
+			require.NoError(t, err)
+			require.Contains(t, gvks, gvk,
+				"the registered Go type %T does not resolve back to %v",
+				pair.item, gvk)
+
+			gvks, _, err = scheme.ObjectKinds(pair.list)
+			require.NoError(t, err)
+			require.Contains(t, gvks, gvkList,
+				"the registered Go list type %T does not resolve back to %v",
+				pair.list, gvkList)
+
+			// Round-trip a zero value through scheme.New to ensure the
+			// returned object is a non-nil pointer of the same dynamic
+			// type the test registered. The cache-warming codepath in
+			// client-go calls scheme.New for every watch event; a
+			// silent regression here would surface as nil-pointer
+			// panics under load instead of at compile time.
+			fresh, err := scheme.New(gvk)
+			require.NoError(t, err)
+			require.NotNil(t, fresh)
+			assert.Equal(t,
+				reflect.TypeOf(pair.item),
+				reflect.TypeOf(fresh),
+				"scheme.New returned %T, expected %T", fresh, pair.item)
+		})
+	}
+}
+
+func TestAddToScheme_NoExtraKindsLeak(t *testing.T) {
+	// The inverse of the previous test: every kind the scheme knows
+	// about under GroupVersion must appear in expectedKinds (modulo
+	// List companions and the metav1.AddToGroupVersion machinery).
+	// Catches a stray AddKnownTypes call that registered a Go type
+	// nobody added to the manifest above.
+	scheme := runtime.NewScheme()
+	require.NoError(t, AddToScheme(scheme))
+
+	knownByGV := scheme.KnownTypes(GroupVersion)
+
+	allowed := map[string]struct{}{
+		// metav1.AddToGroupVersion adds these. They are not part of
+		// this package's CRD surface but must remain present for list
+		// and watch operations to work.
+		"WatchEvent":                {},
+		"APIGroup":                  {},
+		"APIGroupList":              {},
+		"APIResourceList":           {},
+		"APIVersions":               {},
+		"CreateOptions":             {},
+		"DeleteOptions":             {},
+		"GetOptions":                {},
+		"ListOptions":               {},
+		"PatchOptions":              {},
+		"UpdateOptions":             {},
+		"Status":                    {},
+		"Table":                     {},
+		"TableOptions":              {},
+		"PartialObjectMetadata":     {},
+		"PartialObjectMetadataList": {},
+	}
+	for k := range expectedKinds {
+		allowed[k] = struct{}{}
+		allowed[k+"List"] = struct{}{}
+	}
+
+	for kind := range knownByGV {
+		_, ok := allowed[kind]
+		assert.Truef(t, ok,
+			"kind %q is registered with the scheme but is not "+
+				"listed in expectedKinds; either add it to the test "+
+				"manifest or remove the AddKnownTypes call that "+
+				"registered it",
+			kind)
+	}
+}


### PR DESCRIPTION
## Summary

First module covered by the new test infrastructure. Targets the
test-tooling branch so the new CI jobs exercise these tests on the
PR; once that PR lands the base will move to main automatically.

## What lands

- `api/v1alpha1/common_test.go`: FlowIDPattern table (canonical
  accept, uppercase/mixed-case reject, hyphen / length / whitespace
  / non-hex rejections); MxlFabricsProvider enum invariants
  (string values, unique const list, zero value not in enum);
  phase constants pinned to their wire-format strings for each of
  the three phase enums.
- `api/v1alpha1/deepcopy_test.go`: mutate-after-copy assertions
  across every CRD's status and spec reference paths; *List Items
  aliasing assertions; full go-cmp round-trip equality check for
  each kind.
- `api/v1alpha1/groupversion_info_test.go`: expected-kind manifest;
  scheme.Recognizes / scheme.ObjectKinds / scheme.New round-trips;
  inverse no-extra-kinds-leak check against metav1's known
  meta-types.

## Verification

- `make test-one MODULE=api` reports `DONE 47 tests`, coverage
  60.6% of statements in `api/v1alpha1`. The uncovered portion is
  generated DeepCopyInto for kinds whose top-level container is
  exercised through their parent.
- `gofmt -l api/` is clean.
- `cd api && go vet ./...` is clean.