### PR TITLE
refactor(gateway): pass per-tick cgo work into the loops as funcs

### DIFF
--- a/gateway/internal/mirror/iface.go
+++ b/gateway/internal/mirror/iface.go
@@ -1,0 +1,45 @@
+package mirror
+
+// The two per-mirror progress loops below sit at the heart of every
+// data-plane bug the gateway has shipped. They are also the only
+// pieces of this package whose state machine can be exercised
+// without libmxl-fabrics: the cgo-dependent work happens behind a
+// handful of function calls the loops make on every iteration.
+//
+// The refactor that introduced these types narrowed the loop
+// signatures to accept those calls as injected functions. Production
+// binds them to thin closures over *mxl.Reader / *mxl.Writer /
+// *fabrics.Initiator / *fabrics.Target; the tests bind them to
+// closures that record every call and return whatever the scenario
+// needs. No interface gymnastics, no mockery boilerplate; the loops
+// stay where they were, and only their parameter list changed.
+
+// RuntimeProbe asks the source-side flow reader for the current head
+// index. Production reads it from mxl.Reader.Runtime(); tests return
+// a value the scenario controls.
+type RuntimeProbe func() (head uint64, err error)
+
+// TransferFunc transfers one grain from the source flow to the
+// target. The bool return signals "grain was skipped" - production
+// returns it true when grain.TotalSlices == 0 (continuous flows have
+// no slice subdivision and v0 does not transfer them).
+//
+// A non-nil error breaks the per-tick loop; the next tick re-reads
+// head and re-tries from lastSent+1.
+type TransferFunc func(idx uint64) (skipped bool, err error)
+
+// ProgressFunc drives libmxl-fabrics's event/completion queues.
+// Production calls Initiator.MakeProgressNonBlocking; the loop
+// tolerates fabrics.ErrNotReady silently.
+type ProgressFunc func() error
+
+// ReadGrainFunc polls the target side for an arrived grain. Returns
+// fabrics.ErrNotReady when nothing landed since the previous call so
+// the loop can sleep. Any other error is fatal: it tells the loop
+// to exit and the recovery callback to fire.
+type ReadGrainFunc func() (idx uint64, err error)
+
+// CommitFunc finishes one arrived grain on the local writer
+// (OpenGrain + Commit) so consumer FlowReaders see it. Production
+// passes a closure over the per-mirror *mxl.Writer.
+type CommitFunc func(idx uint64) error

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -225,14 +225,50 @@ func (r *SourceReconciler) openInitiator(flowID, targetInfoStr string, provider 
 	if progressInterval <= 0 {
 		progressInterval = 2 * time.Millisecond
 	}
-	go runTransferLoop(loopCtx, done, flowID, reader, initiator, progressInterval)
+	runtimeFn := func() (uint64, error) {
+		rt, err := reader.Runtime()
+		if err != nil {
+			return 0, err
+		}
+		return rt.HeadIndex, nil
+	}
+	transferFn := func(idx uint64) (bool, error) {
+		grain, err := reader.GetGrainNonBlocking(idx)
+		if err != nil {
+			// Not yet committed or already aged out; signal the loop
+			// to break and re-try on the next tick.
+			return false, err
+		}
+		if grain.TotalSlices == 0 {
+			// Continuous flows or grains with no slice subdivision
+			// report TotalSlices==0; v0 sends only fully-discrete
+			// grains and skips these.
+			return true, nil
+		}
+		return false, initiator.TransferGrain(idx, 0, grain.TotalSlices)
+	}
+	progressFn := initiator.MakeProgressNonBlocking
+	go runTransferLoop(loopCtx, done, flowID, runtimeFn, transferFn, progressFn, progressInterval)
 
 	return entry, nil
 }
 
