### PR TITLE
test(operator): cover receiver reconciler and stub smoke paths

### DIFF
--- a/operator/go.mod
+++ b/operator/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -37,6 +38,7 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect

--- a/operator/internal/domain/controller_test.go
+++ b/operator/internal/domain/controller_test.go
@@ -1,0 +1,72 @@
+package domain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// The domain reconciler is an observer stub: the per-node agent
+// owns the status (capacity, free bytes, fanotify state). The
+// operator must not write to it.
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestReconcile_ExistingDomain_IsObservedWithoutMutation(t *testing.T) {
+	scheme := newScheme(t)
+	d := &mxlv1alpha1.MxlDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       mxlv1alpha1.MxlDomainSpec{NodeName: "n1", HostPath: "/run/mxl/domain"},
+		Status: mxlv1alpha1.MxlDomainStatus{
+			CapacityBytes: 1 << 30,
+			FanotifyReady: true,
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlDomain{}).
+		WithObjects(d.DeepCopy()).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "n1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+
+	var after mxlv1alpha1.MxlDomain
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "n1"}, &after))
+	assert.Equal(t, d.Status, after.Status,
+		"the agent is the sole writer of MxlDomain.status; a non-empty "+
+			"diff here would race fanotify-ready transitions")
+}
+
+func TestReconcile_MissingDomain_NoError(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "missing"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+}

--- a/operator/internal/flow/controller_test.go
+++ b/operator/internal/flow/controller_test.go
@@ -1,0 +1,93 @@
+package flow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// The flow reconciler is an observer stub: the agent owns MxlFlow
+// status, the operator only logs the event. The contract that needs
+// to hold is therefore narrow: do not mutate the CR, do not requeue,
+// do not crash on missing objects. A future change that quietly turns
+// the reconciler into a writer would be caught by the no-mutation
+// assertion.
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestReconcile_ExistingFlow_IsObservedWithoutMutation(t *testing.T) {
+	scheme := newScheme(t)
+	flow := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: "11111111-2222-3333-4444-555555555555"},
+		Spec: mxlv1alpha1.MxlFlowSpec{
+			ID: "11111111-2222-3333-4444-555555555555",
+		},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{
+				{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy()).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: flow.Name},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+
+	var after mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: flow.Name}, &after))
+	assert.Equal(t, flow.Spec, after.Spec)
+	assert.Equal(t, flow.Status, after.Status,
+		"the operator must not write MxlFlow.status; the agent owns it. "+
+			"Any non-empty diff here is a contract violation that would "+
+			"race the agent's status updates")
+}
+
+func TestReconcile_MissingFlow_NoError(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "missing"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+}
+
+// Compile-time guarantee that the package still ships an obvious
+// Reconcile entry point. If the public Reconcile method ever moves
+// to a different receiver, every consumer of the package breaks at
+// build time; this declaration keeps that obvious in the test
+// binary too.
+var _ = (*Reconciler)(nil).Reconcile
+
+// silence unused-import diagnostics when the test file is the only
+// importer of a package.
+var _ = client.IgnoreNotFound

--- a/operator/internal/mirror/controller_test.go
+++ b/operator/internal/mirror/controller_test.go
@@ -1,0 +1,80 @@
+package mirror
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// The mirror reconciler is a placeholder: it observes MxlFlowMirror
+// events and logs. The gateway, not the operator, drives the data
+// plane. The contract: read-only, no requeue, no panic on missing.
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestReconcile_ExistingMirror_IsObservedWithoutMutation(t *testing.T) {
+	scheme := newScheme(t)
+	m := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "m1"},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     "11111111-2222-3333-4444-555555555555",
+			SourceNode: "n1",
+			TargetNode: "n2",
+			Provider:   mxlv1alpha1.ProviderTCP,
+		},
+		Status: mxlv1alpha1.MxlFlowMirrorStatus{
+			Phase:      mxlv1alpha1.MxlFlowMirrorReady,
+			TargetInfo: "info",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(m.DeepCopy()).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "m1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+
+	var after mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: "ns", Name: "m1"}, &after))
+	assert.Equal(t, m.Spec, after.Spec)
+	assert.Equal(t, m.Status, after.Status,
+		"the operator must not write MxlFlowMirror.status; the gateway "+
+			"owns it through the OpenMirror gRPC. A status change here "+
+			"would race the data-plane state machine")
+}
+
+func TestReconcile_MissingMirror_NoError(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "missing"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+}

