### PR TITLE
test(gateway): cover config, capabilities, and the mirror loops

### DIFF
--- a/gateway/cmd/mxl-fabrics-gateway/main_test.go
+++ b/gateway/cmd/mxl-fabrics-gateway/main_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+)
+
+func TestProviderNames(t *testing.T) {
+	cases := []struct {
+		name string
+		in   []fabrics.Provider
+		want []string
+	}{
+		{"empty", nil, []string{}},
+		{"single", []fabrics.Provider{fabrics.ProviderTCP}, []string{"tcp"}},
+		{
+			"multiple preserves order",
+			[]fabrics.Provider{fabrics.ProviderTCP, fabrics.ProviderVerbs, fabrics.ProviderSHM},
+			[]string{"tcp", "verbs", "shm"},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := providerNames(tc.in)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -5,6 +5,8 @@ go 1.26.0
 require (
 	github.com/qvest-digital/go-mxl v1.0.0-rc.5
 	github.com/qvest-digital/mxl-k8s/api v0.0.0-00010101000000-000000000000
+	github.com/stretchr/testify v1.11.1
+	go.uber.org/goleak v1.3.0
 	k8s.io/apimachinery v0.36.1
 	k8s.io/client-go v0.36.1
 	sigs.k8s.io/controller-runtime v0.24.1

--- a/gateway/internal/capabilities/publisher_test.go
+++ b/gateway/internal/capabilities/publisher_test.go
@@ -1,0 +1,154 @@
+package capabilities
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestEnsureExists_CreatesOnce(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	p := &Publisher{Client: c, NodeName: "n1", Providers: []fabrics.Provider{fabrics.ProviderTCP}}
+	require.NoError(t, p.EnsureExists(context.Background()))
+
+	var got mxlv1alpha1.MxlNodeCapabilities
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "n1"}, &got))
+	assert.Equal(t, "n1", got.Spec.NodeName)
+	assert.Empty(t, got.Status.Providers,
+		"EnsureExists must leave status to Refresh; the gateway reports "+
+			"capabilities only after the manager cache has synced")
+
+	require.NoError(t, p.EnsureExists(context.Background()),
+		"a second EnsureExists must be a no-op; first-pod-up wins on a "+
+			"cold cluster and any retry must not error out")
+}
+
+func TestRefresh_PublishesProvidersAndLastSeen(t *testing.T) {
+	scheme := newScheme(t)
+	existing := &mxlv1alpha1.MxlNodeCapabilities{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       mxlv1alpha1.MxlNodeCapabilitiesSpec{NodeName: "n1"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlNodeCapabilities{}).
+		WithObjects(existing).
+		Build()
+
+	p := &Publisher{
+		Client:    c,
+		NodeName:  "n1",
+		Providers: []fabrics.Provider{fabrics.ProviderTCP, fabrics.ProviderVerbs},
+	}
+
+	require.NoError(t, p.Refresh(context.Background()))
+
+	var got mxlv1alpha1.MxlNodeCapabilities
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "n1"}, &got))
+	require.NotNil(t, got.Status.LastSeen)
+	require.Len(t, got.Status.Providers, 2)
+	assert.Equal(t, mxlv1alpha1.ProviderTCP, got.Status.Providers[0].Name)
+	assert.Equal(t, mxlv1alpha1.ProviderVerbs, got.Status.Providers[1].Name,
+		"the order of the providers status must mirror the configured list; "+
+			"future scheduling logic in the operator may rely on the first "+
+			"entry being the gateway's preferred provider")
+}
+
+func TestRefresh_RewritesProvidersExactly(t *testing.T) {
+	// A previous run advertised tcp + verbs. Re-running with only
+	// tcp configured must replace the slice (no leftover verbs).
+	scheme := newScheme(t)
+	existing := &mxlv1alpha1.MxlNodeCapabilities{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       mxlv1alpha1.MxlNodeCapabilitiesSpec{NodeName: "n1"},
+		Status: mxlv1alpha1.MxlNodeCapabilitiesStatus{
+			Providers: []mxlv1alpha1.MxlFabricsProviderCapability{
+				{Name: mxlv1alpha1.ProviderTCP},
+				{Name: mxlv1alpha1.ProviderVerbs},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlNodeCapabilities{}).
+		WithObjects(existing).
+		Build()
+
+	p := &Publisher{Client: c, NodeName: "n1", Providers: []fabrics.Provider{fabrics.ProviderTCP}}
+	require.NoError(t, p.Refresh(context.Background()))
+
+	var got mxlv1alpha1.MxlNodeCapabilities
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "n1"}, &got))
+	require.Len(t, got.Status.Providers, 1)
+	assert.Equal(t, mxlv1alpha1.ProviderTCP, got.Status.Providers[0].Name,
+		"the publisher must own the providers slice entirely; merging would "+
+			"surface a removed provider as still-available and mislead the "+
+			"operator's mirror scheduling")
+}
+
+func TestRefresh_ErrorsWhenCRMissing(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := &Publisher{Client: c, NodeName: "n1", Providers: []fabrics.Provider{fabrics.ProviderTCP}}
+
+	err := p.Refresh(context.Background())
+	require.Error(t, err)
+}
+
+func TestRunRefreshLoop_CancelsCleanlyOnCtxDone(t *testing.T) {
+	scheme := newScheme(t)
+	existing := &mxlv1alpha1.MxlNodeCapabilities{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       mxlv1alpha1.MxlNodeCapabilitiesSpec{NodeName: "n1"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlNodeCapabilities{}).
+		WithObjects(existing).
+		Build()
+
+	p := &Publisher{Client: c, NodeName: "n1", Providers: []fabrics.Provider{fabrics.ProviderTCP}}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.RunRefreshLoop(ctx, 10*time.Millisecond)
+		close(done)
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunRefreshLoop did not return on ctx cancel")
+	}
+}