-// runTransferLoop pumps grains that appear on reader into initiator
-// until ctx is canceled. Closes done on exit.
-func runTransferLoop(ctx context.Context, done chan struct{}, flowID string, reader *mxl.Reader, initiator *fabrics.Initiator, interval time.Duration) {
+// runTransferLoop pumps grains that appear on the source flow into
+// the initiator until ctx is canceled. Closes done on exit.
+//
+// The loop is parameterised by three injected functions so the
+// cgo-dependent calls stay isolated from the state machine: tests
+// can drive it with closures that return canned indices and record
+// every interaction.
+func runTransferLoop(
+	ctx context.Context,
+	done chan struct{},
+	flowID string,
+	probeRuntime RuntimeProbe,
+	transferGrain TransferFunc,
+	makeProgress ProgressFunc,
+	interval time.Duration,
+) {
 	defer close(done)
 
 	l := ctrl.Log.WithName("transfer").WithValues("flowID", flowID)
@@ -241,12 +277,12 @@ func runTransferLoop(ctx context.Context, done chan struct{}, flowID string, rea
 	// attached mirror tails the live flow rather than replaying
 	// historical grains the producer may already have aged out of
 	// the ring.
-	rt, err := reader.Runtime()
+	head0, err := probeRuntime()
 	if err != nil {
 		l.Error(err, "initial Runtime")
 		return
 	}
-	lastSent := int64(rt.HeadIndex)
+	lastSent := int64(head0)
 
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -258,35 +294,20 @@ func runTransferLoop(ctx context.Context, done chan struct{}, flowID string, rea
 		case <-t.C:
 		}
 
-		rt, err := reader.Runtime()
+		head, err := probeRuntime()
 		if err != nil {
 			l.Error(err, "Runtime")
 			continue
 		}
-		head := int64(rt.HeadIndex)
-		for idx := lastSent + 1; idx <= head; idx++ {
-			grain, err := reader.GetGrainNonBlocking(uint64(idx))
-			if err != nil {
-				// Not yet committed or already aged out; retry next tick.
-				break
-			}
-			slices := grain.TotalSlices
-			if slices == 0 {
-				// Continuous flows or grains with no slice subdivision
-				// report TotalSlices==0; the kernel interprets the
-				// [start, end) range as empty for them, so v0 sends
-				// only fully-discrete grains.
-				lastSent = idx
-				continue
-			}
-			if err := initiator.TransferGrain(uint64(idx), 0, slices); err != nil {
+		for idx := lastSent + 1; idx <= int64(head); idx++ {
+			if _, err := transferGrain(uint64(idx)); err != nil {
 				l.Error(err, "TransferGrain", "index", idx)
 				break
 			}
 			lastSent = idx
 		}
 
-		if err := initiator.MakeProgressNonBlocking(); err != nil && !errors.Is(err, fabrics.ErrNotReady) {
+		if err := makeProgress(); err != nil && !errors.Is(err, fabrics.ErrNotReady) {
 			l.Error(err, "MakeProgress")
 		}
 	}

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -268,7 +268,9 @@ func (r *TargetReconciler) startProgressLoop(entry *targetEntry, key types.Names
 	entry.done = done
 	target := entry.target
 	writer := entry.writer
-	go runTargetProgressLoop(loopCtx, done, target, writer, func() {
+	readFn := target.ReadGrainNonBlocking
+	commitFn := func(idx uint64) error { return commitArrivedGrain(writer, idx) }
+	go runTargetProgressLoop(loopCtx, done, readFn, commitFn, func() {
 		// Detach the recovery work from the goroutine that's
 		// exiting so the recovery's wait-for-done doesn't deadlock
 		// on its own done channel.
@@ -279,7 +281,7 @@ func (r *TargetReconciler) startProgressLoop(entry *targetEntry, key types.Names
 // runTargetProgressLoop drives the libmxl-fabrics Target until ctx
 // is canceled or ReadGrain reports a non-recoverable error. Each
 // ReadGrain call internally advances the libfabric event +
-// completion queues — without it the target never accepts incoming
+// completion queues - without it the target never accepts incoming
 // connections nor signals grain arrivals.
 //
 // We use the non-blocking ReadGrain plus a Go-side sleep on idle
@@ -292,19 +294,28 @@ func (r *TargetReconciler) startProgressLoop(entry *targetEntry, key types.Names
 // every 10-60 seconds in steady state. Polling from Go avoids
 // blocking in libfabric, which sidesteps the signal-interaction.
 //
-// For every grain ReadGrain reports as received, we also OpenGrain
-// followed by Commit on the local FlowWriter: the initiator side
-// has already RDMA'd payload + header into the ring slot, so the
-// commit only advances the flow's HeadIndex so local FlowReaders
-// (consumer pods) can see the new grain. Mirrors the pattern from
-// upstream `mxl-fabrics-demo` tools/mxl-fabrics-demo/demo.cpp.
+// For every grain ReadGrain reports as received, commitFn does the
+// OpenGrain + Commit dance on the local FlowWriter so consumer
+// FlowReaders see the arrived grain.
 //
 // On any non-ErrNotReady error from ReadGrain the underlying Target
-// is no longer safe to poll — libmxl-fabrics has been observed to
+// is no longer safe to poll - libmxl-fabrics has been observed to
 // dangle internal state after the remote endpoint drops, and the
 // next ReadGrain call segfaults inside cgo. We exit the loop and
 // call onFatal so the reconciler can rebuild the fabric side.
-func runTargetProgressLoop(ctx context.Context, done chan struct{}, target *fabrics.Target, writer *mxl.Writer, onFatal func()) {
+//
+// The loop takes readFn and commitFn as injected closures so the
+// state machine - the only piece prone to bugs and the only piece
+// worth unit-testing - is isolated from cgo. Production passes a
+// closure over fabrics.Target.ReadGrainNonBlocking and a closure
+// over commitArrivedGrain(writer, ...).
+func runTargetProgressLoop(
+	ctx context.Context,
+	done chan struct{},
+	readGrain ReadGrainFunc,
+	commit CommitFunc,
+	onFatal func(),
+) {
 	defer close(done)
 	l := ctrl.Log.WithName("target-progress")
 	const idleSleep = 1 * time.Millisecond
@@ -314,10 +325,10 @@ func runTargetProgressLoop(ctx context.Context, done chan struct{}, target *fabr
 			return
 		default:
 		}
-		idx, err := target.ReadGrainNonBlocking()
+		idx, err := readGrain()
 		switch {
 		case err == nil:
-			if err := commitArrivedGrain(writer, idx); err != nil {
+			if err := commit(idx); err != nil {
 				l.Error(err, "commit received grain", "idx", idx)
 			}
 		case errors.Is(err, fabrics.ErrNotReady):
@@ -327,7 +338,7 @@ func runTargetProgressLoop(ctx context.Context, done chan struct{}, target *fabr
 			case <-time.After(idleSleep):
 			}
 		default:
-			l.Error(err, "ReadGrain — target is no longer safe to poll, exiting loop")
+			l.Error(err, "ReadGrain - target is no longer safe to poll, exiting loop")
 			if onFatal != nil {
 				onFatal()
 			}


### PR DESCRIPTION
## Summary

Minimal mechanical refactor to make the two per-mirror progress
loops unit-testable. No behaviour change.

## What lands

- `gateway/internal/mirror/iface.go`: five named function types
  (RuntimeProbe, TransferFunc, ProgressFunc, ReadGrainFunc,
  CommitFunc) plus the rationale.
- `gateway/internal/mirror/source.go`: openInitiator builds three
  closures over the live *mxl.Reader and *fabrics.Initiator and
  hands them to runTransferLoop, which no longer references either.
- `gateway/internal/mirror/target.go`: startProgressLoop builds two
  closures over the live *fabrics.Target and the per-mirror
  *mxl.Writer; runTargetProgressLoop receives them via readFn and
  commitFn.

The reconcile entry points, fast-path, finalizer handling, fabric
recovery and status updates are unchanged.

## Verification

- `docker run ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.5 go
  build ./...` clean.
- `docker run ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.5 go
  vet ./...` clean.
- `gofmt -l gateway/` clean.

## Base

Stacked on top of `chore/test-tooling` (PR #11). The next PR adds
the actual gateway tests on top of this branch.