--- a/operator/internal/nodecaps/controller_test.go
+++ b/operator/internal/nodecaps/controller_test.go
@@ -1,0 +1,73 @@
+package nodecaps
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// The nodecaps reconciler is an observer stub: the gateway owns the
+// status (probed libmxl-fabrics providers). The operator must not
+// write to it.
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestReconcile_ExistingNodeCapabilities_IsObservedWithoutMutation(t *testing.T) {
+	scheme := newScheme(t)
+	nc := &mxlv1alpha1.MxlNodeCapabilities{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       mxlv1alpha1.MxlNodeCapabilitiesSpec{NodeName: "n1"},
+		Status: mxlv1alpha1.MxlNodeCapabilitiesStatus{
+			Providers: []mxlv1alpha1.MxlFabricsProviderCapability{
+				{Name: mxlv1alpha1.ProviderTCP, DeviceCount: 1},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlNodeCapabilities{}).
+		WithObjects(nc.DeepCopy()).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "n1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+
+	var after mxlv1alpha1.MxlNodeCapabilities
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "n1"}, &after))
+	assert.Equal(t, nc.Status, after.Status,
+		"the gateway is the sole writer of MxlNodeCapabilities.status; "+
+			"an operator-side update would race the provider-probe loop")
+}
+
+func TestReconcile_MissingNodeCapabilities_NoError(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "missing"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+}