--- a/gateway/internal/config/config_test.go
+++ b/gateway/internal/config/config_test.go
@@ -1,0 +1,126 @@
+package config
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+)
+
+func TestFromFlags_RequiresProviderAndDomain(t *testing.T) {
+	t.Setenv("NODE_NAME", "")
+	t.Setenv("MXL_DOMAIN", "")
+	t.Setenv("POD_IP", "")
+	t.Setenv("KUBECONFIG", "")
+
+	_, err := FromFlags(flag.NewFlagSet("g", flag.ContinueOnError), nil)
+	require.Error(t, err, "no node name + no domain must fail")
+}
+
+func TestFromFlags_DefaultsAndProvidersCSV(t *testing.T) {
+	t.Setenv("NODE_NAME", "")
+	t.Setenv("MXL_DOMAIN", "")
+	t.Setenv("POD_IP", "")
+	t.Setenv("KUBECONFIG", "")
+
+	c, err := FromFlags(flag.NewFlagSet("g", flag.ContinueOnError), []string{
+		"--node-name=worker-1",
+		"--domain-path=/run/mxl/domain",
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "worker-1", c.NodeName)
+	assert.Equal(t, "/run/mxl/domain", c.DomainPath)
+	assert.Empty(t, c.BindAddress, "bind address defaults to empty so libmxl-fabrics binds all interfaces")
+	assert.Equal(t, ":8081", c.ProbeAddr,
+		"the chart's liveness/readiness probes target :8081; flipping it disables probes silently")
+	assert.Equal(t, ":8080", c.MetricsAddr)
+	assert.Equal(t, 30*time.Second, c.ResyncPeriod)
+	require.Equal(t, []fabrics.Provider{fabrics.ProviderTCP}, c.Providers,
+		"default provider list must be exactly [tcp]; --providers tcp is the only "+
+			"setup that works out of the box without RDMA hardware on every node")
+}
+
+func TestFromFlags_MultipleProviders(t *testing.T) {
+	t.Setenv("NODE_NAME", "n1")
+	t.Setenv("MXL_DOMAIN", "/d")
+	t.Setenv("POD_IP", "")
+	t.Setenv("KUBECONFIG", "")
+
+	c, err := FromFlags(flag.NewFlagSet("g", flag.ContinueOnError), []string{
+		"--providers=tcp,verbs, shm",
+	})
+	require.NoError(t, err)
+	assert.Equal(t,
+		[]fabrics.Provider{fabrics.ProviderTCP, fabrics.ProviderVerbs, fabrics.ProviderSHM},
+		c.Providers,
+		"the CSV parser must trim whitespace and preserve order; the gateway uses "+
+			"the slice order to bias selection inside libmxl-fabrics")
+}
+
+func TestFromFlags_InvalidProvider(t *testing.T) {
+	t.Setenv("NODE_NAME", "n1")
+	t.Setenv("MXL_DOMAIN", "/d")
+	t.Setenv("POD_IP", "")
+	t.Setenv("KUBECONFIG", "")
+
+	_, err := FromFlags(flag.NewFlagSet("g", flag.ContinueOnError),
+		[]string{"--providers=banana"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "--providers")
+}
+
+func TestFromFlags_EmptyProvidersCSV_Rejected(t *testing.T) {
+	t.Setenv("NODE_NAME", "n1")
+	t.Setenv("MXL_DOMAIN", "/d")
+	t.Setenv("POD_IP", "")
+	t.Setenv("KUBECONFIG", "")
+
+	_, err := FromFlags(flag.NewFlagSet("g", flag.ContinueOnError),
+		[]string{"--providers= ,, "})
+	require.Error(t, err, "an effectively-empty providers list must be rejected at flag time, "+
+		"not at first-reconcile time")
+}
+
+func TestFromFlags_PodIPDefault(t *testing.T) {
+	t.Setenv("NODE_NAME", "n1")
+	t.Setenv("MXL_DOMAIN", "/d")
+	t.Setenv("POD_IP", "10.0.0.42")
+	t.Setenv("KUBECONFIG", "")
+
+	c, err := FromFlags(flag.NewFlagSet("g", flag.ContinueOnError), nil)
+	require.NoError(t, err)
+	assert.Equal(t, "10.0.0.42", c.BindAddress,
+		"$POD_IP must flow through to the bind address; the chart sets it from "+
+			"the downward API, and missing it would make libmxl-fabrics bind to "+
+			"the wrong interface in a multi-NIC pod")
+}
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		c       Config
+		wantErr string
+	}{
+		{"missing node", Config{DomainPath: "/d", Providers: []fabrics.Provider{fabrics.ProviderTCP}}, "--node-name"},
+		{"missing domain", Config{NodeName: "n", Providers: []fabrics.Provider{fabrics.ProviderTCP}}, "--domain-path"},
+		{"relative domain", Config{NodeName: "n", DomainPath: "rel", Providers: []fabrics.Provider{fabrics.ProviderTCP}}, "absolute"},
+		{"empty providers", Config{NodeName: "n", DomainPath: "/d"}, "--providers"},
+		{"valid", Config{NodeName: "n", DomainPath: "/d", Providers: []fabrics.Provider{fabrics.ProviderTCP}}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/gateway/internal/mirror/common_test.go
+++ b/gateway/internal/mirror/common_test.go
@@ -1,0 +1,34 @@
+package mirror
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+func TestMapProvider(t *testing.T) {
+	cases := []struct {
+		in   mxlv1alpha1.MxlFabricsProvider
+		want fabrics.Provider
+	}{
+		{mxlv1alpha1.ProviderTCP, fabrics.ProviderTCP},
+		{mxlv1alpha1.ProviderVerbs, fabrics.ProviderVerbs},
+		{mxlv1alpha1.ProviderEFA, fabrics.ProviderEFA},
+		{mxlv1alpha1.ProviderSHM, fabrics.ProviderSHM},
+		{mxlv1alpha1.ProviderAuto, fabrics.ProviderAuto},
+		{"", fabrics.ProviderAuto},
+		{"made-up", fabrics.ProviderAuto},
+	}
+	for _, tc := range cases {
+		t.Run(string(tc.in), func(t *testing.T) {
+			assert.Equal(t, tc.want, mapProvider(tc.in),
+				"every CRD enum value must map to a known fabrics provider; "+
+					"silent fallthrough to Auto for unknown inputs preserves "+
+					"upgrade compatibility for receivers that pin a new provider "+
+					"the gateway version does not understand yet")
+		})
+	}
+}

--- a/gateway/internal/mirror/source_test.go
+++ b/gateway/internal/mirror/source_test.go
@@ -1,0 +1,230 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+)
+
+func TestMain(m *testing.M) {
+	// Catch goroutine leaks from the loops under test. Every Test*
+	// in this package starts at most one progress goroutine; if it
+	// outlives the test, the loop forgot to honour ctx.
+	goleak.VerifyTestMain(m)
+}
+
+// transferFixture wraps the canned probes/transfers a test wants to
+// feed into runTransferLoop, plus the counters and call logs that
+// the assertions read.
+type transferFixture struct {
+	mu sync.Mutex
+
+	headSeq   []uint64
+	headIdx   int
+	headErr   error
+	headCalls int
+
+	transferLog  []uint64
+	transferErr  error
+	transferSkip map[uint64]bool
+
+	progressErr   error
+	progressCalls int
+}
+
+func (f *transferFixture) probeRuntime() (uint64, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.headCalls++
+	if f.headErr != nil {
+		return 0, f.headErr
+	}
+	if f.headIdx >= len(f.headSeq) {
+		return f.headSeq[len(f.headSeq)-1], nil
+	}
+	h := f.headSeq[f.headIdx]
+	f.headIdx++
+	return h, nil
+}
+
+func (f *transferFixture) transferGrain(idx uint64) (bool, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.transferLog = append(f.transferLog, idx)
+	if f.transferErr != nil {
+		return false, f.transferErr
+	}
+	if f.transferSkip[idx] {
+		return true, nil
+	}
+	return false, nil
+}
+
+func (f *transferFixture) makeProgress() error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.progressCalls++
+	return f.progressErr
+}
+
+func (f *transferFixture) transferred() []uint64 {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]uint64, len(f.transferLog))
+	copy(out, f.transferLog)
+	return out
+}
+
+func TestRunTransferLoop_TailsFromHead(t *testing.T) {
+	// First Runtime probe reports head=10. Subsequent probes report
+	// 12 and 15. The loop must transfer (11, 12, 13, 14, 15) and
+	// never anything <= 10 - the initial head is "where we tune in",
+	// the producer's historical grains are not replayed.
+	fx := &transferFixture{
+		headSeq: []uint64{10, 12, 15, 15},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	go runTransferLoop(ctx, done, "flow-a", fx.probeRuntime, fx.transferGrain, fx.makeProgress, time.Millisecond)
+
+	// Let the loop run a few ticks then cancel.
+	require.Eventually(t, func() bool {
+		fx.mu.Lock()
+		defer fx.mu.Unlock()
+		return len(fx.transferLog) >= 5
+	}, time.Second, time.Millisecond, "expected >=5 transfers")
+
+	cancel()
+	<-done
+
+	got := fx.transferred()
+	assert.GreaterOrEqual(t, len(got), 5)
+	for i, idx := range got[:5] {
+		expected := uint64(11 + i)
+		assert.Equalf(t, expected, idx,
+			"transfers must arrive in head-tail order; got idx[%d]=%d, want %d",
+			i, idx, expected)
+	}
+}
+
+func TestRunTransferLoop_TransferErrorBreaksInnerLoopButLoopSurvives(t *testing.T) {
+	// On a tick that fails the transfer, the loop must break the
+	// per-grain inner pass but keep going on the next tick. If it
+	// exited entirely, a single transient TransferGrain error would
+	// stall the flow forever.
+
+	// Custom probe that reports 0 once, then 3 forever.
+	var calls atomic.Int32
+	probe := func() (uint64, error) {
+		if calls.Add(1) == 1 {
+			return 0, nil
+		}
+		return 3, nil
+	}
+
+	var transferCalls atomic.Int32
+	transfer := func(idx uint64) (bool, error) {
+		transferCalls.Add(1)
+		if idx == 2 {
+			return false, errors.New("transient")
+		}
+		return false, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil }, time.Millisecond)
+
+	// Give the loop time to attempt many ticks (so the error path is
+	// hit at least once, and the next-tick recovery is tried too).
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	// Even though idx=2 always errors, the loop must keep being
+	// invoked - so transferCalls grows past a single tick's worth.
+	assert.Greater(t, int(transferCalls.Load()), 3,
+		"a transient transfer error must not stop the loop; future ticks "+
+			"must retry from lastSent+1 (idx=2 again here)")
+}
+
+func TestRunTransferLoop_InitialProbeErrorReturnsEarly(t *testing.T) {
+	// If the very first Runtime probe fails, the loop returns and
+	// closes done without ever spinning. Catches a regression where
+	// the loop would proceed with a zero head index and silently
+	// flood the initiator with stale grains.
+	probe := func() (uint64, error) { return 0, errors.New("dead reader") }
+	transfer := func(uint64) (bool, error) {
+		t.Fatal("transferGrain must not be called when initial probe errors")
+		return false, nil
+	}
+	progress := func() error {
+		t.Fatal("makeProgress must not be called when initial probe errors")
+		return nil
+	}
+
+	done := make(chan struct{})
+	go runTransferLoop(context.Background(), done, "f", probe, transfer, progress, time.Millisecond)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not exit on initial probe error")
+	}
+}
+
+func TestRunTransferLoop_ProgressErrNotReadyIsSwallowed(t *testing.T) {
+	// fabrics.ErrNotReady is the normal "queue is empty" signal;
+	// the loop must keep ticking. Any other error from MakeProgress
+	// is logged but does not stop the loop either - the next tick
+	// recovers.
+	probe := func() (uint64, error) { return 0, nil }
+	transfer := func(uint64) (bool, error) {
+		return false, nil
+	}
+	calls := atomic.Int32{}
+	progress := func() error {
+		calls.Add(1)
+		return fabrics.ErrNotReady
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTransferLoop(ctx, done, "f", probe, transfer, progress, time.Millisecond)
+
+	require.Eventually(t, func() bool { return calls.Load() >= 3 },
+		time.Second, time.Millisecond,
+		"expected MakeProgress to be called multiple times despite ErrNotReady")
+
+	cancel()
+	<-done
+}
+
+func TestRunTransferLoop_CtxCancelExitsImmediately(t *testing.T) {
+	probe := func() (uint64, error) { return 0, nil }
+	transfer := func(uint64) (bool, error) { return false, nil }
+	progress := func() error { return nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTransferLoop(ctx, done, "f", probe, transfer, progress, time.Hour)
+
+	// Cancel before the first tick fires.
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not honour ctx cancel before first tick")
+	}
+}

--- a/gateway/internal/mirror/target_test.go
+++ b/gateway/internal/mirror/target_test.go
@@ -1,0 +1,167 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+)
+
+// TestMain in source_test.go runs goleak.VerifyTestMain for the
+// whole package; the recovery paths exercised below all rely on
+// progress goroutines exiting cleanly when ctx is cancelled or when
+// the loop hits a fatal error.
+
+func TestRunTargetProgressLoop_CommitsArrivedGrains(t *testing.T) {
+	// Sequence: idx=10 arrives, idx=11 arrives, then ErrNotReady,
+	// then cancel. The loop must commit 10 and 11 in order; the
+	// idle sleep must not eat the cancel signal.
+	var seq atomic.Int32
+	read := func() (uint64, error) {
+		switch seq.Add(1) {
+		case 1:
+			return 10, nil
+		case 2:
+			return 11, nil
+		default:
+			return 0, fabrics.ErrNotReady
+		}
+	}
+
+	var (
+		mu        sync.Mutex
+		committed []uint64
+	)
+	commit := func(idx uint64) error {
+		mu.Lock()
+		committed = append(committed, idx)
+		mu.Unlock()
+		return nil
+	}
+	committedSnap := func() []uint64 {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]uint64, len(committed))
+		copy(out, committed)
+		return out
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	fatal := atomic.Int32{}
+	onFatal := func() { fatal.Add(1) }
+
+	go runTargetProgressLoop(ctx, done, read, commit, onFatal)
+
+	require.Eventually(t, func() bool { return len(committedSnap()) == 2 },
+		time.Second, time.Millisecond, "expected 2 commits")
+
+	cancel()
+	<-done
+
+	assert.Equal(t, []uint64{10, 11}, committedSnap())
+	assert.Zero(t, fatal.Load(),
+		"a clean ctx cancel must not look like a fatal target error; "+
+			"that would trigger spurious fabric rebuilds on every restart")
+}
+
+func TestRunTargetProgressLoop_FatalErrorExitsAndCallsOnFatalOnce(t *testing.T) {
+	// ReadGrain returns a non-ErrNotReady error once. The loop must
+	// exit, close done, and invoke onFatal exactly once. A second
+	// call would double-rebuild the fabric side.
+	read := func() (uint64, error) {
+		return 0, errors.New("EFI_RXMSG dropped, target dead")
+	}
+	commit := func(uint64) error {
+		t.Fatal("commit must not be called on a fatal read error")
+		return nil
+	}
+
+	fatalCalls := atomic.Int32{}
+	onFatal := func() { fatalCalls.Add(1) }
+
+	done := make(chan struct{})
+	go runTargetProgressLoop(context.Background(), done, read, commit, onFatal)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not exit on fatal error")
+	}
+	assert.Equal(t, int32(1), fatalCalls.Load(),
+		"onFatal must fire exactly once; a duplicate call would race two "+
+			"concurrent recoverFromFatalError invocations against the same writer")
+}
+
+func TestRunTargetProgressLoop_CommitErrorIsLoggedButLoopContinues(t *testing.T) {
+	// A commit-side error (e.g. OpenGrain returning busy under load)
+	// must not exit the loop. The next ReadGrain is allowed to
+	// surface the next index.
+	var seq atomic.Int32
+	read := func() (uint64, error) {
+		switch seq.Add(1) {
+		case 1:
+			return 1, nil
+		case 2:
+			return 2, nil
+		default:
+			return 0, fabrics.ErrNotReady
+		}
+	}
+	commitCalls := atomic.Int32{}
+	commit := func(uint64) error {
+		commitCalls.Add(1)
+		return errors.New("transient")
+	}
+	onFatal := func() { t.Fatal("commit failure must not be reported as fatal") }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTargetProgressLoop(ctx, done, read, commit, onFatal)
+
+	require.Eventually(t, func() bool { return commitCalls.Load() >= 2 },
+		time.Second, time.Millisecond)
+	cancel()
+	<-done
+}
+
+func TestRunTargetProgressLoop_CtxCancelExitsImmediately(t *testing.T) {
+	read := func() (uint64, error) { return 0, fabrics.ErrNotReady }
+	commit := func(uint64) error { return nil }
+	onFatal := func() { t.Fatal("ctx cancel must not look fatal") }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTargetProgressLoop(ctx, done, read, commit, onFatal)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not honour ctx cancel during idle sleep")
+	}
+}
+
+func TestRunTargetProgressLoop_NilOnFatalDoesNotPanic(t *testing.T) {
+	// A nil onFatal would be a programming mistake from the caller,
+	// but the loop must defend against it (a panic in the goroutine
+	// would crash the gateway). Catches a regression where someone
+	// forgot the if onFatal != nil guard.
+	read := func() (uint64, error) { return 0, errors.New("fatal") }
+	commit := func(uint64) error { return nil }
+
+	done := make(chan struct{})
+	go runTargetProgressLoop(context.Background(), done, read, commit, nil)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not exit on fatal read with nil onFatal")
+	}
+}