--- a/operator/internal/receiver/controller_envtest_test.go
+++ b/operator/internal/receiver/controller_envtest_test.go
@@ -1,0 +1,291 @@
+package receiver_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+	"github.com/qvest-digital/mxl-k8s/operator/internal/receiver"
+	"github.com/qvest-digital/mxl-k8s/operator/internal/testutil"
+)
+
+// flowIDFor derives a deterministic UUID-shaped string from the
+// current test's name so the cluster-scoped MxlFlow does not collide
+// across the suite's tests. SHA-256 keeps the result reproducible
+// across runs; t.Cleanup deletes the flow when the test exits.
+func flowIDFor(t *testing.T) string {
+	t.Helper()
+	h := sha256.Sum256([]byte(t.Name()))
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		binary.BigEndian.Uint32(h[0:4]),
+		binary.BigEndian.Uint16(h[4:6]),
+		binary.BigEndian.Uint16(h[6:8]),
+		binary.BigEndian.Uint16(h[8:10]),
+		h[10:16])
+}
+
+// newFlow creates a cluster-scoped MxlFlow with a per-test UUID,
+// optionally pins its Origin location, and registers cleanup so the
+// flow does not leak into the next test.
+func newFlow(t *testing.T, originNode string) *mxlv1alpha1.MxlFlow {
+	t.Helper()
+	id := flowIDFor(t)
+	flow := testutil.NewFlow(testutil.WithFlowID(id))
+	require.NoError(t, env.Client.Create(context.Background(), flow))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = env.Client.Delete(ctx, &mxlv1alpha1.MxlFlow{
+			ObjectMeta: metav1.ObjectMeta{Name: id},
+		})
+	})
+	if originNode != "" {
+		require.NoError(t, withFlowOriginStatus(env.Client, flow, originNode))
+	}
+	return flow
+}
+
+// All envtest scenarios share the package-level env spun up by
+// TestMain (see suite_test.go). Each Test* takes its own namespace so
+// the assertions are isolated from sibling tests.
+
+func reconcile(t *testing.T, r *receiver.Reconciler, ns, name string) ctrl.Result {
+	t.Helper()
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	})
+	require.NoError(t, err)
+	return res
+}
+
+func mustGetReceiver(t *testing.T, c client.Client, ns, name string) *mxlv1alpha1.MxlReceiver {
+	t.Helper()
+	var out mxlv1alpha1.MxlReceiver
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: ns, Name: name}, &out))
+	return &out
+}
+
+func TestReconcile_NoMatchingPods_MarksPendingAndRequeues(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	rec := testutil.NewReceiver(ns, "r")
+	require.NoError(t, env.Client.Create(context.Background(), rec))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, 10*time.Second, res.RequeueAfter,
+		"the requeue interval is the contract every consumer expects; "+
+			"shrinking it would burn the operator's leader-election lease, "+
+			"growing it would slow first-grain visibility on a cold cluster")
+
+	got := mustGetReceiver(t, env.Client, ns, "r")
+	assert.Equal(t, mxlv1alpha1.MxlReceiverPending, got.Status.Phase)
+	assert.Nil(t, got.Status.BoundMirror)
+
+	// And no mirror was created.
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	assert.Empty(t, mirrors.Items)
+}
+
+func TestReconcile_PodsButNoFlow_MarksPendingAndRequeues(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "consumer-a", "worker-1")))
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewReceiver(ns, "r")))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, 10*time.Second, res.RequeueAfter)
+	assert.Equal(t, mxlv1alpha1.MxlReceiverPending, mustGetReceiver(t, env.Client, ns, "r").Status.Phase)
+
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	assert.Empty(t, mirrors.Items,
+		"a missing flow must not produce a half-formed mirror; the receiver "+
+			"reconciler is the only writer of MxlFlowMirror and an early "+
+			"create would deadlock the gateway lifecycle")
+}
+
+func TestReconcile_DistinctSourceAndTarget_CreatesOneMirror(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	// Source pod sits on worker-source; target pod on worker-target.
+	// The flow advertises worker-source as Origin.
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "consumer-a", "worker-target")))
+
+	flow := newFlow(t, "worker-source")
+	require.NoError(t, env.Client.Create(context.Background(),
+		testutil.NewReceiver(ns, "r", testutil.WithReceiverFlowID(flow.Spec.ID))))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, ctrl.Result{}, res, "Bound state should not requeue")
+
+	rec := mustGetReceiver(t, env.Client, ns, "r")
+	assert.Equal(t, mxlv1alpha1.MxlReceiverBound, rec.Status.Phase)
+	require.NotNil(t, rec.Status.BoundMirror, "Bound state must carry a mirror reference")
+
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	require.Len(t, mirrors.Items, 1)
+	mirror := mirrors.Items[0]
+	assert.Equal(t, "worker-source", mirror.Spec.SourceNode)
+	assert.Equal(t, "worker-target", mirror.Spec.TargetNode)
+	assert.Equal(t, flow.Spec.ID, mirror.Spec.FlowID)
+	assert.Equal(t, mxlv1alpha1.ProviderTCP, mirror.Spec.Provider,
+		"the receiver's Provider must flow through to the mirror; the "+
+			"gateway selects libfabric provider from this field")
+}
+
+func TestReconcile_SameSourceAndTarget_SkipsMirrorCreation(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	// Pod on the same node as the flow's origin: no mirror needed.
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "consumer-a", "worker-shared")))
+
+	flow := newFlow(t, "worker-shared")
+	require.NoError(t, env.Client.Create(context.Background(),
+		testutil.NewReceiver(ns, "r", testutil.WithReceiverFlowID(flow.Spec.ID))))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, ctrl.Result{}, res)
+
+	rec := mustGetReceiver(t, env.Client, ns, "r")
+	assert.Equal(t, mxlv1alpha1.MxlReceiverBound, rec.Status.Phase)
+	assert.Nil(t, rec.Status.BoundMirror,
+		"same-node skip leaves the receiver Bound but without a mirror ref; "+
+			"the consumer reads the local flow directly without going through libfabric")
+
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	assert.Empty(t, mirrors.Items)
+}
+
+func TestReconcile_MultipleTargetNodes_CreatesOneMirrorPerNode(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "a", "n-b")))
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "b", "n-c")))
+	// A duplicate consumer on n-b must not produce a second mirror.
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "c", "n-b")))
+
+	flow := newFlow(t, "n-source")
+	require.NoError(t, env.Client.Create(context.Background(),
+		testutil.NewReceiver(ns, "r", testutil.WithReceiverFlowID(flow.Spec.ID))))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, ctrl.Result{}, res)
+
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	require.Len(t, mirrors.Items, 2)
+
+	gotNodes := map[string]struct{}{}
+	for _, m := range mirrors.Items {
+		gotNodes[m.Spec.TargetNode] = struct{}{}
+	}
+	assert.Equal(t,
+		map[string]struct{}{"n-b": {}, "n-c": {}},
+		gotNodes,
+		"two distinct target nodes -> two mirrors; the duplicate pod on n-b must collapse")
+}
+
+func TestReconcile_IsIdempotent_DoesNotRecreateExistingMirror(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "consumer-a", "worker-target")))
+	flow := newFlow(t, "worker-source")
+	require.NoError(t, env.Client.Create(context.Background(),
+		testutil.NewReceiver(ns, "r", testutil.WithReceiverFlowID(flow.Spec.ID))))
+
+	// First reconcile creates the mirror.
+	reconcile(t, r, ns, "r")
+	var before mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &before, client.InNamespace(ns)))
+	require.Len(t, before.Items, 1)
+	firstUID := before.Items[0].UID
+
+	// Second reconcile must reuse the same mirror (same UID), not
+	// produce a new one. The reconciler picks names deterministically;
+	// any drift would either error on AlreadyExists or replace the
+	// running mirror, both of which would interrupt the data plane.
+	reconcile(t, r, ns, "r")
+	var after mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &after, client.InNamespace(ns)))
+	require.Len(t, after.Items, 1)
+	assert.Equal(t, firstUID, after.Items[0].UID)
+}
+
+func TestReconcile_DeletionTimestamp_NoOps(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	// Create a receiver carrying a finalizer so it lingers under
+	// deletion, then issue Delete; envtest will set the deletion
+	// timestamp and keep the object around for the reconciler to see.
+	rec := testutil.NewReceiver(ns, "r")
+	rec.Finalizers = []string{"test.mxl.qvest-digital.com/keepalive"}
+	require.NoError(t, env.Client.Create(context.Background(), rec))
+	require.NoError(t, env.Client.Delete(context.Background(), rec))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, ctrl.Result{}, res,
+		"a receiver mid-deletion must not be requeued or mutated; the "+
+			"reconciler's only safe action here is to walk away")
+
+	// And no mirror should have been created.
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	assert.Empty(t, mirrors.Items)
+}
+
+func TestReconcile_NotFound_ReturnsClean(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: "does-not-exist"},
+	})
+	require.NoError(t, err,
+		"a Reconcile call for a deleted CR must not bubble up the 404; "+
+			"controller-runtime requeues errors aggressively and would tight-loop")
+	assert.Equal(t, ctrl.Result{}, res)
+}
+
+// withFlowOriginStatus updates the given flow's status subresource so
+// it advertises the given node as Origin. The status subresource is
+// separate from the spec; the test client must Update through .Status().
+func withFlowOriginStatus(c client.Client, flow *mxlv1alpha1.MxlFlow, node string) error {
+	var live mxlv1alpha1.MxlFlow
+	if err := c.Get(context.Background(), types.NamespacedName{Name: flow.Name}, &live); err != nil {
+		return err
+	}
+	live.Status.Locations = []mxlv1alpha1.MxlFlowLocation{
+		{NodeName: node, Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+	}
+	return c.Status().Update(context.Background(), &live)
+}
+
+// Defensive: ensure a stray apierrors import does not break under
+// future refactor; the helpers above use IsNotFound semantics through
+// the controller-runtime client.
+var _ = apierrors.IsNotFound
+var _ = corev1.Pod{}

--- a/operator/internal/receiver/controller_unit_test.go
+++ b/operator/internal/receiver/controller_unit_test.go
@@ -1,0 +1,351 @@
+package receiver
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// scheme is the per-test scheme passed to the fake client. The
+// envtest path uses its own scheme registered in testutil; keep this
+// one minimal so the unit tests stay cheap.
+func unitScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestMirrorName_DeterministicAndDNSSafe(t *testing.T) {
+	cases := []struct {
+		name   string
+		flowID string
+		node   string
+		want   string
+	}{
+		{
+			name:   "lowercase canonical",
+			flowID: "11111111-2222-3333-4444-555555555555",
+			node:   "worker-1",
+			want:   "11111111-2222-3333-4444-555555555555--worker-1",
+		},
+		{
+			name:   "uppercase chars are lowered",
+			flowID: "ABCDABCD-1234-5678-9ABC-DEF012345678",
+			node:   "Worker-A",
+			want:   "abcdabcd-1234-5678-9abc-def012345678--worker-a",
+		},
+		{
+			name:   "dots in a node name are replaced with -",
+			flowID: "11111111-2222-3333-4444-555555555555",
+			node:   "ip-10.0.0.1.eu-central-1.compute",
+			want:   "11111111-2222-3333-4444-555555555555--ip-10-0-0-1-eu-central-1-compute",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mirrorName(tc.flowID, tc.node)
+			assert.Equal(t, tc.want, got)
+			// The result must satisfy the kubernetes DNS-1123 subdomain
+			// rules; if it does not, the reconciler would silently fail
+			// to Create the mirror at runtime.
+			errs := validation.IsDNS1123Subdomain(got)
+			assert.Emptyf(t, errs, "mirrorName output %q is not a valid DNS-1123 subdomain: %v", got, errs)
+		})
+	}
+
+	t.Run("is deterministic", func(t *testing.T) {
+		a := mirrorName("11111111-2222-3333-4444-555555555555", "n1")
+		b := mirrorName("11111111-2222-3333-4444-555555555555", "n1")
+		assert.Equal(t, a, b)
+	})
+
+	t.Run("differs for distinct nodes", func(t *testing.T) {
+		assert.NotEqual(t,
+			mirrorName("11111111-2222-3333-4444-555555555555", "n1"),
+			mirrorName("11111111-2222-3333-4444-555555555555", "n2"))
+	})
+}
+
+func TestResolveTargetNodes_PodRef(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("found and scheduled", func(t *testing.T) {
+		recv := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec: mxlv1alpha1.MxlReceiverSpec{
+				PodRef: &mxlv1alpha1.PodRef{Namespace: "ns", Name: "pod-a"},
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithObjects(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod-a"},
+				Spec:       corev1.PodSpec{NodeName: "worker-1"},
+			}).
+			Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, recv)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"worker-1"}, got)
+	})
+
+	t.Run("not found returns empty without error", func(t *testing.T) {
+		recv := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec: mxlv1alpha1.MxlReceiverSpec{
+				PodRef: &mxlv1alpha1.PodRef{Namespace: "ns", Name: "missing"},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(unitScheme(t)).Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, recv)
+		require.NoError(t, err)
+		assert.Empty(t, got, "missing pod must not bubble up as an error; it is a normal pending state")
+	})
+
+	t.Run("unscheduled pod is treated as empty", func(t *testing.T) {
+		recv := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec: mxlv1alpha1.MxlReceiverSpec{
+				PodRef: &mxlv1alpha1.PodRef{Namespace: "ns", Name: "pod-a"},
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithObjects(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod-a"},
+				Spec:       corev1.PodSpec{}, // NodeName is empty
+			}).
+			Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, recv)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("podRef.Namespace empty falls back to receiver namespace", func(t *testing.T) {
+		recv := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec: mxlv1alpha1.MxlReceiverSpec{
+				PodRef: &mxlv1alpha1.PodRef{Name: "pod-a"},
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithObjects(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod-a"},
+				Spec:       corev1.PodSpec{NodeName: "worker-1"},
+			}).
+			Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, recv)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"worker-1"}, got)
+	})
+}
+
+func TestResolveTargetNodes_PodSelector(t *testing.T) {
+	ctx := context.Background()
+
+	recv := &mxlv1alpha1.MxlReceiver{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+		Spec: mxlv1alpha1.MxlReceiverSpec{
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "consumer"}},
+		},
+	}
+
+	t.Run("returns distinct nodes only", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithObjects(
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "a", Labels: map[string]string{"app": "consumer"}},
+					Spec:       corev1.PodSpec{NodeName: "n1"},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "b", Labels: map[string]string{"app": "consumer"}},
+					Spec:       corev1.PodSpec{NodeName: "n1"},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "c", Labels: map[string]string{"app": "consumer"}},
+					Spec:       corev1.PodSpec{NodeName: "n2"},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "skipme", Labels: map[string]string{"app": "other"}},
+					Spec:       corev1.PodSpec{NodeName: "n3"},
+				},
+			).
+			Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, recv)
+		require.NoError(t, err)
+		sort.Strings(got)
+		assert.Equal(t, []string{"n1", "n2"}, got,
+			"deduplication must collapse the two pods on n1; non-matching labels must be filtered")
+	})
+
+	t.Run("invalid selector surfaces an error", func(t *testing.T) {
+		bad := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec: mxlv1alpha1.MxlReceiverSpec{
+				PodSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "app", Operator: "NotARealOperator"},
+					},
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(unitScheme(t)).Build()
+		r := &Reconciler{Client: c}
+
+		_, err := r.resolveTargetNodes(ctx, bad)
+		require.Error(t, err)
+	})
+
+	t.Run("neither podRef nor selector returns empty without error", func(t *testing.T) {
+		// The CRD's XValidation rule forbids this state, but the
+		// reconciler must not panic if it ever sees it (a manual edit
+		// of an old CR could produce one).
+		empty := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec:       mxlv1alpha1.MxlReceiverSpec{},
+		}
+		c := fake.NewClientBuilder().WithScheme(unitScheme(t)).Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, empty)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}
+
+func TestResolveSourceNode(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns the Origin location's node", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+			WithObjects(&mxlv1alpha1.MxlFlow{
+				ObjectMeta: metav1.ObjectMeta{Name: "flow-a"},
+				Spec:       mxlv1alpha1.MxlFlowSpec{ID: "flow-a"},
+				Status: mxlv1alpha1.MxlFlowStatus{
+					Locations: []mxlv1alpha1.MxlFlowLocation{
+						{NodeName: "n-mirror", Phase: mxlv1alpha1.MxlFlowLocationMirroring},
+						{NodeName: "n-origin", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+						{NodeName: "n-stale", Phase: mxlv1alpha1.MxlFlowLocationStale},
+					},
+				},
+			}).
+			Build()
+		r := &Reconciler{Client: c}
+
+		node, ok, err := r.resolveSourceNode(ctx, "flow-a")
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, "n-origin", node)
+	})
+
+	t.Run("flow not found returns false without error", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(unitScheme(t)).Build()
+		r := &Reconciler{Client: c}
+		_, ok, err := r.resolveSourceNode(ctx, "missing")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("no Origin location returns false without error", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+			WithObjects(&mxlv1alpha1.MxlFlow{
+				ObjectMeta: metav1.ObjectMeta{Name: "flow-a"},
+				Spec:       mxlv1alpha1.MxlFlowSpec{ID: "flow-a"},
+				Status: mxlv1alpha1.MxlFlowStatus{
+					Locations: []mxlv1alpha1.MxlFlowLocation{
+						{NodeName: "n-stale", Phase: mxlv1alpha1.MxlFlowLocationStale},
+					},
+				},
+			}).
+			Build()
+		r := &Reconciler{Client: c}
+		_, ok, err := r.resolveSourceNode(ctx, "flow-a")
+		require.NoError(t, err)
+		assert.False(t, ok,
+			"a flow without an Origin location is not yet a usable source; "+
+				"the reconciler must mark its receivers Pending rather than "+
+				"misroute the mirror to a Mirroring/Stale node")
+	})
+}
+
+func TestMirrorToReceivers_FiltersByFlowID(t *testing.T) {
+	ctx := context.Background()
+	scheme := unitScheme(t)
+
+	mirror := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "m"},
+		Spec:       mxlv1alpha1.MxlFlowMirrorSpec{FlowID: "flow-a"},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&mxlv1alpha1.MxlReceiver{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r-match"},
+				Spec:       mxlv1alpha1.MxlReceiverSpec{FlowID: "flow-a"},
+			},
+			&mxlv1alpha1.MxlReceiver{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r-skip"},
+				Spec:       mxlv1alpha1.MxlReceiverSpec{FlowID: "flow-b"},
+			},
+			&mxlv1alpha1.MxlReceiver{
+				// Different namespace: must not be enqueued even if
+				// flowID matches; the mirror lives in "ns" and only
+				// receivers in "ns" can own it.
+				ObjectMeta: metav1.ObjectMeta{Namespace: "other", Name: "r-other-ns"},
+				Spec:       mxlv1alpha1.MxlReceiverSpec{FlowID: "flow-a"},
+			},
+		).
+		Build()
+	r := &Reconciler{Client: c}
+
+	out := r.mirrorToReceivers(ctx, mirror)
+	require.Len(t, out, 1)
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: client.ObjectKey{Namespace: "ns", Name: "r-match"},
+	}, out[0])
+}
+
+func TestMirrorToReceivers_NonMirrorObjectReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(unitScheme(t)).Build()
+	r := &Reconciler{Client: c}
+
+	out := r.mirrorToReceivers(ctx, &corev1.Pod{})
+	assert.Nil(t, out,
+		"the mapper guards against a misconfigured Watches by ignoring "+
+			"non-MxlFlowMirror events; if this regresses, every Pod event "+
+			"would enqueue every receiver in the cluster")
+}

--- a/operator/internal/receiver/suite_test.go
+++ b/operator/internal/receiver/suite_test.go
@@ -1,0 +1,32 @@
+package receiver_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/qvest-digital/mxl-k8s/operator/internal/testutil"
+)
+
+// env is the shared envtest harness for every Test* in this package.
+// Booting kube-apiserver + etcd costs about two seconds per process;
+// reusing one instance across the package's tests keeps the suite
+// fast while per-test namespaces preserve isolation.
+var env *testutil.Env
+
+func TestMain(m *testing.M) {
+	e, err := testutil.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "envtest unavailable, skipping suite: %v\n", err)
+		// Exit 0 so a developer running `go test ./...` without
+		// provisioned assets sees a clean PASS-but-skipped rather
+		// than a CI-killing failure. The CI `test` job sets
+		// KUBEBUILDER_ASSETS so this path never triggers there.
+		os.Exit(0)
+	}
+	env = e
+
+	code := m.Run()
+	env.Stop()
+	os.Exit(code)
+}

--- a/operator/internal/testutil/envtest.go
+++ b/operator/internal/testutil/envtest.go
@@ -1,0 +1,155 @@
+// Package testutil hosts shared test helpers for the operator's
+// reconcilers: an envtest harness that boots a real kube-apiserver +
+// etcd with the project's CRDs applied, plus a small set of builder
+// helpers for the CRD types so individual tests stay readable.
+//
+// Tests that need a faithful API server (admission, defaulting, status
+// subresource separation, structured-merge-diff) take this harness.
+// Tests of pure helpers that only need a typed client should reach for
+// fake.NewClientBuilder instead.
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// Env wraps an envtest.Environment together with a direct API-server
+// client (no informer cache). Tests should always read state through
+// Client so assertions see what kube-apiserver actually persisted,
+// rather than what a manager-side cache decided to reflect.
+type Env struct {
+	TestEnv *envtest.Environment
+	Cfg     *rest.Config
+	Scheme  *apiruntime.Scheme
+	Client  client.Client
+
+	stop func()
+}
+
+// Start boots envtest from TestMain without depending on a real
+// *testing.T. Returns the Env plus a Stop function the caller must
+// invoke before exiting. KUBEBUILDER_ASSETS must be set (the Makefile
+// provisions it via setup-envtest); the caller can detect the missing
+// asset case and skip envtest tests rather than fail noisily.
+func Start() (*Env, error) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		return nil, fmt.Errorf("KUBEBUILDER_ASSETS is unset; run via " +
+			"`make test` so setup-envtest provisions kube-apiserver " +
+			"+ etcd into bin/k8s")
+	}
+
+	scheme := apiruntime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(scheme))
+
+	te := &envtest.Environment{
+		CRDDirectoryPaths:     []string{crdDirFromSource()},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := te.Start()
+	if err != nil {
+		return nil, fmt.Errorf("envtest start: %w", err)
+	}
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		_ = te.Stop()
+		return nil, fmt.Errorf("envtest client: %w", err)
+	}
+
+	e := &Env{
+		TestEnv: te,
+		Cfg:     cfg,
+		Scheme:  scheme,
+		Client:  c,
+	}
+	e.stop = func() { _ = te.Stop() }
+	return e, nil
+}
+
+// Stop tears down envtest. Idempotent.
+func (e *Env) Stop() {
+	if e == nil || e.stop == nil {
+		return
+	}
+	e.stop()
+	e.stop = nil
+}
+
+// crdDirFromSource returns the absolute path to the repo's config/crd
+// directory, derived from the source location of this file. Tests can
+// run from any working directory the test runner picks.
+func crdDirFromSource() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "config", "crd")
+}
+
+// NewNamespace creates a namespace named after the current test and
+// deletes it on cleanup. Returning the name lets callers feed it into
+// CR builders so isolation is automatic.
+func (e *Env) NewNamespace(t testing.TB) string {
+	t.Helper()
+	name := dnsNamespace(t.Name())
+	ctx := context.Background()
+	ns := &corev1.Namespace{}
+	ns.SetName(name)
+	require.NoError(t, e.Client.Create(ctx, ns))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = e.Client.Delete(ctx, ns)
+	})
+	return name
+}
+
+// dnsNamespace coerces an arbitrary test name into a DNS-1123-safe
+// namespace label. Test names contain slashes (subtests) and
+// underscores that the API server rejects on namespace creation; the
+// agreed transformation lower-cases everything and replaces every
+// other rune with '-'.
+func dnsNamespace(in string) string {
+	out := make([]byte, 0, len(in))
+	for i := 0; i < len(in); i++ {
+		c := in[i]
+		switch {
+		case c >= 'A' && c <= 'Z':
+			out = append(out, c+('a'-'A'))
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+			out = append(out, c)
+		case c == '-':
+			out = append(out, '-')
+		default:
+			out = append(out, '-')
+		}
+	}
+	if len(out) > 63 {
+		out = out[:63]
+	}
+	for len(out) > 0 && out[0] == '-' {
+		out = out[1:]
+	}
+	for len(out) > 0 && out[len(out)-1] == '-' {
+		out = out[:len(out)-1]
+	}
+	if len(out) == 0 {
+		return "test"
+	}
+	return string(out)
+}