### PR DESCRIPTION
## Summary

39 tests across the five gateway packages whose state machines or
pure helpers can be exercised without a live libmxl-fabrics
handle. The two progress loops, refactored in #16 to accept their
per-tick cgo work as injected closures, are now covered against
the bug classes the gateway has shipped in production (head
ordering, ErrNotReady filtering, fatal-error recovery, ctx
cancellation, goroutine leaks).

## What lands

- `gateway/internal/config/config_test.go`: full FromFlags +
  Validate matrix.
- `gateway/internal/mirror/common_test.go`: mapProvider for every
  CRD enum value plus the unknown -> Auto fallback.
- `gateway/internal/mirror/source_test.go`: runTransferLoop
  scenarios (tail-from-head, transient transfer error, initial
  probe error, ErrNotReady, ctx cancel).
- `gateway/internal/mirror/target_test.go`: runTargetProgressLoop
  scenarios (commit ordering, fatal exits once, commit error
  non-fatal, ctx cancel, nil onFatal). goleak in TestMain.
- `gateway/internal/capabilities/publisher_test.go`: EnsureExists,
  Refresh, RunRefreshLoop with goleak.
- `gateway/cmd/mxl-fabrics-gateway/main_test.go`: providerNames.

## Verification

- Inside the go-mxl-builder container, `go test -race ./...`
  reports `ok` for all four packages with tests. Per-package
  coverage: `internal/config` 96.9%, `internal/capabilities`
  87.9%, `cmd/mxl-fabrics-gateway` 13.6% (only providerNames is
  unit-testable; main + run drive live mxl handles),
  `internal/mirror` 12.0% (the loops, mapProvider; the Reconcile
  + openTarget + recoverFromFatalError codepaths still require a
  live writer and are deferred to integration tests).
- `gofmt -l gateway/` clean.
- `go vet ./...` clean.

## Base

Stacked on `refactor/gateway-interfaces` (PR #16); merges to
`main` once that lands.