--- a/operator/internal/testutil/factories.go
+++ b/operator/internal/testutil/factories.go
@@ -1,0 +1,165 @@
+package testutil
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// Functional-option builders for the CRD types used by the operator
+// tests. Defaults are deliberately benign so the failure mode of a
+// missing field is "assert this CR has the value the test expected"
+// rather than "API server rejected the create with a validation
+// error" - which would hide the actual regression behind a CRD
+// schema complaint.
+
+// FlowID is a canonical fixture UUID used in tests that need a
+// concrete flow but do not care about the value itself.
+const FlowID = "11111111-2222-3333-4444-555555555555"
+
+// FlowOption mutates a MxlFlow under construction.
+type FlowOption func(*mxlv1alpha1.MxlFlow)
+
+// NewFlow builds a cluster-scoped MxlFlow with the given options
+// layered on top of sensible defaults.
+func NewFlow(opts ...FlowOption) *mxlv1alpha1.MxlFlow {
+	f := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: FlowID},
+		Spec: mxlv1alpha1.MxlFlowSpec{
+			ID:         FlowID,
+			Definition: runtime.RawExtension{Raw: []byte(`{"id":"` + FlowID + `"}`)},
+		},
+	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
+}
+
+// WithFlowOrigin pins an Origin location on the flow's status.
+func WithFlowOrigin(node string) FlowOption {
+	return func(f *mxlv1alpha1.MxlFlow) {
+		f.Status.Locations = append(f.Status.Locations, mxlv1alpha1.MxlFlowLocation{
+			NodeName: node,
+			Phase:    mxlv1alpha1.MxlFlowLocationOrigin,
+		})
+	}
+}
+
+// WithFlowID overrides the default UUID. Use when a test needs more
+// than one flow at the same time.
+func WithFlowID(id string) FlowOption {
+	return func(f *mxlv1alpha1.MxlFlow) {
+		f.SetName(id)
+		f.Spec.ID = id
+		f.Spec.Definition = runtime.RawExtension{Raw: []byte(`{"id":"` + id + `"}`)}
+	}
+}
+
+// ReceiverOption mutates a MxlReceiver under construction.
+type ReceiverOption func(*mxlv1alpha1.MxlReceiver)
+
+// NewReceiver builds a namespaced MxlReceiver with a pod label
+// selector matching `app=consumer`. Override via the options.
+func NewReceiver(namespace, name string, opts ...ReceiverOption) *mxlv1alpha1.MxlReceiver {
+	r := &mxlv1alpha1.MxlReceiver{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: mxlv1alpha1.MxlReceiverSpec{
+			FlowID:      FlowID,
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "consumer"}},
+			Provider:    mxlv1alpha1.ProviderTCP,
+		},
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// WithReceiverFlowID overrides the receiver's flow target.
+func WithReceiverFlowID(id string) ReceiverOption {
+	return func(r *mxlv1alpha1.MxlReceiver) {
+		r.Spec.FlowID = id
+	}
+}
+
+// WithReceiverPodRef pins the receiver to a single pod.
+func WithReceiverPodRef(podName string) ReceiverOption {
+	return func(r *mxlv1alpha1.MxlReceiver) {
+		r.Spec.PodSelector = nil
+		r.Spec.PodRef = &mxlv1alpha1.PodRef{
+			Namespace: r.Namespace,
+			Name:      podName,
+		}
+	}
+}
+
+// WithReceiverSelector replaces the default selector.
+func WithReceiverSelector(matchLabels map[string]string) ReceiverOption {
+	return func(r *mxlv1alpha1.MxlReceiver) {
+		r.Spec.PodRef = nil
+		r.Spec.PodSelector = &metav1.LabelSelector{MatchLabels: matchLabels}
+	}
+}
+
+// PodOption mutates a Pod under construction.
+type PodOption func(*corev1.Pod)
+
+// NewPod builds a minimally-valid Pod pinned to the given node and
+// labelled `app=consumer`. PodSpec.Containers carries one filler
+// entry so the API server's required-fields admission accepts it.
+func NewPod(namespace, name, node string, opts ...PodOption) *corev1.Pod {
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    map[string]string{"app": "consumer"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   node,
+			Containers: []corev1.Container{{Name: "c", Image: "pause:3.10"}},
+		},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// WithPodLabels overrides the default label set entirely.
+func WithPodLabels(labels map[string]string) PodOption {
+	return func(p *corev1.Pod) {
+		p.SetLabels(labels)
+	}
+}
+
+// MirrorOption mutates a MxlFlowMirror under construction.
+type MirrorOption func(*mxlv1alpha1.MxlFlowMirror)
+
+// NewMirror builds a MxlFlowMirror with sensible defaults for unit
+// tests; envtest tests should usually let the reconciler under test
+// produce the mirror instead.
+func NewMirror(namespace, name string, opts ...MirrorOption) *mxlv1alpha1.MxlFlowMirror {
+	m := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     FlowID,
+			SourceNode: "src",
+			TargetNode: "dst",
+			Provider:   mxlv1alpha1.ProviderTCP,
+		},
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// WithMirrorFlowID overrides the default flow.
+func WithMirrorFlowID(id string) MirrorOption {
+	return func(m *mxlv1alpha1.MxlFlowMirror) {
+		m.Spec.FlowID = id
+	}
+}


### PR DESCRIPTION
## Summary

Drives the operator's reconcile branches through envtest (real
kube-apiserver + etcd) for the receiver controller, and through
fake.NewClientBuilder for the four observer-stub controllers. Adds
the shared testutil package the next module PRs reuse.

## What lands

- `operator/internal/testutil/{envtest,factories}.go`: shared
  envtest harness with TestMain integration; functional-option
  builders for MxlFlow, MxlReceiver, Pod, MxlFlowMirror.
- `operator/internal/receiver/controller_envtest_test.go`: eight
  envtest scenarios for the receiver reconciler.
- `operator/internal/receiver/controller_unit_test.go`: pure
  helpers against fake client.
- `operator/internal/{flow,mirror,domain,nodecaps}/controller_test.go`:
  observer-stub smoke + no-mutation assertions.
- `operator/internal/receiver/suite_test.go`: package-wide TestMain
  that boots envtest once.

## Verification

- `make envtest-assets` provisions kube-apiserver + etcd into
  `bin/k8s/`.
- `make test-one MODULE=operator` reports `DONE 37 tests`,
  coverage `internal/receiver` at 84.9% of statements (the
  uncovered portion is logging-only branches in the helper
  functions).
- `gofmt -l operator/` clean.
- `cd operator && go vet ./...` clean.

## Base

Stacked on top of `chore/test-tooling` (PR #11).