### PR TITLE
test: bring per-module test suites and gateway refactor into main

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -25,6 +25,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -38,7 +39,9 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.uber.org/goleak v1.3.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -1,0 +1,123 @@
+package config
+
+import (
+	"flag"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// FromFlags parses CLI args, falls back to env vars for NodeName and
+// Kubeconfig, and finally calls Validate. The tests pin defaults
+// (because the operator uses them to derive cluster-wide
+// readiness expectations) and every Validate rejection path.
+
+func TestFromFlags_DefaultsAndRequiredFields(t *testing.T) {
+	t.Setenv("NODE_NAME", "")
+	t.Setenv("KUBECONFIG", "")
+
+	_, err := FromFlags(flag.NewFlagSet("agent", flag.ContinueOnError), nil)
+	require.Error(t, err,
+		"FromFlags must reject an empty args set; --domain-path has no default")
+	assert.Contains(t, err.Error(), "--domain-path")
+}
+
+func TestFromFlags_DefaultsFireWhenArgsProvided(t *testing.T) {
+	t.Setenv("NODE_NAME", "")
+	t.Setenv("KUBECONFIG", "")
+
+	c, err := FromFlags(flag.NewFlagSet("agent", flag.ContinueOnError),
+		[]string{"--domain-path=/run/mxl/domain", "--node-name=n1"})
+	require.NoError(t, err)
+	assert.Equal(t, "/run/mxl/domain", c.DomainPath)
+	assert.Equal(t, "n1", c.NodeName)
+	assert.Equal(t, ":8081", c.ProbeAddr,
+		"probe address default must stay :8081 because the chart's "+
+			"liveness/readiness probes target that port; flipping it "+
+			"silently disables every pod's probes on upgrade")
+	assert.Equal(t, ":8080", c.MetricsAddr)
+	assert.Equal(t, 30*time.Second, c.ResyncPeriod)
+	assert.Equal(t, "/run/mxl/agent.sock", c.IntentSocketPath)
+	assert.Equal(t, 5*time.Second, c.MaterializeTimeout)
+}
+
+func TestFromFlags_OverridesAreRespected(t *testing.T) {
+	t.Setenv("NODE_NAME", "")
+	t.Setenv("KUBECONFIG", "")
+
+	c, err := FromFlags(flag.NewFlagSet("agent", flag.ContinueOnError), []string{
+		"--domain-path=/data/mxl",
+		"--node-name=worker-7",
+		"--kubeconfig=/etc/kube",
+		"--health-probe-bind-address=:9081",
+		"--metrics-bind-address=:9080",
+		"--resync-period=15s",
+		"--intent-socket=/tmp/mxl.sock",
+		"--materialize-timeout=2s",
+	})
+	require.NoError(t, err)
+	assert.Equal(t, "/data/mxl", c.DomainPath)
+	assert.Equal(t, "worker-7", c.NodeName)
+	assert.Equal(t, "/etc/kube", c.Kubeconfig)
+	assert.Equal(t, ":9081", c.ProbeAddr)
+	assert.Equal(t, ":9080", c.MetricsAddr)
+	assert.Equal(t, 15*time.Second, c.ResyncPeriod)
+	assert.Equal(t, "/tmp/mxl.sock", c.IntentSocketPath)
+	assert.Equal(t, 2*time.Second, c.MaterializeTimeout)
+}
+
+func TestFromFlags_NodeNameFallsBackToEnv(t *testing.T) {
+	t.Setenv("NODE_NAME", "from-env")
+	t.Setenv("KUBECONFIG", "/some/path")
+
+	c, err := FromFlags(flag.NewFlagSet("agent", flag.ContinueOnError),
+		[]string{"--domain-path=/run/mxl/domain"})
+	require.NoError(t, err)
+	assert.Equal(t, "from-env", c.NodeName)
+	assert.Equal(t, "/some/path", c.Kubeconfig,
+		"downward-API env vars must be picked up; missing them on a "+
+			"production node would make the agent fail to look itself up")
+}
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name    string
+		c       Config
+		wantErr string
+	}{
+		{
+			name:    "missing domain path",
+			c:       Config{NodeName: "n1"},
+			wantErr: "--domain-path is required",
+		},
+		{
+			name:    "relative domain path",
+			c:       Config{DomainPath: "run/mxl/domain", NodeName: "n1"},
+			wantErr: "must be absolute",
+		},
+		{
+			name:    "missing node name",
+			c:       Config{DomainPath: "/run/mxl/domain"},
+			wantErr: "--node-name",
+		},
+		{
+			name:    "valid",
+			c:       Config{DomainPath: "/run/mxl/domain", NodeName: "n1"},
+			wantErr: "",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.c.Validate()
+			if tc.wantErr == "" {
+				require.NoError(t, err)
+				return
+			}
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tc.wantErr)
+		})
+	}
+}

--- a/agent/internal/domainpublisher/publisher_test.go
+++ b/agent/internal/domainpublisher/publisher_test.go
@@ -1,0 +1,184 @@
+package domainpublisher
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/goleak"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// goleak checks every test in this package starts and ends with the
+// same set of goroutines. RunRefreshLoop is the only goroutine
+// producer here; the assertion catches a regression that forgot to
+// honour ctx cancellation.
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func staticStats(cap, free int64) FilesystemStats {
+	return func(_ string) (int64, int64, error) { return cap, free, nil }
+}
+
+func TestEnsureExists_CreatesMxlDomainOnce(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := &Publisher{
+		Client:        c,
+		NodeName:      "n1",
+		HostPath:      "/run/mxl/domain",
+		Stats:         staticStats(1024, 512),
+		FanotifyReady: func() bool { return true },
+	}
+
+	require.NoError(t, p.EnsureExists(context.Background()))
+
+	var got mxlv1alpha1.MxlDomain
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "n1"}, &got))
+	assert.Equal(t, "n1", got.Spec.NodeName)
+	assert.Equal(t, "/run/mxl/domain", got.Spec.HostPath)
+	assert.Empty(t, got.Status.LastSeen,
+		"EnsureExists only creates; status is left for Refresh, so the "+
+			"agent can split creation from periodic refresh on cold start")
+
+	// Second EnsureExists must be idempotent.
+	require.NoError(t, p.EnsureExists(context.Background()))
+}
+
+func TestRefresh_UpdatesStatusFromStatsAndFanotifyReady(t *testing.T) {
+	scheme := newScheme(t)
+	existing := &mxlv1alpha1.MxlDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       mxlv1alpha1.MxlDomainSpec{NodeName: "n1", HostPath: "/run/mxl/domain"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlDomain{}).
+		WithObjects(existing).
+		Build()
+
+	fanotify := false
+	p := &Publisher{
+		Client:        c,
+		NodeName:      "n1",
+		HostPath:      "/run/mxl/domain",
+		Stats:         staticStats(2048, 1024),
+		FanotifyReady: func() bool { return fanotify },
+	}
+
+	require.NoError(t, p.Refresh(context.Background()))
+
+	var got mxlv1alpha1.MxlDomain
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "n1"}, &got))
+	assert.Equal(t, int64(2048), got.Status.CapacityBytes)
+	assert.Equal(t, int64(1024), got.Status.FreeBytes)
+	assert.False(t, got.Status.FanotifyReady,
+		"FanotifyReady=false at the agent must surface in CR status; "+
+			"otherwise on-demand mirror materialization stays broken without "+
+			"the operator noticing")
+	require.NotNil(t, got.Status.LastSeen)
+
+	// Toggle the readiness signal and refresh again: the new value
+	// must replace the old one (no silent stickiness).
+	fanotify = true
+	require.NoError(t, p.Refresh(context.Background()))
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "n1"}, &got))
+	assert.True(t, got.Status.FanotifyReady)
+}
+
+func TestRefresh_PropagatesStatsError(t *testing.T) {
+	scheme := newScheme(t)
+	existing := &mxlv1alpha1.MxlDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlDomain{}).
+		WithObjects(existing).
+		Build()
+
+	want := errors.New("statfs broke")
+	p := &Publisher{
+		Client:        c,
+		NodeName:      "n1",
+		HostPath:      "/run/mxl/domain",
+		Stats:         func(_ string) (int64, int64, error) { return 0, 0, want },
+		FanotifyReady: func() bool { return true },
+	}
+
+	err := p.Refresh(context.Background())
+	require.Error(t, err)
+	assert.ErrorIs(t, err, want,
+		"the underlying statfs error must be wrapped, not swallowed; "+
+			"the agent must surface 'cannot read disk' to logs so an "+
+			"alert can fire")
+}
+
+func TestRefresh_MissingMxlDomain_Errors(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := &Publisher{
+		Client:        c,
+		NodeName:      "n1",
+		Stats:         staticStats(1, 1),
+		FanotifyReady: func() bool { return true },
+	}
+	err := p.Refresh(context.Background())
+	require.Error(t, err)
+}
+
+func TestRunRefreshLoop_CancelsOnContextDone(t *testing.T) {
+	scheme := newScheme(t)
+	existing := &mxlv1alpha1.MxlDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlDomain{}).
+		WithObjects(existing).
+		Build()
+	p := &Publisher{
+		Client:        c,
+		NodeName:      "n1",
+		HostPath:      "/run/mxl/domain",
+		Stats:         staticStats(1, 1),
+		FanotifyReady: func() bool { return true },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		p.RunRefreshLoop(ctx, 10*time.Millisecond)
+		close(done)
+	}()
+
+	// Wait long enough for at least one tick to land, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("RunRefreshLoop did not return after ctx cancel")
+	}
+	// goleak in TestMain catches any leftover goroutine.
+}

--- a/agent/internal/fanotify/parse_test.go
+++ b/agent/internal/fanotify/parse_test.go
@@ -1,0 +1,199 @@
+//go:build linux
+
+package fanotify
+
+import (
+	"context"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/sys/unix"
+)
+
+// These tests drive parseOne / extractName / dispatch with hand-built
+// byte buffers. The fanotify wire format does not change across
+// kernel releases, but the parser easily off-by-ones the cursor when
+// edited; the tests pin both happy-path decoding and the rejection
+// paths a malformed event must take.
+
+// buildEvent constructs one fanotify event ready for parseOne:
+//
+//	metadata (24 bytes) + info_dfid_name (header 4 + fsid 8 + fh 8 + 0
+//	handle bytes + zero-terminated name).
+//
+// handleBytes is the length of the (variable-size) file_handle handle
+// portion; the test passes 0 because the parser only needs to skip it.
+func buildEvent(t *testing.T, mask uint64, pid int32, name string, handleBytes int) []byte {
+	t.Helper()
+
+	payload := make([]byte, 0)
+	// fsid (8 bytes, opaque to the parser).
+	payload = append(payload, make([]byte, fanFSIDSize)...)
+	// file_handle header: handle_bytes (uint32) + handle_type (int32).
+	hdr := make([]byte, fileHandleHdrSize)
+	binary.LittleEndian.PutUint32(hdr[0:4], uint32(handleBytes))
+	binary.LittleEndian.PutUint32(hdr[4:8], 0) // type
+	payload = append(payload, hdr...)
+	// Handle content (skipped by the parser).
+	payload = append(payload, make([]byte, handleBytes)...)
+	// Null-terminated name.
+	payload = append(payload, []byte(name)...)
+	payload = append(payload, 0x00)
+
+	// info record header: 1 byte type, 1 byte pad, 2 bytes total_len.
+	info := make([]byte, infoHeaderSize)
+	info[0] = byte(infoTypeDFIDName)
+	infoLen := infoHeaderSize + len(payload)
+	binary.LittleEndian.PutUint16(info[2:4], uint16(infoLen))
+	info = append(info, payload...)
+
+	// metadata: 24 bytes.
+	//  0..3:   event_len (uint32 LE)
+	//  4..7:   vers + reserved (don't care)
+	//  8..15:  mask (uint64 LE)
+	// 16..19:  fd (int32, not consumed)
+	// 20..23:  pid (uint32 LE)
+	meta := make([]byte, metaSize)
+	eventLen := uint32(metaSize + len(info))
+	binary.LittleEndian.PutUint32(meta[0:4], eventLen)
+	binary.LittleEndian.PutUint64(meta[8:16], mask)
+	binary.LittleEndian.PutUint32(meta[20:24], uint32(pid))
+
+	return append(meta, info...)
+}
+
+func TestParseOne_HappyPath(t *testing.T) {
+	const name = "11111111-2222-3333-4444-555555555555.mxl-flow"
+	buf := buildEvent(t, unix.FAN_CREATE|unix.FAN_ONDIR, 12345, name, 0)
+
+	ev, consumed, err := parseOne(buf)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	assert.Equal(t, len(buf), consumed)
+	assert.Equal(t, uint64(unix.FAN_CREATE|unix.FAN_ONDIR), ev.Mask)
+	assert.Equal(t, int32(12345), ev.PID)
+	assert.Equal(t, name, ev.Name)
+	assert.True(t, ev.IsCreate())
+	assert.False(t, ev.IsRemove())
+}
+
+func TestParseOne_RemoveMaskIsClassified(t *testing.T) {
+	buf := buildEvent(t, unix.FAN_DELETE|unix.FAN_ONDIR, 7, "x.mxl-flow", 0)
+	ev, _, err := parseOne(buf)
+	require.NoError(t, err)
+	require.NotNil(t, ev)
+	assert.True(t, ev.IsRemove())
+	assert.False(t, ev.IsCreate(),
+		"a delete event must not classify as a create; the agent uses "+
+			"this discriminator to choose between PublishAppeared and "+
+			"PublishVanished, and a misclassification would flip the "+
+			"MxlFlow phase the wrong way")
+}
+
+func TestParseOne_HandleBytesSkipped(t *testing.T) {
+	// Vary handle_bytes; the parser must skip over it without
+	// reading the contents or mistaking them for the name.
+	for _, hb := range []int{0, 4, 16, 64} {
+		buf := buildEvent(t, unix.FAN_CREATE, 1, "a.mxl-flow", hb)
+		ev, _, err := parseOne(buf)
+		require.NoError(t, err)
+		require.NotNil(t, ev)
+		assert.Equalf(t, "a.mxl-flow", ev.Name,
+			"handle_bytes=%d must not bleed into the name", hb)
+	}
+}
+
+func TestParseOne_TruncatedMetadata_ReturnsError(t *testing.T) {
+	buf := []byte{0, 1, 2} // way under metaSize
+	_, _, err := parseOne(buf)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "truncated")
+}
+
+func TestParseOne_InvalidEventLen_ReturnsError(t *testing.T) {
+	buf := buildEvent(t, unix.FAN_CREATE, 1, "a.mxl-flow", 0)
+	// Overwrite the event_len with a value larger than the buffer.
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(buf))+100)
+	_, _, err := parseOne(buf)
+	require.Error(t, err)
+}
+
+func TestParseOne_EventWithoutName_IsSkippedQuietly(t *testing.T) {
+	// Construct a metadata-only event (no info record). The parser
+	// must return (nil, eventLen, nil) so dispatch skips it.
+	meta := make([]byte, metaSize)
+	binary.LittleEndian.PutUint32(meta[0:4], metaSize)
+	binary.LittleEndian.PutUint64(meta[8:16], unix.FAN_CREATE)
+
+	ev, consumed, err := parseOne(meta)
+	require.NoError(t, err)
+	assert.Nil(t, ev,
+		"events without a DFID_NAME record are routine on older kernels "+
+			"and on inode-mark events for non-name-bearing changes; the "+
+			"parser must skip them, not fail the whole read")
+	assert.Equal(t, metaSize, consumed)
+}
+
+func TestExtractName_TruncatedPayload(t *testing.T) {
+	_, err := extractName([]byte{0, 1, 2})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "too short")
+}
+
+func TestExtractName_HandleOverrunsPayload(t *testing.T) {
+	payload := make([]byte, fanFSIDSize+fileHandleHdrSize)
+	binary.LittleEndian.PutUint32(payload[fanFSIDSize:fanFSIDSize+4], 9999)
+	_, err := extractName(payload)
+	require.Error(t, err)
+}
+
+func TestDispatch_ForwardsMultipleEvents(t *testing.T) {
+	// Concatenate two events; dispatch must emit both on the channel
+	// and consume the entire buffer.
+	a := buildEvent(t, unix.FAN_CREATE, 1, "a.mxl-flow", 0)
+	b := buildEvent(t, unix.FAN_DELETE, 2, "b.mxl-flow", 0)
+	buf := append(append([]byte{}, a...), b...)
+
+	out := make(chan Event, 4)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := dispatch(ctx, buf, out)
+	require.NoError(t, err)
+	close(out)
+
+	got := make([]Event, 0, 2)
+	for e := range out {
+		got = append(got, e)
+	}
+	require.Len(t, got, 2)
+	assert.Equal(t, "a.mxl-flow", got[0].Name)
+	assert.Equal(t, "b.mxl-flow", got[1].Name)
+	assert.True(t, got[1].IsRemove())
+}
+
+func TestDispatch_RespectsContextCancel(t *testing.T) {
+	// One event waiting; channel buffered=0; ctx already cancelled.
+	a := buildEvent(t, unix.FAN_CREATE, 1, "a.mxl-flow", 0)
+	out := make(chan Event)
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	err := dispatch(ctx, a, out)
+	assert.ErrorIs(t, err, context.Canceled,
+		"a fanotify dispatch must abandon a blocked channel send when "+
+			"the agent is shutting down; otherwise the read loop never "+
+			"unblocks on Close")
+}
+
+func TestEventMaskHelpers(t *testing.T) {
+	assert.True(t, Event{Mask: MaskCreate}.IsCreate())
+	assert.True(t, Event{Mask: MaskMovedTo}.IsCreate())
+	assert.True(t, Event{Mask: MaskDelete}.IsRemove())
+	assert.True(t, Event{Mask: MaskMovedFrom}.IsRemove())
+	assert.False(t, Event{Mask: MaskOnDir}.IsCreate(),
+		"FAN_ONDIR alone is not a creation; it is the directory-flavour bit")
+	assert.False(t, Event{Mask: MaskOnDir}.IsRemove())
+}

--- a/agent/internal/flowpublisher/publisher_test.go
+++ b/agent/internal/flowpublisher/publisher_test.go
@@ -1,0 +1,247 @@
+package flowpublisher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+const validFlowID = "11111111-2222-3333-4444-555555555555"
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestFlowIDFromDirName(t *testing.T) {
+	cases := []struct {
+		name   string
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"canonical", validFlowID + ".mxl-flow", validFlowID, true},
+		{"empty id but suffix", ".mxl-flow", "", false},
+		{"missing suffix", validFlowID, "", false},
+		{"wrong suffix", validFlowID + ".mxl-flowx", "", false},
+		{"empty", "", "", false},
+		{"only suffix-looking", "abc.mxl-flow", "abc", true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := FlowIDFromDirName(tc.in)
+			assert.Equal(t, tc.wantOK, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestPublishAppeared_CreatesMxlFlowAndLocationOnFirstObservation(t *testing.T) {
+	scheme := newScheme(t)
+	domain := t.TempDir()
+	flowDir := filepath.Join(domain, validFlowID+".mxl-flow")
+	require.NoError(t, os.Mkdir(flowDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(flowDir, FlowDefName),
+		[]byte(`{"id":"`+validFlowID+`","grain_size":1234}`),
+		0o644))
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		Build()
+
+	p := &Publisher{Client: c, DomainPath: domain, NodeName: "n1"}
+
+	require.NoError(t, p.PublishAppeared(context.Background(), validFlowID+".mxl-flow"))
+
+	var got mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: validFlowID}, &got))
+	assert.Equal(t, validFlowID, got.Spec.ID)
+	assert.JSONEq(t, `{"id":"`+validFlowID+`","grain_size":1234}`, string(got.Spec.Definition.Raw))
+
+	require.Len(t, got.Status.Locations, 1)
+	assert.Equal(t, "n1", got.Status.Locations[0].NodeName)
+	assert.Equal(t, mxlv1alpha1.MxlFlowLocationOrigin, got.Status.Locations[0].Phase)
+	assert.NotNil(t, got.Status.Locations[0].LastObserved,
+		"the agent stamps observed time so stale-detection downstream "+
+			"has a reference; missing this turns Stale into a permanent state")
+}
+
+func TestPublishAppeared_IsIdempotent_DoesNotOverwriteExistingSpec(t *testing.T) {
+	scheme := newScheme(t)
+	domain := t.TempDir()
+	flowDir := filepath.Join(domain, validFlowID+".mxl-flow")
+	require.NoError(t, os.Mkdir(flowDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(flowDir, FlowDefName),
+		[]byte(`{"id":"`+validFlowID+`"}`),
+		0o644))
+
+	// Pre-existing MxlFlow with a richer spec - simulates the case
+	// where another writer (operator-driven, or a different agent
+	// that watched first) created the CR.
+	existing := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: ObjectMeta(validFlowID),
+		Spec: mxlv1alpha1.MxlFlowSpec{
+			ID:         validFlowID,
+			Definition: runtime.RawExtension{Raw: []byte(`{"id":"` + validFlowID + `","richer":true}`)},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(existing).
+		Build()
+
+	p := &Publisher{Client: c, DomainPath: domain, NodeName: "n1"}
+
+	require.NoError(t, p.PublishAppeared(context.Background(), validFlowID+".mxl-flow"))
+
+	var got mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: validFlowID}, &got))
+	assert.Equal(t,
+		`{"id":"`+validFlowID+`","richer":true}`,
+		string(got.Spec.Definition.Raw),
+		"the agent must not clobber a richer definition the operator "+
+			"or another writer set; only the per-node location is the "+
+			"agent's to own")
+	require.Len(t, got.Status.Locations, 1)
+	assert.Equal(t, mxlv1alpha1.MxlFlowLocationOrigin, got.Status.Locations[0].Phase)
+}
+
+func TestPublishAppeared_RejectsInvalidJSON(t *testing.T) {
+	scheme := newScheme(t)
+	domain := t.TempDir()
+	flowDir := filepath.Join(domain, validFlowID+".mxl-flow")
+	require.NoError(t, os.Mkdir(flowDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(flowDir, FlowDefName),
+		[]byte(`not-json-at-all`),
+		0o644))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := &Publisher{Client: c, DomainPath: domain, NodeName: "n1"}
+
+	err := p.PublishAppeared(context.Background(), validFlowID+".mxl-flow")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not valid JSON")
+}
+
+func TestPublishAppeared_MissingDefFileReturnsError(t *testing.T) {
+	scheme := newScheme(t)
+	domain := t.TempDir()
+	// Directory exists but no flow_def.json inside.
+	require.NoError(t, os.Mkdir(filepath.Join(domain, validFlowID+".mxl-flow"), 0o755))
+
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := &Publisher{Client: c, DomainPath: domain, NodeName: "n1"}
+
+	err := p.PublishAppeared(context.Background(), validFlowID+".mxl-flow")
+	require.Error(t, err)
+}
+
+func TestPublishAppeared_NonFlowEntryIsIgnoredQuietly(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := &Publisher{Client: c, DomainPath: t.TempDir(), NodeName: "n1"}
+
+	require.NoError(t, p.PublishAppeared(context.Background(), "not-a-flow.txt"))
+	// No CR should have been created.
+	var list mxlv1alpha1.MxlFlowList
+	require.NoError(t, c.List(context.Background(), &list))
+	assert.Empty(t, list.Items)
+}
+
+func TestPublishVanished_MarksLocationStale(t *testing.T) {
+	scheme := newScheme(t)
+	existing := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: ObjectMeta(validFlowID),
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: validFlowID},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{
+				{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+				{NodeName: "other", Phase: mxlv1alpha1.MxlFlowLocationReady},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(existing).
+		Build()
+	p := &Publisher{Client: c, DomainPath: "/tmp", NodeName: "n1"}
+
+	require.NoError(t, p.PublishVanished(context.Background(), validFlowID+".mxl-flow"))
+
+	var got mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: validFlowID}, &got))
+	require.Len(t, got.Status.Locations, 2)
+
+	byNode := map[string]mxlv1alpha1.MxlFlowLocationPhase{}
+	for _, l := range got.Status.Locations {
+		byNode[l.NodeName] = l.Phase
+	}
+	assert.Equal(t, mxlv1alpha1.MxlFlowLocationStale, byNode["n1"],
+		"vanishing on this node flips this node's phase to Stale only; "+
+			"other nodes' locations must stay intact")
+	assert.Equal(t, mxlv1alpha1.MxlFlowLocationReady, byNode["other"])
+}
+
+func TestPublishVanished_MissingMxlFlowIsNoOp(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	p := &Publisher{Client: c, DomainPath: "/tmp", NodeName: "n1"}
+
+	require.NoError(t, p.PublishVanished(context.Background(), validFlowID+".mxl-flow"),
+		"a flow that never made it to the API server is the same as "+
+			"one that vanished; the agent must not error out on the race")
+}
+
+func TestInitialSync_WalksDomainAndPublishesEach(t *testing.T) {
+	scheme := newScheme(t)
+	domain := t.TempDir()
+
+	// Create two valid flows + one entry to ignore.
+	for _, id := range []string{
+		validFlowID,
+		"22222222-3333-4444-5555-666666666666",
+	} {
+		dir := filepath.Join(domain, id+".mxl-flow")
+		require.NoError(t, os.Mkdir(dir, 0o755))
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, FlowDefName),
+			[]byte(`{"id":"`+id+`"}`), 0o644))
+	}
+	// A non-flow directory must not produce a Create call.
+	require.NoError(t, os.Mkdir(filepath.Join(domain, "junk"), 0o755))
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		Build()
+	p := &Publisher{Client: c, DomainPath: domain, NodeName: "n1"}
+	require.NoError(t, p.InitialSync(context.Background()))
+
+	var list mxlv1alpha1.MxlFlowList
+	require.NoError(t, c.List(context.Background(), &list))
+	assert.Len(t, list.Items, 2,
+		"InitialSync must produce one CR per .mxl-flow directory and "+
+			"ignore non-matching entries; if this slips, the agent "+
+			"would either skip flows on cold start or produce garbage CRs")
+}

--- a/agent/internal/flowpublisher/testhelpers_test.go
+++ b/agent/internal/flowpublisher/testhelpers_test.go
@@ -1,0 +1,9 @@
+package flowpublisher
+
+import metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+// ObjectMeta is a tiny convenience for the cluster-scoped MxlFlow
+// fixtures used in tests.
+func ObjectMeta(name string) metav1.ObjectMeta {
+	return metav1.ObjectMeta{Name: name}
+}

--- a/agent/internal/intent/dispatcher.go
+++ b/agent/internal/intent/dispatcher.go
@@ -33,6 +33,11 @@ const (
 	defaultPollInterval       = 50 * time.Millisecond
 )
 
+// FlowChecker reports whether the named flow's flow_def.json is
+// present locally. The default implementation stats the filesystem
+// under DomainPath; tests inject a closure that fakes the lookup.
+type FlowChecker func(flowID string) bool
+
 // Dispatcher resolves a libmxl-intent.so request into an
 // MxlFlowMirror reconciliation that completes (Ready) or fails.
 type Dispatcher struct {
@@ -53,6 +58,10 @@ type Dispatcher struct {
 	// mirror status while waiting; zero means use the package
 	// default.
 	PollInterval time.Duration
+
+	// FlowChecker overrides the filesystem-based local-flow check.
+	// Nil falls back to the default stat under DomainPath.
+	FlowChecker FlowChecker
 }
 
 // Materialize ensures that the flow referenced by path is, or will
@@ -134,6 +143,9 @@ func FlowIDFromPath(domain, path string) (string, bool) {
 }
 
 func (d *Dispatcher) flowExistsLocally(flowID string) bool {
+	if d.FlowChecker != nil {
+		return d.FlowChecker(flowID)
+	}
 	_, err := os.Stat(filepath.Join(d.DomainPath, flowID+".mxl-flow", "flow_def.json"))
 	return err == nil
 }

--- a/agent/internal/intent/dispatcher_test.go
+++ b/agent/internal/intent/dispatcher_test.go
@@ -1,0 +1,403 @@
+package intent
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/qvest-digital/mxl-k8s/agent/internal/podlookup"
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+const flowID = "11111111-2222-3333-4444-555555555555"
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestFlowIDFromPath(t *testing.T) {
+	cases := []struct {
+		name   string
+		domain string
+		path   string
+		want   string
+		ok     bool
+	}{
+		{
+			name:   "canonical",
+			domain: "/run/mxl/domain",
+			path:   "/run/mxl/domain/" + flowID + ".mxl-flow/flow_def.json",
+			want:   flowID,
+			ok:     true,
+		},
+		{
+			name:   "trailing slash on domain still matches",
+			domain: "/run/mxl/domain/",
+			path:   "/run/mxl/domain/" + flowID + ".mxl-flow/flow_def.json",
+			want:   flowID,
+			ok:     true,
+		},
+		{
+			name:   "different domain root rejected",
+			domain: "/run/mxl/domain",
+			path:   "/run/other/" + flowID + ".mxl-flow/flow_def.json",
+			ok:     false,
+		},
+		{
+			name:   "deeper path rejected",
+			domain: "/run/mxl/domain",
+			path:   "/run/mxl/domain/" + flowID + ".mxl-flow/subdir/flow_def.json",
+			ok:     false,
+		},
+		{
+			name:   "wrong filename rejected",
+			domain: "/run/mxl/domain",
+			path:   "/run/mxl/domain/" + flowID + ".mxl-flow/data.json",
+			ok:     false,
+		},
+		{
+			name:   "missing flow suffix rejected",
+			domain: "/run/mxl/domain",
+			path:   "/run/mxl/domain/" + flowID + "/flow_def.json",
+			ok:     false,
+		},
+		{
+			name:   "empty id rejected",
+			domain: "/run/mxl/domain",
+			path:   "/run/mxl/domain/.mxl-flow/flow_def.json",
+			ok:     false,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := FlowIDFromPath(tc.domain, tc.path)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}
+
+func TestMirrorName_MatchesOperatorAlgorithm(t *testing.T) {
+	// The operator and the agent must converge on identical names so
+	// the gateway sees exactly one MxlFlowMirror per (flow, target
+	// node). Pin the result here so any drift in either codepath
+	// surfaces with a failed test.
+	cases := []struct {
+		flowID string
+		target string
+		want   string
+	}{
+		{flowID, "worker-1", flowID + "--worker-1"},
+		{"ABCDABCD-1234-5678-9ABC-DEF012345678", "Worker-A",
+			"abcdabcd-1234-5678-9abc-def012345678--worker-a"},
+		{flowID, "ip-10.0.0.1.eu-central-1.compute",
+			flowID + "--ip-10-0-0-1-eu-central-1-compute"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.want, func(t *testing.T) {
+			got := MirrorName(tc.flowID, tc.target)
+			assert.Equal(t, tc.want, got)
+			errs := validation.IsDNS1123Subdomain(got)
+			assert.Empty(t, errs, "MirrorName output not DNS-1123: %v", errs)
+		})
+	}
+}
+
+func TestMaterialize_LocalFlow_ReturnsImmediately(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+
+	d := &Dispatcher{
+		Client:      c,
+		Resolver:    &podlookup.Resolver{Client: c, NodeName: "n1"},
+		DomainPath:  "/run/mxl/domain",
+		NodeName:    "n1",
+		FlowChecker: func(string) bool { return true },
+	}
+
+	err := d.Materialize(context.Background(), 42, "/run/mxl/domain/"+flowID+".mxl-flow/flow_def.json")
+	require.NoError(t, err,
+		"a flow already materialized on this node must not trigger a mirror "+
+			"creation; the shim's caller only needs the file to exist before it retries")
+}
+
+func TestMaterialize_InvalidPath_ErrorsWithoutSideEffects(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	d := &Dispatcher{
+		Client:      c,
+		Resolver:    &podlookup.Resolver{Client: c, NodeName: "n1"},
+		DomainPath:  "/run/mxl/domain",
+		NodeName:    "n1",
+		FlowChecker: func(string) bool { return false },
+	}
+
+	err := d.Materialize(context.Background(), 42, "/etc/passwd")
+	require.Error(t, err)
+
+	var list mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, c.List(context.Background(), &list))
+	assert.Empty(t, list.Items,
+		"a malformed path must never lead to a mirror Create; if it does, "+
+			"a buggy shim can spam unrelated mirrors into the cluster")
+}
+
+func TestMaterialize_MissingFlow_Errors(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(&corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace: "ns",
+				Name:      "consumer",
+				UID:       "uid-1",
+			},
+			Spec: corev1.PodSpec{NodeName: "n1"},
+		}).
+		Build()
+
+	d := &Dispatcher{
+		Client:      c,
+		Resolver:    &podlookup.Resolver{Client: c, NodeName: "n1"},
+		DomainPath:  "/run/mxl/domain",
+		NodeName:    "n1",
+		FlowChecker: func(string) bool { return false },
+	}
+
+	// Materialize cannot call PodForPID without /proc; bypass via a
+	// shortcut: when FlowChecker says true on second call, the
+	// dispatcher early-returns. Instead test the
+	// resolveSourceNode-missing-flow case by exercising it directly.
+	_, ok, err := d.resolveSourceNode(context.Background(), "missing-flow")
+	require.NoError(t, err)
+	assert.False(t, ok)
+}
+
+func TestMaterialize_SourceIsLocalNode_NoOps(t *testing.T) {
+	// When the flow's origin is the same node the dispatcher runs on,
+	// Materialize returns without creating any mirror. This protects
+	// against the agent racing its own MxlFlow publish - the writer
+	// is local; the file will appear shortly.
+	scheme := newScheme(t)
+	flow := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: flowID},
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: flowID},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{
+				{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow).
+		Build()
+
+	d := &Dispatcher{
+		Client:      c,
+		Resolver:    &podlookup.Resolver{Client: c, NodeName: "n1"},
+		DomainPath:  "/run/mxl/domain",
+		NodeName:    "n1",
+		FlowChecker: func(string) bool { return false },
+	}
+	_, ok, err := d.resolveSourceNode(context.Background(), flowID)
+	require.NoError(t, err)
+	require.True(t, ok)
+
+	// Manually drive the same logic Materialize uses for the
+	// same-node branch by inspecting resolveSourceNode plus a check.
+	src, _, _ := d.resolveSourceNode(context.Background(), flowID)
+	assert.Equal(t, "n1", src)
+
+	// No mirror has been created at this point.
+	var list mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, c.List(context.Background(), &list))
+	assert.Empty(t, list.Items)
+}
+
+func TestWaitReady_FailedPhase_ReturnsError(t *testing.T) {
+	scheme := newScheme(t)
+	mirror := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "m"},
+		Status: mxlv1alpha1.MxlFlowMirrorStatus{
+			Phase: mxlv1alpha1.MxlFlowMirrorFailed,
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	d := &Dispatcher{
+		Client:       c,
+		PollInterval: 5 * time.Millisecond,
+	}
+	err := d.waitReady(context.Background(), mirror)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Failed phase")
+}
+
+func TestWaitReady_ContextDeadline_PropagatesError(t *testing.T) {
+	scheme := newScheme(t)
+	mirror := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "m"},
+		Status: mxlv1alpha1.MxlFlowMirrorStatus{
+			Phase: mxlv1alpha1.MxlFlowMirrorMaterializing,
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	d := &Dispatcher{
+		Client:       c,
+		PollInterval: 5 * time.Millisecond,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Millisecond)
+	defer cancel()
+
+	err := d.waitReady(ctx, mirror)
+	require.ErrorIs(t, err, context.DeadlineExceeded,
+		"the per-request timeout must surface as DeadlineExceeded so the "+
+			"shim's caller stays out of an indefinite wait when the gateway "+
+			"never materializes the mirror")
+}
+
+func TestWaitReady_Ready_ReturnsNil(t *testing.T) {
+	scheme := newScheme(t)
+	mirror := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "m"},
+		Status: mxlv1alpha1.MxlFlowMirrorStatus{
+			Phase:      mxlv1alpha1.MxlFlowMirrorReady,
+			TargetInfo: "info",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	d := &Dispatcher{
+		Client:       c,
+		PollInterval: 5 * time.Millisecond,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	require.NoError(t, d.waitReady(ctx, mirror))
+}
+
+func TestWaitReady_ReadyButMissingTargetInfo_KeepsPolling(t *testing.T) {
+	// A Ready phase with an empty TargetInfo is a half-published
+	// state from the gateway. The dispatcher must keep polling so a
+	// transient missing-field race doesn't return success early.
+	scheme := newScheme(t)
+	mirror := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "m"},
+		Status: mxlv1alpha1.MxlFlowMirrorStatus{
+			Phase:      mxlv1alpha1.MxlFlowMirrorReady,
+			TargetInfo: "",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	d := &Dispatcher{
+		Client:       c,
+		PollInterval: 5 * time.Millisecond,
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	err := d.waitReady(ctx, mirror)
+	require.ErrorIs(t, err, context.DeadlineExceeded)
+}
+
+func TestEnsureMirror_Idempotent(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		Build()
+
+	d := &Dispatcher{
+		Client:     c,
+		DomainPath: "/run/mxl/domain",
+		NodeName:   "n1",
+		Provider:   mxlv1alpha1.ProviderTCP,
+	}
+
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "consumer", UID: "uid-1"},
+	}
+
+	first, err := d.ensureMirror(context.Background(), flowID, "n-src", pod)
+	require.NoError(t, err)
+	require.NotNil(t, first)
+	assert.Equal(t, MirrorName(flowID, "n1"), first.Name)
+	assert.Equal(t, "n-src", first.Spec.SourceNode)
+	assert.Equal(t, "n1", first.Spec.TargetNode)
+	assert.Equal(t, mxlv1alpha1.ProviderTCP, first.Spec.Provider)
+
+	// Same call again must return the same name (no AlreadyExists
+	// surfacing up). The reconciler relies on this idempotence so
+	// the agent and the operator can race-create without errors.
+	second, err := d.ensureMirror(context.Background(), flowID, "n-src", pod)
+	require.NoError(t, err)
+	assert.Equal(t, first.Name, second.Name)
+}
+
+func TestEnsureMirror_EmptyProviderDefaultsToAuto(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		Build()
+
+	d := &Dispatcher{
+		Client:     c,
+		DomainPath: "/run/mxl/domain",
+		NodeName:   "n1",
+		// Provider left empty
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "p", UID: "u"},
+	}
+
+	got, err := d.ensureMirror(context.Background(), flowID, "n-src", pod)
+	require.NoError(t, err)
+
+	var live mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: "ns", Name: got.Name}, &live))
+	assert.Equal(t, mxlv1alpha1.ProviderAuto, live.Spec.Provider,
+		"an empty Provider on the dispatcher must default to Auto so the "+
+			"gateway picks the provider at materialization time")
+}
+
+var _ = client.IgnoreNotFound

--- a/agent/internal/intentsock/server.go
+++ b/agent/internal/intentsock/server.go
@@ -33,15 +33,30 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 
 	"golang.org/x/sys/unix"
-
-	"github.com/qvest-digital/mxl-k8s/agent/internal/intent"
 )
 
+// MaterializeDispatcher is the contract the Server expects from the
+// intent dispatcher: given a peer PID and a flow_def.json path, drive
+// the mirror to Ready (or surface a terminal error).
+//
+// The narrow interface keeps the server testable without pulling in
+// the full intent package; *intent.Dispatcher satisfies it
+// implicitly.
+type MaterializeDispatcher interface {
+	Materialize(ctx context.Context, pid int32, path string) error
+}
+
 // Server listens on a UDS and dispatches requests to the intent
-// Dispatcher.
+// dispatcher.
 type Server struct {
 	SocketPath string
-	Dispatcher *intent.Dispatcher
+	Dispatcher MaterializeDispatcher
+
+	// PeerPIDFn overrides the SO_PEERCRED-based PID extraction.
+	// Tests inject a closure returning a known PID over net.Pipe;
+	// production leaves this nil and the unix(7) implementation
+	// kicks in.
+	PeerPIDFn func(net.Conn) (int32, error)
 }
 
 type request struct {
@@ -111,7 +126,11 @@ func (s *Server) handle(ctx context.Context, conn net.Conn) {
 		return
 	}
 
-	pid, err := peerPID(conn)
+	pidFn := s.PeerPIDFn
+	if pidFn == nil {
+		pidFn = peerPID
+	}
+	pid, err := pidFn(conn)
 	if err != nil {
 		writeResponse(conn, response{Error: fmt.Sprintf("peer credentials: %s", err)})
 		return

--- a/agent/internal/intentsock/server_test.go
+++ b/agent/internal/intentsock/server_test.go
@@ -1,0 +1,221 @@
+package intentsock
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"net"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeDispatcher captures Materialize calls and returns a canned
+// error. Each call records (pid, path) so the test can assert the
+// server fed the dispatcher correctly.
+type fakeDispatcher struct {
+	mu    sync.Mutex
+	calls []dispatcherCall
+	err   error
+}
+
+type dispatcherCall struct {
+	pid  int32
+	path string
+}
+
+func (f *fakeDispatcher) Materialize(ctx context.Context, pid int32, path string) error {
+	f.mu.Lock()
+	f.calls = append(f.calls, dispatcherCall{pid: pid, path: path})
+	f.mu.Unlock()
+	return f.err
+}
+
+func (f *fakeDispatcher) lastCall() dispatcherCall {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if len(f.calls) == 0 {
+		return dispatcherCall{}
+	}
+	return f.calls[len(f.calls)-1]
+}
+
+// runOneRequest drives the connection through one full request/
+// response cycle. The test pair is built on net.Pipe so SO_PEERCRED
+// never fires; PeerPIDFn injects the value the test expects.
+//
+// The Write happens in a background goroutine so a server that
+// closes the conn before reading (the PeerPID-error path) does not
+// deadlock the test on a blocked synchronous Write.
+func runOneRequest(t *testing.T, srv *Server, requestJSON string) string {
+	t.Helper()
+	client, server := net.Pipe()
+	defer client.Close()
+
+	done := make(chan struct{})
+	go func() {
+		srv.handle(context.Background(), server)
+		close(done)
+	}()
+	go func() {
+		_, _ = client.Write([]byte(requestJSON))
+	}()
+
+	br := bufio.NewReader(client)
+	line, err := br.ReadString('\n')
+	require.NoError(t, err)
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("handle did not return after response")
+	}
+	return strings.TrimRight(line, "\n")
+}
+
+func TestHandle_ValidRequest_Succeeds(t *testing.T) {
+	disp := &fakeDispatcher{}
+	srv := &Server{
+		Dispatcher: disp,
+		PeerPIDFn:  func(net.Conn) (int32, error) { return 4242, nil },
+	}
+
+	out := runOneRequest(t, srv, `{"path":"/run/mxl/domain/`+
+		`11111111-2222-3333-4444-555555555555.mxl-flow/flow_def.json"}`+"\n")
+
+	var resp response
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	assert.True(t, resp.OK)
+	assert.Empty(t, resp.Error)
+
+	call := disp.lastCall()
+	assert.Equal(t, int32(4242), call.pid,
+		"the server must hand the SO_PEERCRED-derived PID to the dispatcher; "+
+			"forwarding the wrong PID would let any caller materialize a "+
+			"mirror as a different pod")
+	assert.Contains(t, call.path, "flow_def.json")
+}
+
+func TestHandle_InvalidJSON_RespondsWithError(t *testing.T) {
+	disp := &fakeDispatcher{}
+	srv := &Server{
+		Dispatcher: disp,
+		PeerPIDFn:  func(net.Conn) (int32, error) { return 1, nil },
+	}
+
+	out := runOneRequest(t, srv, "not-json\n")
+
+	var resp response
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	assert.False(t, resp.OK)
+	assert.NotEmpty(t, resp.Error)
+	assert.Empty(t, disp.calls,
+		"malformed input must never reach the dispatcher; otherwise a "+
+			"buggy shim could trigger Materialize calls with arbitrary state")
+}
+
+func TestHandle_EmptyPath_RespondsWithError(t *testing.T) {
+	disp := &fakeDispatcher{}
+	srv := &Server{
+		Dispatcher: disp,
+		PeerPIDFn:  func(net.Conn) (int32, error) { return 1, nil },
+	}
+
+	out := runOneRequest(t, srv, `{"path":""}`+"\n")
+
+	var resp response
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	assert.False(t, resp.OK)
+	assert.Contains(t, resp.Error, "empty path")
+	assert.Empty(t, disp.calls)
+}
+
+func TestHandle_DispatcherError_PropagatesReason(t *testing.T) {
+	disp := &fakeDispatcher{err: errors.New("mirror Failed phase")}
+	srv := &Server{
+		Dispatcher: disp,
+		PeerPIDFn:  func(net.Conn) (int32, error) { return 1, nil },
+	}
+
+	out := runOneRequest(t, srv, `{"path":"/run/mxl/domain/f.mxl-flow/flow_def.json"}`+"\n")
+
+	var resp response
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	assert.False(t, resp.OK)
+	assert.Contains(t, resp.Error, "mirror Failed phase",
+		"the dispatcher's error string must round-trip to the shim so the "+
+			"consumer pod's log carries a non-generic reason for the open() fail")
+}
+
+func TestHandle_PeerPIDError_ShortCircuitsBeforeDispatcher(t *testing.T) {
+	disp := &fakeDispatcher{}
+	srv := &Server{
+		Dispatcher: disp,
+		PeerPIDFn:  func(net.Conn) (int32, error) { return 0, errors.New("no creds") },
+	}
+
+	out := runOneRequest(t, srv, `{"path":"/run/mxl/domain/f.mxl-flow/flow_def.json"}`+"\n")
+
+	var resp response
+	require.NoError(t, json.Unmarshal([]byte(out), &resp))
+	assert.False(t, resp.OK)
+	assert.Contains(t, resp.Error, "peer credentials")
+	assert.Empty(t, disp.calls,
+		"if the agent cannot identify the caller, the dispatcher must "+
+			"not run; the access-control story relies on knowing the pod")
+}
+
+func TestServer_RunBindsAndServesOverRealUDS(t *testing.T) {
+	tmp := t.TempDir()
+	sock := tmp + "/agent.sock"
+
+	disp := &fakeDispatcher{}
+	srv := &Server{
+		SocketPath: sock,
+		Dispatcher: disp,
+		PeerPIDFn:  func(net.Conn) (int32, error) { return 9999, nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	done := make(chan error, 1)
+	go func() { done <- srv.Run(ctx) }()
+
+	// Poll until the socket appears (Run does some setup work).
+	deadline := time.Now().Add(2 * time.Second)
+	var conn net.Conn
+	var err error
+	for time.Now().Before(deadline) {
+		conn, err = net.Dial("unix", sock)
+		if err == nil {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	require.NoError(t, err, "could not connect to %s within deadline", sock)
+	defer conn.Close()
+
+	_, err = conn.Write([]byte(`{"path":"/run/mxl/domain/f.mxl-flow/flow_def.json"}` + "\n"))
+	require.NoError(t, err)
+
+	br := bufio.NewReader(conn)
+	line, err := br.ReadString('\n')
+	require.NoError(t, err)
+	var resp response
+	require.NoError(t, json.Unmarshal([]byte(line), &resp))
+	assert.True(t, resp.OK)
+	assert.Equal(t, int32(9999), disp.lastCall().pid)
+
+	cancel()
+	select {
+	case err := <-done:
+		require.NoError(t, err)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Run did not return after ctx cancel")
+	}
+}

--- a/agent/internal/podlookup/resolver_test.go
+++ b/agent/internal/podlookup/resolver_test.go
@@ -1,0 +1,78 @@
+package podlookup
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// parsePodUID is what stands between a UDS request and the correct
+// Pod. Wrong format detection here means SO_PEERCRED-based access
+// control routes the wrong consumer's mirrors. Each cgroup format the
+// kubelet might emit must round-trip to a canonical hyphenated UID.
+
+func TestParsePodUID(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+		ok   bool
+	}{
+		{
+			name: "systemd format with underscores",
+			in:   "0::/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-pod11111111_2222_3333_4444_555555555555.slice/cri-containerd-abcd.scope",
+			want: "11111111-2222-3333-4444-555555555555",
+			ok:   true,
+		},
+		{
+			name: "cgroupfs format with hyphens",
+			in:   "0::/kubepods/burstable/pod11111111-2222-3333-4444-555555555555/abcd",
+			want: "11111111-2222-3333-4444-555555555555",
+			ok:   true,
+		},
+		{
+			name: "cgroupfs at the end of the line",
+			in:   "0::/kubepods/burstable/pod11111111-2222-3333-4444-555555555555",
+			want: "11111111-2222-3333-4444-555555555555",
+			ok:   true,
+		},
+		{
+			name: "multi-line cgroup, first match wins",
+			in:   "10:devices:/\n0::/kubepods.slice/kubepods-pod11111111_2222_3333_4444_555555555555.slice/x.scope\n",
+			want: "11111111-2222-3333-4444-555555555555",
+			ok:   true,
+		},
+		{
+			name: "no kubepods entry",
+			in:   "0::/user.slice/user-1000.slice/session-1.scope",
+			want: "",
+			ok:   false,
+		},
+		{
+			name: "uid shape wrong (too short)",
+			in:   "0::/kubepods/burstable/pod11111111-2222-3333-4444-55555555",
+			want: "",
+			ok:   false,
+		},
+		{
+			name: "empty input",
+			in:   "",
+			want: "",
+			ok:   false,
+		},
+		{
+			name: "raw UUID-looking string outside pod-prefix is rejected",
+			in:   "0::/something/11111111-2222-3333-4444-555555555555/x",
+			want: "",
+			ok:   false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := parsePodUID(tc.in)
+			assert.Equal(t, tc.ok, ok)
+			assert.Equal(t, tc.want, got)
+		})
+	}
+}

--- a/api/go.mod
+++ b/api/go.mod
@@ -2,19 +2,26 @@ module github.com/qvest-digital/mxl-k8s/api
 
 go 1.26.0
 
-require k8s.io/apimachinery v0.36.1
+require (
+	github.com/google/go-cmp v0.7.0
+	github.com/stretchr/testify v1.11.1
+	k8s.io/apimachinery v0.36.1
+)
 
 require (
+	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.yaml.in/yaml/v2 v2.4.3 // indirect
 	golang.org/x/net v0.49.0 // indirect
 	golang.org/x/text v0.33.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/klog/v2 v2.140.0 // indirect
 	k8s.io/kube-openapi v0.0.0-20260317180543-43fb72c5454a // indirect
 	k8s.io/utils v0.0.0-20260210185600-b8788abfbbc2 // indirect

--- a/api/v1alpha1/common_test.go
+++ b/api/v1alpha1/common_test.go
@@ -1,0 +1,108 @@
+package v1alpha1
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// allProviders is the closed set of MxlFabricsProvider values accepted by
+// the CRD validation (kubebuilder:validation:Enum on the type). When
+// libmxl-fabrics gains a provider, both the enum and this slice grow
+// together; the tests below pin that invariant.
+var allProviders = []MxlFabricsProvider{
+	ProviderAuto,
+	ProviderTCP,
+	ProviderVerbs,
+	ProviderEFA,
+	ProviderSHM,
+}
+
+func TestFlowIDPattern_Matches(t *testing.T) {
+	re := regexp.MustCompile(FlowIDPattern)
+
+	cases := []struct {
+		name  string
+		input string
+		match bool
+	}{
+		{"canonical lower", "1bcad0e1-3d2d-4d3a-8f1d-9c8c2a2f4f01", true},
+		{"all zeros", "00000000-0000-0000-0000-000000000000", true},
+		{"all f", "ffffffff-ffff-ffff-ffff-ffffffffffff", true},
+		{"uppercase rejected", "1BCAD0E1-3D2D-4D3A-8F1D-9C8C2A2F4F01", false},
+		{"mixed case rejected", "1BCAD0e1-3d2d-4d3a-8f1d-9c8c2a2f4f01", false},
+		{"missing hyphens", "1bcad0e13d2d4d3a8f1d9c8c2a2f4f01", false},
+		{"wrong group sizes", "1bcad0e-13d2d-4d3a-8f1d-9c8c2a2f4f01", false},
+		{"extra group", "1bcad0e1-3d2d-4d3a-8f1d-9c8c2a2f4f01-extra", false},
+		{"trailing whitespace", "1bcad0e1-3d2d-4d3a-8f1d-9c8c2a2f4f01 ", false},
+		{"leading whitespace", " 1bcad0e1-3d2d-4d3a-8f1d-9c8c2a2f4f01", false},
+		{"non-hex chars", "1bcad0e1-3d2d-4d3a-8f1d-9c8c2a2f4f0g", false},
+		{"empty", "", false},
+		{"too short", "1bcad0e1-3d2d-4d3a-8f1d", false},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.match, re.MatchString(tc.input))
+		})
+	}
+}
+
+func TestMxlFabricsProvider_KnownValues(t *testing.T) {
+	t.Run("each provider stringifies to its const", func(t *testing.T) {
+		expected := map[MxlFabricsProvider]string{
+			ProviderAuto:  "auto",
+			ProviderTCP:   "tcp",
+			ProviderVerbs: "verbs",
+			ProviderEFA:   "efa",
+			ProviderSHM:   "shm",
+		}
+		for p, want := range expected {
+			assert.Equal(t, want, string(p), "provider %q", p)
+		}
+	})
+
+	t.Run("allProviders is unique", func(t *testing.T) {
+		seen := map[MxlFabricsProvider]struct{}{}
+		for _, p := range allProviders {
+			_, dup := seen[p]
+			require.Falsef(t, dup, "duplicate provider %q in allProviders", p)
+			seen[p] = struct{}{}
+		}
+	})
+
+	t.Run("zero value is not a valid provider", func(t *testing.T) {
+		var zero MxlFabricsProvider
+		assert.NotContains(t, allProviders, zero,
+			"empty provider string must not be a valid CRD enum value; "+
+				"the operator relies on the kubebuilder default kicking in "+
+				"when the field is omitted")
+	})
+}
+
+func TestFlowPhaseConstants(t *testing.T) {
+	// Pin the wire format of every CRD phase. A typo in a const that
+	// flips the casing or drops a letter would cascade into stale CRs
+	// that the controllers no longer match against.
+	t.Run("MxlFlowLocationPhase", func(t *testing.T) {
+		assert.Equal(t, MxlFlowLocationPhase("Origin"), MxlFlowLocationOrigin)
+		assert.Equal(t, MxlFlowLocationPhase("Mirroring"), MxlFlowLocationMirroring)
+		assert.Equal(t, MxlFlowLocationPhase("Ready"), MxlFlowLocationReady)
+		assert.Equal(t, MxlFlowLocationPhase("Stale"), MxlFlowLocationStale)
+	})
+
+	t.Run("MxlReceiverPhase", func(t *testing.T) {
+		assert.Equal(t, MxlReceiverPhase("Pending"), MxlReceiverPending)
+		assert.Equal(t, MxlReceiverPhase("Bound"), MxlReceiverBound)
+		assert.Equal(t, MxlReceiverPhase("Failed"), MxlReceiverFailed)
+	})
+
+	t.Run("MxlFlowMirrorPhase", func(t *testing.T) {
+		assert.Equal(t, MxlFlowMirrorPhase("Pending"), MxlFlowMirrorPending)
+		assert.Equal(t, MxlFlowMirrorPhase("Materializing"), MxlFlowMirrorMaterializing)
+		assert.Equal(t, MxlFlowMirrorPhase("Ready"), MxlFlowMirrorReady)
+		assert.Equal(t, MxlFlowMirrorPhase("Failed"), MxlFlowMirrorFailed)
+	})
+}

--- a/api/v1alpha1/deepcopy_test.go
+++ b/api/v1alpha1/deepcopy_test.go
@@ -1,0 +1,299 @@
+package v1alpha1
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+)
+
+// These tests guard against accidental shallow copies in the
+// controller-gen-emitted DeepCopyInto helpers. Any future hand-edit (or
+// controller-gen change) that drops the per-element copy of a slice or
+// map will let the original and the copy share backing storage; a
+// reconciler that mutates the copy will then leak into the cached
+// object. The tests provoke exactly that aliasing.
+
+func TestDeepCopy_MxlFlow_LocationsAreNotAliased(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	orig := &MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: "flow-a"},
+		Spec: MxlFlowSpec{
+			ID:         "11111111-2222-3333-4444-555555555555",
+			Definition: runtime.RawExtension{Raw: []byte(`{"id":"x"}`)},
+		},
+		Status: MxlFlowStatus{
+			Locations: []MxlFlowLocation{
+				{NodeName: "n1", Phase: MxlFlowLocationOrigin, LastObserved: &now},
+				{NodeName: "n2", Phase: MxlFlowLocationReady},
+			},
+			Conditions: []metav1.Condition{
+				{Type: "Available", Status: metav1.ConditionTrue, Reason: "Live"},
+			},
+		},
+	}
+
+	copy := orig.DeepCopy()
+	require.NotNil(t, copy)
+	require.NotSame(t, orig, copy)
+
+	// Mutate the original through every reference path that DeepCopy
+	// must have severed. Each mutation must NOT show up in the copy.
+	orig.Status.Locations[0].NodeName = "mutated"
+	orig.Status.Locations[1].Phase = MxlFlowLocationStale
+	orig.Status.Conditions[0].Reason = "Broken"
+	orig.Spec.Definition.Raw[0] = 'Z'
+
+	assert.Equal(t, "n1", copy.Status.Locations[0].NodeName)
+	assert.Equal(t, MxlFlowLocationReady, copy.Status.Locations[1].Phase)
+	assert.Equal(t, "Live", copy.Status.Conditions[0].Reason)
+	assert.Equal(t, byte('{'), copy.Spec.Definition.Raw[0])
+}
+
+func TestDeepCopy_MxlFlowMirror_StatusFieldsAreNotAliased(t *testing.T) {
+	orig := &MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Name: "m"},
+		Spec: MxlFlowMirrorSpec{
+			FlowID:     "11111111-2222-3333-4444-555555555555",
+			SourceNode: "n1",
+			TargetNode: "n2",
+			Provider:   ProviderTCP,
+			Requestor:  &PodRef{Name: "pod", Namespace: "ns"},
+		},
+		Status: MxlFlowMirrorStatus{
+			Phase:      MxlFlowMirrorReady,
+			TargetInfo: "info-a",
+			Conditions: []metav1.Condition{
+				{Type: "Materialized", Status: metav1.ConditionTrue},
+			},
+		},
+	}
+
+	copy := orig.DeepCopy()
+	require.NotNil(t, copy)
+
+	orig.Spec.Requestor.Name = "mutated"
+	orig.Status.Conditions[0].Type = "BrokenType"
+	orig.Status.Phase = MxlFlowMirrorFailed
+
+	assert.Equal(t, "pod", copy.Spec.Requestor.Name)
+	assert.Equal(t, "Materialized", copy.Status.Conditions[0].Type)
+	assert.Equal(t, MxlFlowMirrorReady, copy.Status.Phase)
+}
+
+func TestDeepCopy_MxlNodeCapabilities_ProvidersAreNotAliased(t *testing.T) {
+	orig := &MxlNodeCapabilities{
+		ObjectMeta: metav1.ObjectMeta{Name: "node-a"},
+		Spec:       MxlNodeCapabilitiesSpec{NodeName: "node-a"},
+		Status: MxlNodeCapabilitiesStatus{
+			Providers: []MxlFabricsProviderCapability{
+				{Name: ProviderTCP, Version: "1.2", DeviceCount: 1},
+				{Name: ProviderVerbs, Version: "3.4", DeviceCount: 2},
+			},
+		},
+	}
+
+	copy := orig.DeepCopy()
+	require.NotNil(t, copy)
+
+	orig.Status.Providers[0].DeviceCount = 99
+	orig.Status.Providers = append(orig.Status.Providers,
+		MxlFabricsProviderCapability{Name: ProviderEFA})
+
+	assert.Equal(t, int32(1), copy.Status.Providers[0].DeviceCount)
+	assert.Lenf(t, copy.Status.Providers, 2,
+		"appending to the original must not extend the copy")
+}
+
+func TestDeepCopy_MxlReceiver_PodSelectorAndRefAreNotAliased(t *testing.T) {
+	orig := &MxlReceiver{
+		ObjectMeta: metav1.ObjectMeta{Name: "r1", Namespace: "ns"},
+		Spec: MxlReceiverSpec{
+			FlowID:      "11111111-2222-3333-4444-555555555555",
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "x"}},
+			Provider:    ProviderAuto,
+		},
+		Status: MxlReceiverStatus{
+			Phase:       MxlReceiverBound,
+			BoundMirror: &MirrorRef{Name: "m1", Namespace: "ns"},
+		},
+	}
+
+	copy := orig.DeepCopy()
+	require.NotNil(t, copy)
+
+	orig.Spec.PodSelector.MatchLabels["app"] = "mutated"
+	orig.Status.BoundMirror.Name = "mutated"
+
+	assert.Equal(t, "x", copy.Spec.PodSelector.MatchLabels["app"])
+	assert.Equal(t, "m1", copy.Status.BoundMirror.Name)
+}
+
+func TestDeepCopy_MxlDomain_StatusIsNotAliased(t *testing.T) {
+	now := metav1.NewTime(time.Now())
+	orig := &MxlDomain{
+		Spec: MxlDomainSpec{NodeName: "n1", HostPath: "/run/mxl/domain"},
+		Status: MxlDomainStatus{
+			CapacityBytes: 1 << 30,
+			FreeBytes:     1 << 20,
+			FanotifyReady: true,
+			LastSeen:      &now,
+			Conditions: []metav1.Condition{
+				{Type: "Ready", Status: metav1.ConditionTrue},
+			},
+		},
+	}
+
+	copy := orig.DeepCopy()
+	require.NotNil(t, copy)
+
+	orig.Status.LastSeen.Time = time.Time{}
+	orig.Status.Conditions[0].Status = metav1.ConditionFalse
+
+	assert.NotEqual(t, time.Time{}, copy.Status.LastSeen.Time)
+	assert.Equal(t, metav1.ConditionTrue, copy.Status.Conditions[0].Status)
+}
+
+func TestDeepCopy_Lists_ItemsAreNotAliased(t *testing.T) {
+	// One assertion per List type. controller-gen has historically
+	// emitted shallow Items copies when manually altered; if a list's
+	// Items slice ever shares backing storage with the source, mutating
+	// the source list leaks into the cached copy held by client-go.
+	cases := []struct {
+		name string
+		mut  func() (orig runtime.Object, copy runtime.Object)
+	}{
+		{"MxlFlowList", func() (runtime.Object, runtime.Object) {
+			o := &MxlFlowList{Items: []MxlFlow{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}}
+			c := o.DeepCopy()
+			o.Items[0].ObjectMeta.Name = "mutated"
+			return o, c
+		}},
+		{"MxlReceiverList", func() (runtime.Object, runtime.Object) {
+			o := &MxlReceiverList{Items: []MxlReceiver{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}}
+			c := o.DeepCopy()
+			o.Items[0].ObjectMeta.Name = "mutated"
+			return o, c
+		}},
+		{"MxlFlowMirrorList", func() (runtime.Object, runtime.Object) {
+			o := &MxlFlowMirrorList{Items: []MxlFlowMirror{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}}
+			c := o.DeepCopy()
+			o.Items[0].ObjectMeta.Name = "mutated"
+			return o, c
+		}},
+		{"MxlDomainList", func() (runtime.Object, runtime.Object) {
+			o := &MxlDomainList{Items: []MxlDomain{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}}
+			c := o.DeepCopy()
+			o.Items[0].ObjectMeta.Name = "mutated"
+			return o, c
+		}},
+		{"MxlNodeCapabilitiesList", func() (runtime.Object, runtime.Object) {
+			o := &MxlNodeCapabilitiesList{Items: []MxlNodeCapabilities{{ObjectMeta: metav1.ObjectMeta{Name: "a"}}}}
+			c := o.DeepCopy()
+			o.Items[0].ObjectMeta.Name = "mutated"
+			return o, c
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, c := tc.mut()
+			// Pull the copy's first item name through reflection-free
+			// type assertions for each concrete type.
+			switch v := c.(type) {
+			case *MxlFlowList:
+				assert.Equal(t, "a", v.Items[0].ObjectMeta.Name)
+			case *MxlReceiverList:
+				assert.Equal(t, "a", v.Items[0].ObjectMeta.Name)
+			case *MxlFlowMirrorList:
+				assert.Equal(t, "a", v.Items[0].ObjectMeta.Name)
+			case *MxlDomainList:
+				assert.Equal(t, "a", v.Items[0].ObjectMeta.Name)
+			case *MxlNodeCapabilitiesList:
+				assert.Equal(t, "a", v.Items[0].ObjectMeta.Name)
+			default:
+				t.Fatalf("unexpected list type %T", v)
+			}
+		})
+	}
+}
+
+func TestDeepCopy_RoundTrip_Equals(t *testing.T) {
+	// For each top-level kind: building an object, deep-copying it,
+	// and comparing the two with go-cmp must produce no diff. This
+	// catches any field that DeepCopyInto silently leaves unset (a
+	// regression class controller-gen has produced in the past when a
+	// new field is added to a type but the generator is not re-run).
+	cases := []runtime.Object{
+		&MxlFlow{
+			ObjectMeta: metav1.ObjectMeta{Name: "f"},
+			Spec: MxlFlowSpec{
+				ID:         "11111111-2222-3333-4444-555555555555",
+				Definition: runtime.RawExtension{Raw: []byte(`{"a":1}`)},
+			},
+			Status: MxlFlowStatus{
+				Locations: []MxlFlowLocation{{NodeName: "n", Phase: MxlFlowLocationOrigin}},
+			},
+		},
+		&MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Name: "r", Namespace: "ns"},
+			Spec: MxlReceiverSpec{
+				FlowID:   "11111111-2222-3333-4444-555555555555",
+				PodRef:   &PodRef{Name: "p", Namespace: "ns", UID: "u"},
+				Provider: ProviderTCP,
+			},
+			Status: MxlReceiverStatus{
+				Phase:       MxlReceiverBound,
+				BoundMirror: &MirrorRef{Name: "m", Namespace: "ns"},
+			},
+		},
+		&MxlFlowMirror{
+			Spec: MxlFlowMirrorSpec{
+				FlowID:     "11111111-2222-3333-4444-555555555555",
+				SourceNode: "a",
+				TargetNode: "b",
+				Provider:   ProviderVerbs,
+			},
+			Status: MxlFlowMirrorStatus{Phase: MxlFlowMirrorReady, TargetInfo: "info"},
+		},
+		&MxlDomain{
+			Spec:   MxlDomainSpec{NodeName: "n", HostPath: "/run/mxl/domain"},
+			Status: MxlDomainStatus{CapacityBytes: 100, FreeBytes: 50, FanotifyReady: true},
+		},
+		&MxlNodeCapabilities{
+			Spec: MxlNodeCapabilitiesSpec{NodeName: "n"},
+			Status: MxlNodeCapabilitiesStatus{
+				Providers: []MxlFabricsProviderCapability{{Name: ProviderTCP, DeviceCount: 1}},
+			},
+		},
+	}
+	for _, in := range cases {
+		t.Run(typeName(in), func(t *testing.T) {
+			out := in.DeepCopyObject()
+			if diff := cmp.Diff(in, out); diff != "" {
+				t.Fatalf("DeepCopyObject diverged from source (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func typeName(o runtime.Object) string {
+	return o.GetObjectKind().GroupVersionKind().Kind + "_" + objAddrName(o)
+}
+
+func objAddrName(o runtime.Object) string {
+	type named interface {
+		GetName() string
+	}
+	if n, ok := o.(metav1.Object); ok {
+		return n.GetName()
+	}
+	if n, ok := o.(named); ok {
+		return n.GetName()
+	}
+	return "unnamed"
+}

--- a/api/v1alpha1/groupversion_info_test.go
+++ b/api/v1alpha1/groupversion_info_test.go
@@ -1,0 +1,133 @@
+package v1alpha1
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// expectedKinds enumerates every CRD kind this package serves. The map
+// pairs the kind name (the value of the kubebuilder:resource marker's
+// effective Kind, i.e. the Go struct name) with a zero-valued instance
+// the test can register and look up. A new CRD added to the package
+// without an entry here fails the test, forcing the new type to be
+// added to addKnownTypes alongside this map.
+var expectedKinds = map[string]struct {
+	item runtime.Object
+	list runtime.Object
+}{
+	"MxlDomain":           {&MxlDomain{}, &MxlDomainList{}},
+	"MxlFlow":             {&MxlFlow{}, &MxlFlowList{}},
+	"MxlFlowMirror":       {&MxlFlowMirror{}, &MxlFlowMirrorList{}},
+	"MxlReceiver":         {&MxlReceiver{}, &MxlReceiverList{}},
+	"MxlNodeCapabilities": {&MxlNodeCapabilities{}, &MxlNodeCapabilitiesList{}},
+}
+
+func TestGroupVersion(t *testing.T) {
+	assert.Equal(t, "mxl.qvest-digital.com", GroupVersion.Group)
+	assert.Equal(t, "v1alpha1", GroupVersion.Version)
+}
+
+func TestAddToScheme_RegistersEveryKind(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, AddToScheme(scheme))
+
+	for kind, pair := range expectedKinds {
+		t.Run(kind, func(t *testing.T) {
+			gvk := schema.GroupVersionKind{
+				Group:   GroupVersion.Group,
+				Version: GroupVersion.Version,
+				Kind:    kind,
+			}
+			gvkList := schema.GroupVersionKind{
+				Group:   GroupVersion.Group,
+				Version: GroupVersion.Version,
+				Kind:    kind + "List",
+			}
+
+			assert.Truef(t, scheme.Recognizes(gvk),
+				"scheme did not register the %s kind; addKnownTypes "+
+					"likely lost the entry", kind)
+			assert.Truef(t, scheme.Recognizes(gvkList),
+				"scheme did not register the %sList kind", kind)
+
+			gvks, _, err := scheme.ObjectKinds(pair.item)
+			require.NoError(t, err)
+			require.Contains(t, gvks, gvk,
+				"the registered Go type %T does not resolve back to %v",
+				pair.item, gvk)
+
+			gvks, _, err = scheme.ObjectKinds(pair.list)
+			require.NoError(t, err)
+			require.Contains(t, gvks, gvkList,
+				"the registered Go list type %T does not resolve back to %v",
+				pair.list, gvkList)
+
+			// Round-trip a zero value through scheme.New to ensure the
+			// returned object is a non-nil pointer of the same dynamic
+			// type the test registered. The cache-warming codepath in
+			// client-go calls scheme.New for every watch event; a
+			// silent regression here would surface as nil-pointer
+			// panics under load instead of at compile time.
+			fresh, err := scheme.New(gvk)
+			require.NoError(t, err)
+			require.NotNil(t, fresh)
+			assert.Equal(t,
+				reflect.TypeOf(pair.item),
+				reflect.TypeOf(fresh),
+				"scheme.New returned %T, expected %T", fresh, pair.item)
+		})
+	}
+}
+
+func TestAddToScheme_NoExtraKindsLeak(t *testing.T) {
+	// The inverse of the previous test: every kind the scheme knows
+	// about under GroupVersion must appear in expectedKinds (modulo
+	// List companions and the metav1.AddToGroupVersion machinery).
+	// Catches a stray AddKnownTypes call that registered a Go type
+	// nobody added to the manifest above.
+	scheme := runtime.NewScheme()
+	require.NoError(t, AddToScheme(scheme))
+
+	knownByGV := scheme.KnownTypes(GroupVersion)
+
+	allowed := map[string]struct{}{
+		// metav1.AddToGroupVersion adds these. They are not part of
+		// this package's CRD surface but must remain present for list
+		// and watch operations to work.
+		"WatchEvent":                {},
+		"APIGroup":                  {},
+		"APIGroupList":              {},
+		"APIResourceList":           {},
+		"APIVersions":               {},
+		"CreateOptions":             {},
+		"DeleteOptions":             {},
+		"GetOptions":                {},
+		"ListOptions":               {},
+		"PatchOptions":              {},
+		"UpdateOptions":             {},
+		"Status":                    {},
+		"Table":                     {},
+		"TableOptions":              {},
+		"PartialObjectMetadata":     {},
+		"PartialObjectMetadataList": {},
+	}
+	for k := range expectedKinds {
+		allowed[k] = struct{}{}
+		allowed[k+"List"] = struct{}{}
+	}
+
+	for kind := range knownByGV {
+		_, ok := allowed[kind]
+		assert.Truef(t, ok,
+			"kind %q is registered with the scheme but is not "+
+				"listed in expectedKinds; either add it to the test "+
+				"manifest or remove the AddKnownTypes call that "+
+				"registered it",
+			kind)
+	}
+}

--- a/gateway/internal/mirror/iface.go
+++ b/gateway/internal/mirror/iface.go
@@ -1,0 +1,45 @@
+package mirror
+
+// The two per-mirror progress loops below sit at the heart of every
+// data-plane bug the gateway has shipped. They are also the only
+// pieces of this package whose state machine can be exercised
+// without libmxl-fabrics: the cgo-dependent work happens behind a
+// handful of function calls the loops make on every iteration.
+//
+// The refactor that introduced these types narrowed the loop
+// signatures to accept those calls as injected functions. Production
+// binds them to thin closures over *mxl.Reader / *mxl.Writer /
+// *fabrics.Initiator / *fabrics.Target; the tests bind them to
+// closures that record every call and return whatever the scenario
+// needs. No interface gymnastics, no mockery boilerplate; the loops
+// stay where they were, and only their parameter list changed.
+
+// RuntimeProbe asks the source-side flow reader for the current head
+// index. Production reads it from mxl.Reader.Runtime(); tests return
+// a value the scenario controls.
+type RuntimeProbe func() (head uint64, err error)
+
+// TransferFunc transfers one grain from the source flow to the
+// target. The bool return signals "grain was skipped" - production
+// returns it true when grain.TotalSlices == 0 (continuous flows have
+// no slice subdivision and v0 does not transfer them).
+//
+// A non-nil error breaks the per-tick loop; the next tick re-reads
+// head and re-tries from lastSent+1.
+type TransferFunc func(idx uint64) (skipped bool, err error)
+
+// ProgressFunc drives libmxl-fabrics's event/completion queues.
+// Production calls Initiator.MakeProgressNonBlocking; the loop
+// tolerates fabrics.ErrNotReady silently.
+type ProgressFunc func() error
+
+// ReadGrainFunc polls the target side for an arrived grain. Returns
+// fabrics.ErrNotReady when nothing landed since the previous call so
+// the loop can sleep. Any other error is fatal: it tells the loop
+// to exit and the recovery callback to fire.
+type ReadGrainFunc func() (idx uint64, err error)
+
+// CommitFunc finishes one arrived grain on the local writer
+// (OpenGrain + Commit) so consumer FlowReaders see it. Production
+// passes a closure over the per-mirror *mxl.Writer.
+type CommitFunc func(idx uint64) error

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -225,14 +225,50 @@ func (r *SourceReconciler) openInitiator(flowID, targetInfoStr string, provider 
 	if progressInterval <= 0 {
 		progressInterval = 2 * time.Millisecond
 	}
-	go runTransferLoop(loopCtx, done, flowID, reader, initiator, progressInterval)
+	runtimeFn := func() (uint64, error) {
+		rt, err := reader.Runtime()
+		if err != nil {
+			return 0, err
+		}
+		return rt.HeadIndex, nil
+	}
+	transferFn := func(idx uint64) (bool, error) {
+		grain, err := reader.GetGrainNonBlocking(idx)
+		if err != nil {
+			// Not yet committed or already aged out; signal the loop
+			// to break and re-try on the next tick.
+			return false, err
+		}
+		if grain.TotalSlices == 0 {
+			// Continuous flows or grains with no slice subdivision
+			// report TotalSlices==0; v0 sends only fully-discrete
+			// grains and skips these.
+			return true, nil
+		}
+		return false, initiator.TransferGrain(idx, 0, grain.TotalSlices)
+	}
+	progressFn := initiator.MakeProgressNonBlocking
+	go runTransferLoop(loopCtx, done, flowID, runtimeFn, transferFn, progressFn, progressInterval)
 
 	return entry, nil
 }
 
-// runTransferLoop pumps grains that appear on reader into initiator
-// until ctx is canceled. Closes done on exit.
-func runTransferLoop(ctx context.Context, done chan struct{}, flowID string, reader *mxl.Reader, initiator *fabrics.Initiator, interval time.Duration) {
+// runTransferLoop pumps grains that appear on the source flow into
+// the initiator until ctx is canceled. Closes done on exit.
+//
+// The loop is parameterised by three injected functions so the
+// cgo-dependent calls stay isolated from the state machine: tests
+// can drive it with closures that return canned indices and record
+// every interaction.
+func runTransferLoop(
+	ctx context.Context,
+	done chan struct{},
+	flowID string,
+	probeRuntime RuntimeProbe,
+	transferGrain TransferFunc,
+	makeProgress ProgressFunc,
+	interval time.Duration,
+) {
 	defer close(done)
 
 	l := ctrl.Log.WithName("transfer").WithValues("flowID", flowID)
@@ -241,12 +277,12 @@ func runTransferLoop(ctx context.Context, done chan struct{}, flowID string, rea
 	// attached mirror tails the live flow rather than replaying
 	// historical grains the producer may already have aged out of
 	// the ring.
-	rt, err := reader.Runtime()
+	head0, err := probeRuntime()
 	if err != nil {
 		l.Error(err, "initial Runtime")
 		return
 	}
-	lastSent := int64(rt.HeadIndex)
+	lastSent := int64(head0)
 
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -258,35 +294,20 @@ func runTransferLoop(ctx context.Context, done chan struct{}, flowID string, rea
 		case <-t.C:
 		}
 
-		rt, err := reader.Runtime()
+		head, err := probeRuntime()
 		if err != nil {
 			l.Error(err, "Runtime")
 			continue
 		}
-		head := int64(rt.HeadIndex)
-		for idx := lastSent + 1; idx <= head; idx++ {
-			grain, err := reader.GetGrainNonBlocking(uint64(idx))
-			if err != nil {
-				// Not yet committed or already aged out; retry next tick.
-				break
-			}
-			slices := grain.TotalSlices
-			if slices == 0 {
-				// Continuous flows or grains with no slice subdivision
-				// report TotalSlices==0; the kernel interprets the
-				// [start, end) range as empty for them, so v0 sends
-				// only fully-discrete grains.
-				lastSent = idx
-				continue
-			}
-			if err := initiator.TransferGrain(uint64(idx), 0, slices); err != nil {
+		for idx := lastSent + 1; idx <= int64(head); idx++ {
+			if _, err := transferGrain(uint64(idx)); err != nil {
 				l.Error(err, "TransferGrain", "index", idx)
 				break
 			}
 			lastSent = idx
 		}
 
-		if err := initiator.MakeProgressNonBlocking(); err != nil && !errors.Is(err, fabrics.ErrNotReady) {
+		if err := makeProgress(); err != nil && !errors.Is(err, fabrics.ErrNotReady) {
 			l.Error(err, "MakeProgress")
 		}
 	}

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -268,7 +268,9 @@ func (r *TargetReconciler) startProgressLoop(entry *targetEntry, key types.Names
 	entry.done = done
 	target := entry.target
 	writer := entry.writer
-	go runTargetProgressLoop(loopCtx, done, target, writer, func() {
+	readFn := target.ReadGrainNonBlocking
+	commitFn := func(idx uint64) error { return commitArrivedGrain(writer, idx) }
+	go runTargetProgressLoop(loopCtx, done, readFn, commitFn, func() {
 		// Detach the recovery work from the goroutine that's
 		// exiting so the recovery's wait-for-done doesn't deadlock
 		// on its own done channel.
@@ -279,7 +281,7 @@ func (r *TargetReconciler) startProgressLoop(entry *targetEntry, key types.Names
 // runTargetProgressLoop drives the libmxl-fabrics Target until ctx
 // is canceled or ReadGrain reports a non-recoverable error. Each
 // ReadGrain call internally advances the libfabric event +
-// completion queues — without it the target never accepts incoming
+// completion queues - without it the target never accepts incoming
 // connections nor signals grain arrivals.
 //
 // We use the non-blocking ReadGrain plus a Go-side sleep on idle
@@ -292,19 +294,28 @@ func (r *TargetReconciler) startProgressLoop(entry *targetEntry, key types.Names
 // every 10-60 seconds in steady state. Polling from Go avoids
 // blocking in libfabric, which sidesteps the signal-interaction.
 //
-// For every grain ReadGrain reports as received, we also OpenGrain
-// followed by Commit on the local FlowWriter: the initiator side
-// has already RDMA'd payload + header into the ring slot, so the
-// commit only advances the flow's HeadIndex so local FlowReaders
-// (consumer pods) can see the new grain. Mirrors the pattern from
-// upstream `mxl-fabrics-demo` tools/mxl-fabrics-demo/demo.cpp.
+// For every grain ReadGrain reports as received, commitFn does the
+// OpenGrain + Commit dance on the local FlowWriter so consumer
+// FlowReaders see the arrived grain.
 //
 // On any non-ErrNotReady error from ReadGrain the underlying Target
-// is no longer safe to poll — libmxl-fabrics has been observed to
+// is no longer safe to poll - libmxl-fabrics has been observed to
 // dangle internal state after the remote endpoint drops, and the
 // next ReadGrain call segfaults inside cgo. We exit the loop and
 // call onFatal so the reconciler can rebuild the fabric side.
-func runTargetProgressLoop(ctx context.Context, done chan struct{}, target *fabrics.Target, writer *mxl.Writer, onFatal func()) {
+//
+// The loop takes readFn and commitFn as injected closures so the
+// state machine - the only piece prone to bugs and the only piece
+// worth unit-testing - is isolated from cgo. Production passes a
+// closure over fabrics.Target.ReadGrainNonBlocking and a closure
+// over commitArrivedGrain(writer, ...).
+func runTargetProgressLoop(
+	ctx context.Context,
+	done chan struct{},
+	readGrain ReadGrainFunc,
+	commit CommitFunc,
+	onFatal func(),
+) {
 	defer close(done)
 	l := ctrl.Log.WithName("target-progress")
 	const idleSleep = 1 * time.Millisecond
@@ -314,10 +325,10 @@ func runTargetProgressLoop(ctx context.Context, done chan struct{}, target *fabr
 			return
 		default:
 		}
-		idx, err := target.ReadGrainNonBlocking()
+		idx, err := readGrain()
 		switch {
 		case err == nil:
-			if err := commitArrivedGrain(writer, idx); err != nil {
+			if err := commit(idx); err != nil {
 				l.Error(err, "commit received grain", "idx", idx)
 			}
 		case errors.Is(err, fabrics.ErrNotReady):
@@ -327,7 +338,7 @@ func runTargetProgressLoop(ctx context.Context, done chan struct{}, target *fabr
 			case <-time.After(idleSleep):
 			}
 		default:
-			l.Error(err, "ReadGrain — target is no longer safe to poll, exiting loop")
+			l.Error(err, "ReadGrain - target is no longer safe to poll, exiting loop")
 			if onFatal != nil {
 				onFatal()
 			}

--- a/ipc/go.mod
+++ b/ipc/go.mod
@@ -8,6 +8,8 @@ require (
 )
 
 require (
+	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/sys v0.26.0 // indirect
 	golang.org/x/text v0.19.0 // indirect

--- a/ipc/go.sum
+++ b/ipc/go.sum
@@ -6,8 +6,12 @@ github.com/golang/protobuf v1.5.4 h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek
 github.com/golang/protobuf v1.5.4/go.mod h1:lnTiLA8Wa4RWRcIUkrtSVa5nRhsEGBg48fD6rSs7xps=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
+github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
+github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.opentelemetry.io/otel v1.31.0 h1:NsJcKPIW0D0H3NgzPDHmo0WW6SptzPdqg/L1zsIm2hY=
 go.opentelemetry.io/otel v1.31.0/go.mod h1:O0C14Yl9FgkjqcCZAsE053C13OaddMYr/hz6clDkEJE=
 go.opentelemetry.io/otel/metric v1.31.0 h1:FSErL0ATQAmYHUIzSezZibnyVlft1ybhy4ozRPcF2fE=

--- a/ipc/v1/control_test.go
+++ b/ipc/v1/control_test.go
@@ -1,0 +1,199 @@
+package ipcv1
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+)
+
+// The wire format of these messages is the only thing pinning the
+// agent and gateway together across releases. The tests below freeze
+// each enum number and each message round-trip; a future regen that
+// silently changes field numbers or enum positions will fail before it
+// can produce CRs neither component can decode.
+
+func TestProviderEnum_ZeroAndValues(t *testing.T) {
+	t.Run("zero value is unspecified", func(t *testing.T) {
+		var zero Provider
+		assert.Equal(t, Provider_PROVIDER_UNSPECIFIED, zero)
+	})
+
+	t.Run("numeric values are stable", func(t *testing.T) {
+		// Changing any of these means an in-flight gRPC message from
+		// an older peer is silently reinterpreted. Pin them.
+		assert.Equal(t, int32(0), int32(Provider_PROVIDER_UNSPECIFIED))
+		assert.Equal(t, int32(1), int32(Provider_PROVIDER_AUTO))
+		assert.Equal(t, int32(2), int32(Provider_PROVIDER_TCP))
+		assert.Equal(t, int32(3), int32(Provider_PROVIDER_VERBS))
+		assert.Equal(t, int32(4), int32(Provider_PROVIDER_EFA))
+		assert.Equal(t, int32(5), int32(Provider_PROVIDER_SHM))
+	})
+
+	t.Run("name table is exhaustive", func(t *testing.T) {
+		// Every numeric value in the const block has a name entry; a
+		// missing entry would make .String() return the number, not
+		// the symbolic form, which is what the logs and the
+		// gateway-side translator depend on.
+		want := map[int32]string{
+			0: "PROVIDER_UNSPECIFIED",
+			1: "PROVIDER_AUTO",
+			2: "PROVIDER_TCP",
+			3: "PROVIDER_VERBS",
+			4: "PROVIDER_EFA",
+			5: "PROVIDER_SHM",
+		}
+		if diff := cmp.Diff(want, Provider_name); diff != "" {
+			t.Fatalf("Provider_name diverged (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestDirectionEnum_ZeroAndValues(t *testing.T) {
+	t.Run("zero value is unspecified", func(t *testing.T) {
+		var zero Direction
+		assert.Equal(t, Direction_DIRECTION_UNSPECIFIED, zero)
+	})
+
+	t.Run("numeric values are stable", func(t *testing.T) {
+		assert.Equal(t, int32(0), int32(Direction_DIRECTION_UNSPECIFIED))
+		assert.Equal(t, int32(1), int32(Direction_DIRECTION_INGRESS))
+		assert.Equal(t, int32(2), int32(Direction_DIRECTION_EGRESS))
+	})
+
+	t.Run("name table is exhaustive", func(t *testing.T) {
+		want := map[int32]string{
+			0: "DIRECTION_UNSPECIFIED",
+			1: "DIRECTION_INGRESS",
+			2: "DIRECTION_EGRESS",
+		}
+		if diff := cmp.Diff(want, Direction_name); diff != "" {
+			t.Fatalf("Direction_name diverged (-want +got):\n%s", diff)
+		}
+	})
+}
+
+func TestMessages_RoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		msg  proto.Message
+	}{
+		{
+			"OpenMirrorRequest",
+			&OpenMirrorRequest{
+				FlowId:     "11111111-2222-3333-4444-555555555555",
+				SourceNode: "node-a",
+				Provider:   Provider_PROVIDER_TCP,
+			},
+		},
+		{
+			"OpenMirrorResponse",
+			&OpenMirrorResponse{TargetInfo: "info-string"},
+		},
+		{
+			"CloseMirrorRequest",
+			&CloseMirrorRequest{FlowId: "11111111-2222-3333-4444-555555555555"},
+		},
+		{
+			"CloseMirrorResponse",
+			&CloseMirrorResponse{},
+		},
+		{
+			"ListLocalEndpointsRequest",
+			&ListLocalEndpointsRequest{},
+		},
+		{
+			"ListLocalEndpointsResponse",
+			&ListLocalEndpointsResponse{
+				Endpoints: []*LocalEndpoint{
+					{
+						FlowId:     "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+						Provider:   Provider_PROVIDER_VERBS,
+						Direction:  Direction_DIRECTION_INGRESS,
+						TargetInfo: "info",
+					},
+					{
+						FlowId:    "11111111-2222-3333-4444-555555555555",
+						Provider:  Provider_PROVIDER_TCP,
+						Direction: Direction_DIRECTION_EGRESS,
+					},
+				},
+			},
+		},
+	}
+
+	opts := []cmp.Option{
+		cmpopts.IgnoreUnexported(
+			OpenMirrorRequest{}, OpenMirrorResponse{},
+			CloseMirrorRequest{}, CloseMirrorResponse{},
+			ListLocalEndpointsRequest{}, ListLocalEndpointsResponse{},
+			LocalEndpoint{},
+		),
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			wire, err := proto.Marshal(tc.msg)
+			require.NoError(t, err)
+
+			// A fresh empty instance of the same concrete type.
+			out := proto.Clone(tc.msg)
+			proto.Reset(out)
+			require.NoError(t, proto.Unmarshal(wire, out))
+
+			if diff := cmp.Diff(tc.msg, out, opts...); diff != "" {
+				t.Fatalf("round-trip diverged (-orig +decoded):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestLocalEndpoint_IngressEgressDifferAfterRoundTrip(t *testing.T) {
+	// LocalEndpoint.TargetInfo is documented as empty for egress
+	// endpoints. proto3 strings serialise the empty value as "no field
+	// present", which round-trips back to "". This is the property the
+	// agent relies on when discriminating ingress vs egress in the
+	// gateway response; the test pins it so a future migration to
+	// proto2 (or an `optional` keyword on the field) would surface.
+	ingress := &LocalEndpoint{
+		FlowId:     "11111111-2222-3333-4444-555555555555",
+		Direction:  Direction_DIRECTION_INGRESS,
+		TargetInfo: "info",
+	}
+	egress := &LocalEndpoint{
+		FlowId:    "11111111-2222-3333-4444-555555555555",
+		Direction: Direction_DIRECTION_EGRESS,
+	}
+
+	for _, in := range []*LocalEndpoint{ingress, egress} {
+		wire, err := proto.Marshal(in)
+		require.NoError(t, err)
+		out := &LocalEndpoint{}
+		require.NoError(t, proto.Unmarshal(wire, out))
+		assert.Equal(t, in.TargetInfo, out.TargetInfo)
+	}
+}
+
+func TestUnknownEnumValue_DoesNotPanic(t *testing.T) {
+	// proto3 must preserve unknown enum numbers across versions: an
+	// older peer that knows providers {auto..shm} must not crash when
+	// it receives a wire message produced by a newer peer that added
+	// PROVIDER_NEW = 6. The test simulates that by serialising the
+	// known message with a numeric value the const block does not
+	// declare, then deserialising back.
+	src := &OpenMirrorRequest{
+		FlowId:   "11111111-2222-3333-4444-555555555555",
+		Provider: Provider(99),
+	}
+	wire, err := proto.Marshal(src)
+	require.NoError(t, err)
+
+	out := &OpenMirrorRequest{}
+	require.NoError(t, proto.Unmarshal(wire, out))
+	assert.Equal(t, Provider(99), out.Provider,
+		"proto3 must round-trip unknown enum numbers verbatim; if "+
+			"this fails, peer-version skew turns into silent data loss")
+}

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -24,6 +24,7 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
 	github.com/google/gnostic-models v0.7.0 // indirect
+	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
@@ -37,6 +38,7 @@ require (
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
+	github.com/stretchr/testify v1.11.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.1 // indirect

--- a/operator/internal/domain/controller_test.go
+++ b/operator/internal/domain/controller_test.go
@@ -1,0 +1,72 @@
+package domain
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// The domain reconciler is an observer stub: the per-node agent
+// owns the status (capacity, free bytes, fanotify state). The
+// operator must not write to it.
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestReconcile_ExistingDomain_IsObservedWithoutMutation(t *testing.T) {
+	scheme := newScheme(t)
+	d := &mxlv1alpha1.MxlDomain{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       mxlv1alpha1.MxlDomainSpec{NodeName: "n1", HostPath: "/run/mxl/domain"},
+		Status: mxlv1alpha1.MxlDomainStatus{
+			CapacityBytes: 1 << 30,
+			FanotifyReady: true,
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlDomain{}).
+		WithObjects(d.DeepCopy()).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "n1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+
+	var after mxlv1alpha1.MxlDomain
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "n1"}, &after))
+	assert.Equal(t, d.Status, after.Status,
+		"the agent is the sole writer of MxlDomain.status; a non-empty "+
+			"diff here would race fanotify-ready transitions")
+}
+
+func TestReconcile_MissingDomain_NoError(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "missing"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+}

--- a/operator/internal/flow/controller_test.go
+++ b/operator/internal/flow/controller_test.go
@@ -1,0 +1,93 @@
+package flow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// The flow reconciler is an observer stub: the agent owns MxlFlow
+// status, the operator only logs the event. The contract that needs
+// to hold is therefore narrow: do not mutate the CR, do not requeue,
+// do not crash on missing objects. A future change that quietly turns
+// the reconciler into a writer would be caught by the no-mutation
+// assertion.
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestReconcile_ExistingFlow_IsObservedWithoutMutation(t *testing.T) {
+	scheme := newScheme(t)
+	flow := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: "11111111-2222-3333-4444-555555555555"},
+		Spec: mxlv1alpha1.MxlFlowSpec{
+			ID: "11111111-2222-3333-4444-555555555555",
+		},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{
+				{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy()).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: flow.Name},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+
+	var after mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: flow.Name}, &after))
+	assert.Equal(t, flow.Spec, after.Spec)
+	assert.Equal(t, flow.Status, after.Status,
+		"the operator must not write MxlFlow.status; the agent owns it. "+
+			"Any non-empty diff here is a contract violation that would "+
+			"race the agent's status updates")
+}
+
+func TestReconcile_MissingFlow_NoError(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "missing"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+}
+
+// Compile-time guarantee that the package still ships an obvious
+// Reconcile entry point. If the public Reconcile method ever moves
+// to a different receiver, every consumer of the package breaks at
+// build time; this declaration keeps that obvious in the test
+// binary too.
+var _ = (*Reconciler)(nil).Reconcile
+
+// silence unused-import diagnostics when the test file is the only
+// importer of a package.
+var _ = client.IgnoreNotFound

--- a/operator/internal/mirror/controller_test.go
+++ b/operator/internal/mirror/controller_test.go
@@ -1,0 +1,80 @@
+package mirror
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// The mirror reconciler is a placeholder: it observes MxlFlowMirror
+// events and logs. The gateway, not the operator, drives the data
+// plane. The contract: read-only, no requeue, no panic on missing.
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestReconcile_ExistingMirror_IsObservedWithoutMutation(t *testing.T) {
+	scheme := newScheme(t)
+	m := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "m1"},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     "11111111-2222-3333-4444-555555555555",
+			SourceNode: "n1",
+			TargetNode: "n2",
+			Provider:   mxlv1alpha1.ProviderTCP,
+		},
+		Status: mxlv1alpha1.MxlFlowMirrorStatus{
+			Phase:      mxlv1alpha1.MxlFlowMirrorReady,
+			TargetInfo: "info",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(m.DeepCopy()).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "m1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+
+	var after mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: "ns", Name: "m1"}, &after))
+	assert.Equal(t, m.Spec, after.Spec)
+	assert.Equal(t, m.Status, after.Status,
+		"the operator must not write MxlFlowMirror.status; the gateway "+
+			"owns it through the OpenMirror gRPC. A status change here "+
+			"would race the data-plane state machine")
+}
+
+func TestReconcile_MissingMirror_NoError(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: "ns", Name: "missing"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+}

--- a/operator/internal/nodecaps/controller_test.go
+++ b/operator/internal/nodecaps/controller_test.go
@@ -1,0 +1,73 @@
+package nodecaps
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// The nodecaps reconciler is an observer stub: the gateway owns the
+// status (probed libmxl-fabrics providers). The operator must not
+// write to it.
+
+func newScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestReconcile_ExistingNodeCapabilities_IsObservedWithoutMutation(t *testing.T) {
+	scheme := newScheme(t)
+	nc := &mxlv1alpha1.MxlNodeCapabilities{
+		ObjectMeta: metav1.ObjectMeta{Name: "n1"},
+		Spec:       mxlv1alpha1.MxlNodeCapabilitiesSpec{NodeName: "n1"},
+		Status: mxlv1alpha1.MxlNodeCapabilitiesStatus{
+			Providers: []mxlv1alpha1.MxlFabricsProviderCapability{
+				{Name: mxlv1alpha1.ProviderTCP, DeviceCount: 1},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlNodeCapabilities{}).
+		WithObjects(nc.DeepCopy()).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "n1"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+
+	var after mxlv1alpha1.MxlNodeCapabilities
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "n1"}, &after))
+	assert.Equal(t, nc.Status, after.Status,
+		"the gateway is the sole writer of MxlNodeCapabilities.status; "+
+			"an operator-side update would race the provider-probe loop")
+}
+
+func TestReconcile_MissingNodeCapabilities_NoError(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "missing"},
+	})
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+}

--- a/operator/internal/receiver/controller_envtest_test.go
+++ b/operator/internal/receiver/controller_envtest_test.go
@@ -1,0 +1,291 @@
+package receiver_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+	"github.com/qvest-digital/mxl-k8s/operator/internal/receiver"
+	"github.com/qvest-digital/mxl-k8s/operator/internal/testutil"
+)
+
+// flowIDFor derives a deterministic UUID-shaped string from the
+// current test's name so the cluster-scoped MxlFlow does not collide
+// across the suite's tests. SHA-256 keeps the result reproducible
+// across runs; t.Cleanup deletes the flow when the test exits.
+func flowIDFor(t *testing.T) string {
+	t.Helper()
+	h := sha256.Sum256([]byte(t.Name()))
+	return fmt.Sprintf("%08x-%04x-%04x-%04x-%012x",
+		binary.BigEndian.Uint32(h[0:4]),
+		binary.BigEndian.Uint16(h[4:6]),
+		binary.BigEndian.Uint16(h[6:8]),
+		binary.BigEndian.Uint16(h[8:10]),
+		h[10:16])
+}
+
+// newFlow creates a cluster-scoped MxlFlow with a per-test UUID,
+// optionally pins its Origin location, and registers cleanup so the
+// flow does not leak into the next test.
+func newFlow(t *testing.T, originNode string) *mxlv1alpha1.MxlFlow {
+	t.Helper()
+	id := flowIDFor(t)
+	flow := testutil.NewFlow(testutil.WithFlowID(id))
+	require.NoError(t, env.Client.Create(context.Background(), flow))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = env.Client.Delete(ctx, &mxlv1alpha1.MxlFlow{
+			ObjectMeta: metav1.ObjectMeta{Name: id},
+		})
+	})
+	if originNode != "" {
+		require.NoError(t, withFlowOriginStatus(env.Client, flow, originNode))
+	}
+	return flow
+}
+
+// All envtest scenarios share the package-level env spun up by
+// TestMain (see suite_test.go). Each Test* takes its own namespace so
+// the assertions are isolated from sibling tests.
+
+func reconcile(t *testing.T, r *receiver.Reconciler, ns, name string) ctrl.Result {
+	t.Helper()
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: name},
+	})
+	require.NoError(t, err)
+	return res
+}
+
+func mustGetReceiver(t *testing.T, c client.Client, ns, name string) *mxlv1alpha1.MxlReceiver {
+	t.Helper()
+	var out mxlv1alpha1.MxlReceiver
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: ns, Name: name}, &out))
+	return &out
+}
+
+func TestReconcile_NoMatchingPods_MarksPendingAndRequeues(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	rec := testutil.NewReceiver(ns, "r")
+	require.NoError(t, env.Client.Create(context.Background(), rec))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, 10*time.Second, res.RequeueAfter,
+		"the requeue interval is the contract every consumer expects; "+
+			"shrinking it would burn the operator's leader-election lease, "+
+			"growing it would slow first-grain visibility on a cold cluster")
+
+	got := mustGetReceiver(t, env.Client, ns, "r")
+	assert.Equal(t, mxlv1alpha1.MxlReceiverPending, got.Status.Phase)
+	assert.Nil(t, got.Status.BoundMirror)
+
+	// And no mirror was created.
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	assert.Empty(t, mirrors.Items)
+}
+
+func TestReconcile_PodsButNoFlow_MarksPendingAndRequeues(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "consumer-a", "worker-1")))
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewReceiver(ns, "r")))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, 10*time.Second, res.RequeueAfter)
+	assert.Equal(t, mxlv1alpha1.MxlReceiverPending, mustGetReceiver(t, env.Client, ns, "r").Status.Phase)
+
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	assert.Empty(t, mirrors.Items,
+		"a missing flow must not produce a half-formed mirror; the receiver "+
+			"reconciler is the only writer of MxlFlowMirror and an early "+
+			"create would deadlock the gateway lifecycle")
+}
+
+func TestReconcile_DistinctSourceAndTarget_CreatesOneMirror(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	// Source pod sits on worker-source; target pod on worker-target.
+	// The flow advertises worker-source as Origin.
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "consumer-a", "worker-target")))
+
+	flow := newFlow(t, "worker-source")
+	require.NoError(t, env.Client.Create(context.Background(),
+		testutil.NewReceiver(ns, "r", testutil.WithReceiverFlowID(flow.Spec.ID))))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, ctrl.Result{}, res, "Bound state should not requeue")
+
+	rec := mustGetReceiver(t, env.Client, ns, "r")
+	assert.Equal(t, mxlv1alpha1.MxlReceiverBound, rec.Status.Phase)
+	require.NotNil(t, rec.Status.BoundMirror, "Bound state must carry a mirror reference")
+
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	require.Len(t, mirrors.Items, 1)
+	mirror := mirrors.Items[0]
+	assert.Equal(t, "worker-source", mirror.Spec.SourceNode)
+	assert.Equal(t, "worker-target", mirror.Spec.TargetNode)
+	assert.Equal(t, flow.Spec.ID, mirror.Spec.FlowID)
+	assert.Equal(t, mxlv1alpha1.ProviderTCP, mirror.Spec.Provider,
+		"the receiver's Provider must flow through to the mirror; the "+
+			"gateway selects libfabric provider from this field")
+}
+
+func TestReconcile_SameSourceAndTarget_SkipsMirrorCreation(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	// Pod on the same node as the flow's origin: no mirror needed.
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "consumer-a", "worker-shared")))
+
+	flow := newFlow(t, "worker-shared")
+	require.NoError(t, env.Client.Create(context.Background(),
+		testutil.NewReceiver(ns, "r", testutil.WithReceiverFlowID(flow.Spec.ID))))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, ctrl.Result{}, res)
+
+	rec := mustGetReceiver(t, env.Client, ns, "r")
+	assert.Equal(t, mxlv1alpha1.MxlReceiverBound, rec.Status.Phase)
+	assert.Nil(t, rec.Status.BoundMirror,
+		"same-node skip leaves the receiver Bound but without a mirror ref; "+
+			"the consumer reads the local flow directly without going through libfabric")
+
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	assert.Empty(t, mirrors.Items)
+}
+
+func TestReconcile_MultipleTargetNodes_CreatesOneMirrorPerNode(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "a", "n-b")))
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "b", "n-c")))
+	// A duplicate consumer on n-b must not produce a second mirror.
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "c", "n-b")))
+
+	flow := newFlow(t, "n-source")
+	require.NoError(t, env.Client.Create(context.Background(),
+		testutil.NewReceiver(ns, "r", testutil.WithReceiverFlowID(flow.Spec.ID))))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, ctrl.Result{}, res)
+
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	require.Len(t, mirrors.Items, 2)
+
+	gotNodes := map[string]struct{}{}
+	for _, m := range mirrors.Items {
+		gotNodes[m.Spec.TargetNode] = struct{}{}
+	}
+	assert.Equal(t,
+		map[string]struct{}{"n-b": {}, "n-c": {}},
+		gotNodes,
+		"two distinct target nodes -> two mirrors; the duplicate pod on n-b must collapse")
+}
+
+func TestReconcile_IsIdempotent_DoesNotRecreateExistingMirror(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	require.NoError(t, env.Client.Create(context.Background(), testutil.NewPod(ns, "consumer-a", "worker-target")))
+	flow := newFlow(t, "worker-source")
+	require.NoError(t, env.Client.Create(context.Background(),
+		testutil.NewReceiver(ns, "r", testutil.WithReceiverFlowID(flow.Spec.ID))))
+
+	// First reconcile creates the mirror.
+	reconcile(t, r, ns, "r")
+	var before mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &before, client.InNamespace(ns)))
+	require.Len(t, before.Items, 1)
+	firstUID := before.Items[0].UID
+
+	// Second reconcile must reuse the same mirror (same UID), not
+	// produce a new one. The reconciler picks names deterministically;
+	// any drift would either error on AlreadyExists or replace the
+	// running mirror, both of which would interrupt the data plane.
+	reconcile(t, r, ns, "r")
+	var after mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &after, client.InNamespace(ns)))
+	require.Len(t, after.Items, 1)
+	assert.Equal(t, firstUID, after.Items[0].UID)
+}
+
+func TestReconcile_DeletionTimestamp_NoOps(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	// Create a receiver carrying a finalizer so it lingers under
+	// deletion, then issue Delete; envtest will set the deletion
+	// timestamp and keep the object around for the reconciler to see.
+	rec := testutil.NewReceiver(ns, "r")
+	rec.Finalizers = []string{"test.mxl.qvest-digital.com/keepalive"}
+	require.NoError(t, env.Client.Create(context.Background(), rec))
+	require.NoError(t, env.Client.Delete(context.Background(), rec))
+
+	res := reconcile(t, r, ns, "r")
+	assert.Equal(t, ctrl.Result{}, res,
+		"a receiver mid-deletion must not be requeued or mutated; the "+
+			"reconciler's only safe action here is to walk away")
+
+	// And no mirror should have been created.
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(context.Background(), &mirrors, client.InNamespace(ns)))
+	assert.Empty(t, mirrors.Items)
+}
+
+func TestReconcile_NotFound_ReturnsClean(t *testing.T) {
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Namespace: ns, Name: "does-not-exist"},
+	})
+	require.NoError(t, err,
+		"a Reconcile call for a deleted CR must not bubble up the 404; "+
+			"controller-runtime requeues errors aggressively and would tight-loop")
+	assert.Equal(t, ctrl.Result{}, res)
+}
+
+// withFlowOriginStatus updates the given flow's status subresource so
+// it advertises the given node as Origin. The status subresource is
+// separate from the spec; the test client must Update through .Status().
+func withFlowOriginStatus(c client.Client, flow *mxlv1alpha1.MxlFlow, node string) error {
+	var live mxlv1alpha1.MxlFlow
+	if err := c.Get(context.Background(), types.NamespacedName{Name: flow.Name}, &live); err != nil {
+		return err
+	}
+	live.Status.Locations = []mxlv1alpha1.MxlFlowLocation{
+		{NodeName: node, Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+	}
+	return c.Status().Update(context.Background(), &live)
+}
+
+// Defensive: ensure a stray apierrors import does not break under
+// future refactor; the helpers above use IsNotFound semantics through
+// the controller-runtime client.
+var _ = apierrors.IsNotFound
+var _ = corev1.Pod{}

--- a/operator/internal/receiver/controller_unit_test.go
+++ b/operator/internal/receiver/controller_unit_test.go
@@ -1,0 +1,351 @@
+package receiver
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/apimachinery/pkg/util/validation"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// scheme is the per-test scheme passed to the fake client. The
+// envtest path uses its own scheme registered in testutil; keep this
+// one minimal so the unit tests stay cheap.
+func unitScheme(t *testing.T) *runtime.Scheme {
+	t.Helper()
+	s := runtime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(s))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(s))
+	return s
+}
+
+func TestMirrorName_DeterministicAndDNSSafe(t *testing.T) {
+	cases := []struct {
+		name   string
+		flowID string
+		node   string
+		want   string
+	}{
+		{
+			name:   "lowercase canonical",
+			flowID: "11111111-2222-3333-4444-555555555555",
+			node:   "worker-1",
+			want:   "11111111-2222-3333-4444-555555555555--worker-1",
+		},
+		{
+			name:   "uppercase chars are lowered",
+			flowID: "ABCDABCD-1234-5678-9ABC-DEF012345678",
+			node:   "Worker-A",
+			want:   "abcdabcd-1234-5678-9abc-def012345678--worker-a",
+		},
+		{
+			name:   "dots in a node name are replaced with -",
+			flowID: "11111111-2222-3333-4444-555555555555",
+			node:   "ip-10.0.0.1.eu-central-1.compute",
+			want:   "11111111-2222-3333-4444-555555555555--ip-10-0-0-1-eu-central-1-compute",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mirrorName(tc.flowID, tc.node)
+			assert.Equal(t, tc.want, got)
+			// The result must satisfy the kubernetes DNS-1123 subdomain
+			// rules; if it does not, the reconciler would silently fail
+			// to Create the mirror at runtime.
+			errs := validation.IsDNS1123Subdomain(got)
+			assert.Emptyf(t, errs, "mirrorName output %q is not a valid DNS-1123 subdomain: %v", got, errs)
+		})
+	}
+
+	t.Run("is deterministic", func(t *testing.T) {
+		a := mirrorName("11111111-2222-3333-4444-555555555555", "n1")
+		b := mirrorName("11111111-2222-3333-4444-555555555555", "n1")
+		assert.Equal(t, a, b)
+	})
+
+	t.Run("differs for distinct nodes", func(t *testing.T) {
+		assert.NotEqual(t,
+			mirrorName("11111111-2222-3333-4444-555555555555", "n1"),
+			mirrorName("11111111-2222-3333-4444-555555555555", "n2"))
+	})
+}
+
+func TestResolveTargetNodes_PodRef(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("found and scheduled", func(t *testing.T) {
+		recv := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec: mxlv1alpha1.MxlReceiverSpec{
+				PodRef: &mxlv1alpha1.PodRef{Namespace: "ns", Name: "pod-a"},
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithObjects(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod-a"},
+				Spec:       corev1.PodSpec{NodeName: "worker-1"},
+			}).
+			Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, recv)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"worker-1"}, got)
+	})
+
+	t.Run("not found returns empty without error", func(t *testing.T) {
+		recv := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec: mxlv1alpha1.MxlReceiverSpec{
+				PodRef: &mxlv1alpha1.PodRef{Namespace: "ns", Name: "missing"},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(unitScheme(t)).Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, recv)
+		require.NoError(t, err)
+		assert.Empty(t, got, "missing pod must not bubble up as an error; it is a normal pending state")
+	})
+
+	t.Run("unscheduled pod is treated as empty", func(t *testing.T) {
+		recv := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec: mxlv1alpha1.MxlReceiverSpec{
+				PodRef: &mxlv1alpha1.PodRef{Namespace: "ns", Name: "pod-a"},
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithObjects(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod-a"},
+				Spec:       corev1.PodSpec{}, // NodeName is empty
+			}).
+			Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, recv)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+
+	t.Run("podRef.Namespace empty falls back to receiver namespace", func(t *testing.T) {
+		recv := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec: mxlv1alpha1.MxlReceiverSpec{
+				PodRef: &mxlv1alpha1.PodRef{Name: "pod-a"},
+			},
+		}
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithObjects(&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "pod-a"},
+				Spec:       corev1.PodSpec{NodeName: "worker-1"},
+			}).
+			Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, recv)
+		require.NoError(t, err)
+		assert.Equal(t, []string{"worker-1"}, got)
+	})
+}
+
+func TestResolveTargetNodes_PodSelector(t *testing.T) {
+	ctx := context.Background()
+
+	recv := &mxlv1alpha1.MxlReceiver{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+		Spec: mxlv1alpha1.MxlReceiverSpec{
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "consumer"}},
+		},
+	}
+
+	t.Run("returns distinct nodes only", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithObjects(
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "a", Labels: map[string]string{"app": "consumer"}},
+					Spec:       corev1.PodSpec{NodeName: "n1"},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "b", Labels: map[string]string{"app": "consumer"}},
+					Spec:       corev1.PodSpec{NodeName: "n1"},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "c", Labels: map[string]string{"app": "consumer"}},
+					Spec:       corev1.PodSpec{NodeName: "n2"},
+				},
+				&corev1.Pod{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "skipme", Labels: map[string]string{"app": "other"}},
+					Spec:       corev1.PodSpec{NodeName: "n3"},
+				},
+			).
+			Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, recv)
+		require.NoError(t, err)
+		sort.Strings(got)
+		assert.Equal(t, []string{"n1", "n2"}, got,
+			"deduplication must collapse the two pods on n1; non-matching labels must be filtered")
+	})
+
+	t.Run("invalid selector surfaces an error", func(t *testing.T) {
+		bad := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec: mxlv1alpha1.MxlReceiverSpec{
+				PodSelector: &metav1.LabelSelector{
+					MatchExpressions: []metav1.LabelSelectorRequirement{
+						{Key: "app", Operator: "NotARealOperator"},
+					},
+				},
+			},
+		}
+		c := fake.NewClientBuilder().WithScheme(unitScheme(t)).Build()
+		r := &Reconciler{Client: c}
+
+		_, err := r.resolveTargetNodes(ctx, bad)
+		require.Error(t, err)
+	})
+
+	t.Run("neither podRef nor selector returns empty without error", func(t *testing.T) {
+		// The CRD's XValidation rule forbids this state, but the
+		// reconciler must not panic if it ever sees it (a manual edit
+		// of an old CR could produce one).
+		empty := &mxlv1alpha1.MxlReceiver{
+			ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r"},
+			Spec:       mxlv1alpha1.MxlReceiverSpec{},
+		}
+		c := fake.NewClientBuilder().WithScheme(unitScheme(t)).Build()
+		r := &Reconciler{Client: c}
+
+		got, err := r.resolveTargetNodes(ctx, empty)
+		require.NoError(t, err)
+		assert.Empty(t, got)
+	})
+}
+
+func TestResolveSourceNode(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("returns the Origin location's node", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+			WithObjects(&mxlv1alpha1.MxlFlow{
+				ObjectMeta: metav1.ObjectMeta{Name: "flow-a"},
+				Spec:       mxlv1alpha1.MxlFlowSpec{ID: "flow-a"},
+				Status: mxlv1alpha1.MxlFlowStatus{
+					Locations: []mxlv1alpha1.MxlFlowLocation{
+						{NodeName: "n-mirror", Phase: mxlv1alpha1.MxlFlowLocationMirroring},
+						{NodeName: "n-origin", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+						{NodeName: "n-stale", Phase: mxlv1alpha1.MxlFlowLocationStale},
+					},
+				},
+			}).
+			Build()
+		r := &Reconciler{Client: c}
+
+		node, ok, err := r.resolveSourceNode(ctx, "flow-a")
+		require.NoError(t, err)
+		assert.True(t, ok)
+		assert.Equal(t, "n-origin", node)
+	})
+
+	t.Run("flow not found returns false without error", func(t *testing.T) {
+		c := fake.NewClientBuilder().WithScheme(unitScheme(t)).Build()
+		r := &Reconciler{Client: c}
+		_, ok, err := r.resolveSourceNode(ctx, "missing")
+		require.NoError(t, err)
+		assert.False(t, ok)
+	})
+
+	t.Run("no Origin location returns false without error", func(t *testing.T) {
+		c := fake.NewClientBuilder().
+			WithScheme(unitScheme(t)).
+			WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+			WithObjects(&mxlv1alpha1.MxlFlow{
+				ObjectMeta: metav1.ObjectMeta{Name: "flow-a"},
+				Spec:       mxlv1alpha1.MxlFlowSpec{ID: "flow-a"},
+				Status: mxlv1alpha1.MxlFlowStatus{
+					Locations: []mxlv1alpha1.MxlFlowLocation{
+						{NodeName: "n-stale", Phase: mxlv1alpha1.MxlFlowLocationStale},
+					},
+				},
+			}).
+			Build()
+		r := &Reconciler{Client: c}
+		_, ok, err := r.resolveSourceNode(ctx, "flow-a")
+		require.NoError(t, err)
+		assert.False(t, ok,
+			"a flow without an Origin location is not yet a usable source; "+
+				"the reconciler must mark its receivers Pending rather than "+
+				"misroute the mirror to a Mirroring/Stale node")
+	})
+}
+
+func TestMirrorToReceivers_FiltersByFlowID(t *testing.T) {
+	ctx := context.Background()
+	scheme := unitScheme(t)
+
+	mirror := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "m"},
+		Spec:       mxlv1alpha1.MxlFlowMirrorSpec{FlowID: "flow-a"},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(
+			&mxlv1alpha1.MxlReceiver{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r-match"},
+				Spec:       mxlv1alpha1.MxlReceiverSpec{FlowID: "flow-a"},
+			},
+			&mxlv1alpha1.MxlReceiver{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r-skip"},
+				Spec:       mxlv1alpha1.MxlReceiverSpec{FlowID: "flow-b"},
+			},
+			&mxlv1alpha1.MxlReceiver{
+				// Different namespace: must not be enqueued even if
+				// flowID matches; the mirror lives in "ns" and only
+				// receivers in "ns" can own it.
+				ObjectMeta: metav1.ObjectMeta{Namespace: "other", Name: "r-other-ns"},
+				Spec:       mxlv1alpha1.MxlReceiverSpec{FlowID: "flow-a"},
+			},
+		).
+		Build()
+	r := &Reconciler{Client: c}
+
+	out := r.mirrorToReceivers(ctx, mirror)
+	require.Len(t, out, 1)
+	assert.Equal(t, reconcile.Request{
+		NamespacedName: client.ObjectKey{Namespace: "ns", Name: "r-match"},
+	}, out[0])
+}
+
+func TestMirrorToReceivers_NonMirrorObjectReturnsNil(t *testing.T) {
+	ctx := context.Background()
+	c := fake.NewClientBuilder().WithScheme(unitScheme(t)).Build()
+	r := &Reconciler{Client: c}
+
+	out := r.mirrorToReceivers(ctx, &corev1.Pod{})
+	assert.Nil(t, out,
+		"the mapper guards against a misconfigured Watches by ignoring "+
+			"non-MxlFlowMirror events; if this regresses, every Pod event "+
+			"would enqueue every receiver in the cluster")
+}

--- a/operator/internal/receiver/suite_test.go
+++ b/operator/internal/receiver/suite_test.go
@@ -1,0 +1,32 @@
+package receiver_test
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/qvest-digital/mxl-k8s/operator/internal/testutil"
+)
+
+// env is the shared envtest harness for every Test* in this package.
+// Booting kube-apiserver + etcd costs about two seconds per process;
+// reusing one instance across the package's tests keeps the suite
+// fast while per-test namespaces preserve isolation.
+var env *testutil.Env
+
+func TestMain(m *testing.M) {
+	e, err := testutil.Start()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "envtest unavailable, skipping suite: %v\n", err)
+		// Exit 0 so a developer running `go test ./...` without
+		// provisioned assets sees a clean PASS-but-skipped rather
+		// than a CI-killing failure. The CI `test` job sets
+		// KUBEBUILDER_ASSETS so this path never triggers there.
+		os.Exit(0)
+	}
+	env = e
+
+	code := m.Run()
+	env.Stop()
+	os.Exit(code)
+}

--- a/operator/internal/testutil/envtest.go
+++ b/operator/internal/testutil/envtest.go
@@ -1,0 +1,155 @@
+// Package testutil hosts shared test helpers for the operator's
+// reconcilers: an envtest harness that boots a real kube-apiserver +
+// etcd with the project's CRDs applied, plus a small set of builder
+// helpers for the CRD types so individual tests stay readable.
+//
+// Tests that need a faithful API server (admission, defaulting, status
+// subresource separation, structured-merge-diff) take this harness.
+// Tests of pure helpers that only need a typed client should reach for
+// fake.NewClientBuilder instead.
+package testutil
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apiruntime "k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// Env wraps an envtest.Environment together with a direct API-server
+// client (no informer cache). Tests should always read state through
+// Client so assertions see what kube-apiserver actually persisted,
+// rather than what a manager-side cache decided to reflect.
+type Env struct {
+	TestEnv *envtest.Environment
+	Cfg     *rest.Config
+	Scheme  *apiruntime.Scheme
+	Client  client.Client
+
+	stop func()
+}
+
+// Start boots envtest from TestMain without depending on a real
+// *testing.T. Returns the Env plus a Stop function the caller must
+// invoke before exiting. KUBEBUILDER_ASSETS must be set (the Makefile
+// provisions it via setup-envtest); the caller can detect the missing
+// asset case and skip envtest tests rather than fail noisily.
+func Start() (*Env, error) {
+	if os.Getenv("KUBEBUILDER_ASSETS") == "" {
+		return nil, fmt.Errorf("KUBEBUILDER_ASSETS is unset; run via " +
+			"`make test` so setup-envtest provisions kube-apiserver " +
+			"+ etcd into bin/k8s")
+	}
+
+	scheme := apiruntime.NewScheme()
+	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
+	utilruntime.Must(mxlv1alpha1.AddToScheme(scheme))
+
+	te := &envtest.Environment{
+		CRDDirectoryPaths:     []string{crdDirFromSource()},
+		ErrorIfCRDPathMissing: true,
+	}
+	cfg, err := te.Start()
+	if err != nil {
+		return nil, fmt.Errorf("envtest start: %w", err)
+	}
+
+	c, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		_ = te.Stop()
+		return nil, fmt.Errorf("envtest client: %w", err)
+	}
+
+	e := &Env{
+		TestEnv: te,
+		Cfg:     cfg,
+		Scheme:  scheme,
+		Client:  c,
+	}
+	e.stop = func() { _ = te.Stop() }
+	return e, nil
+}
+
+// Stop tears down envtest. Idempotent.
+func (e *Env) Stop() {
+	if e == nil || e.stop == nil {
+		return
+	}
+	e.stop()
+	e.stop = nil
+}
+
+// crdDirFromSource returns the absolute path to the repo's config/crd
+// directory, derived from the source location of this file. Tests can
+// run from any working directory the test runner picks.
+func crdDirFromSource() string {
+	_, thisFile, _, _ := runtime.Caller(0)
+	return filepath.Join(filepath.Dir(thisFile), "..", "..", "..", "config", "crd")
+}
+
+// NewNamespace creates a namespace named after the current test and
+// deletes it on cleanup. Returning the name lets callers feed it into
+// CR builders so isolation is automatic.
+func (e *Env) NewNamespace(t testing.TB) string {
+	t.Helper()
+	name := dnsNamespace(t.Name())
+	ctx := context.Background()
+	ns := &corev1.Namespace{}
+	ns.SetName(name)
+	require.NoError(t, e.Client.Create(ctx, ns))
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		_ = e.Client.Delete(ctx, ns)
+	})
+	return name
+}
+
+// dnsNamespace coerces an arbitrary test name into a DNS-1123-safe
+// namespace label. Test names contain slashes (subtests) and
+// underscores that the API server rejects on namespace creation; the
+// agreed transformation lower-cases everything and replaces every
+// other rune with '-'.
+func dnsNamespace(in string) string {
+	out := make([]byte, 0, len(in))
+	for i := 0; i < len(in); i++ {
+		c := in[i]
+		switch {
+		case c >= 'A' && c <= 'Z':
+			out = append(out, c+('a'-'A'))
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9':
+			out = append(out, c)
+		case c == '-':
+			out = append(out, '-')
+		default:
+			out = append(out, '-')
+		}
+	}
+	if len(out) > 63 {
+		out = out[:63]
+	}
+	for len(out) > 0 && out[0] == '-' {
+		out = out[1:]
+	}
+	for len(out) > 0 && out[len(out)-1] == '-' {
+		out = out[:len(out)-1]
+	}
+	if len(out) == 0 {
+		return "test"
+	}
+	return string(out)
+}

--- a/operator/internal/testutil/factories.go
+++ b/operator/internal/testutil/factories.go
@@ -1,0 +1,165 @@
+package testutil
+
+import (
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// Functional-option builders for the CRD types used by the operator
+// tests. Defaults are deliberately benign so the failure mode of a
+// missing field is "assert this CR has the value the test expected"
+// rather than "API server rejected the create with a validation
+// error" - which would hide the actual regression behind a CRD
+// schema complaint.
+
+// FlowID is a canonical fixture UUID used in tests that need a
+// concrete flow but do not care about the value itself.
+const FlowID = "11111111-2222-3333-4444-555555555555"
+
+// FlowOption mutates a MxlFlow under construction.
+type FlowOption func(*mxlv1alpha1.MxlFlow)
+
+// NewFlow builds a cluster-scoped MxlFlow with the given options
+// layered on top of sensible defaults.
+func NewFlow(opts ...FlowOption) *mxlv1alpha1.MxlFlow {
+	f := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: FlowID},
+		Spec: mxlv1alpha1.MxlFlowSpec{
+			ID:         FlowID,
+			Definition: runtime.RawExtension{Raw: []byte(`{"id":"` + FlowID + `"}`)},
+		},
+	}
+	for _, opt := range opts {
+		opt(f)
+	}
+	return f
+}
+
+// WithFlowOrigin pins an Origin location on the flow's status.
+func WithFlowOrigin(node string) FlowOption {
+	return func(f *mxlv1alpha1.MxlFlow) {
+		f.Status.Locations = append(f.Status.Locations, mxlv1alpha1.MxlFlowLocation{
+			NodeName: node,
+			Phase:    mxlv1alpha1.MxlFlowLocationOrigin,
+		})
+	}
+}
+
+// WithFlowID overrides the default UUID. Use when a test needs more
+// than one flow at the same time.
+func WithFlowID(id string) FlowOption {
+	return func(f *mxlv1alpha1.MxlFlow) {
+		f.SetName(id)
+		f.Spec.ID = id
+		f.Spec.Definition = runtime.RawExtension{Raw: []byte(`{"id":"` + id + `"}`)}
+	}
+}
+
+// ReceiverOption mutates a MxlReceiver under construction.
+type ReceiverOption func(*mxlv1alpha1.MxlReceiver)
+
+// NewReceiver builds a namespaced MxlReceiver with a pod label
+// selector matching `app=consumer`. Override via the options.
+func NewReceiver(namespace, name string, opts ...ReceiverOption) *mxlv1alpha1.MxlReceiver {
+	r := &mxlv1alpha1.MxlReceiver{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: mxlv1alpha1.MxlReceiverSpec{
+			FlowID:      FlowID,
+			PodSelector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "consumer"}},
+			Provider:    mxlv1alpha1.ProviderTCP,
+		},
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+	return r
+}
+
+// WithReceiverFlowID overrides the receiver's flow target.
+func WithReceiverFlowID(id string) ReceiverOption {
+	return func(r *mxlv1alpha1.MxlReceiver) {
+		r.Spec.FlowID = id
+	}
+}
+
+// WithReceiverPodRef pins the receiver to a single pod.
+func WithReceiverPodRef(podName string) ReceiverOption {
+	return func(r *mxlv1alpha1.MxlReceiver) {
+		r.Spec.PodSelector = nil
+		r.Spec.PodRef = &mxlv1alpha1.PodRef{
+			Namespace: r.Namespace,
+			Name:      podName,
+		}
+	}
+}
+
+// WithReceiverSelector replaces the default selector.
+func WithReceiverSelector(matchLabels map[string]string) ReceiverOption {
+	return func(r *mxlv1alpha1.MxlReceiver) {
+		r.Spec.PodRef = nil
+		r.Spec.PodSelector = &metav1.LabelSelector{MatchLabels: matchLabels}
+	}
+}
+
+// PodOption mutates a Pod under construction.
+type PodOption func(*corev1.Pod)
+
+// NewPod builds a minimally-valid Pod pinned to the given node and
+// labelled `app=consumer`. PodSpec.Containers carries one filler
+// entry so the API server's required-fields admission accepts it.
+func NewPod(namespace, name, node string, opts ...PodOption) *corev1.Pod {
+	p := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: namespace,
+			Name:      name,
+			Labels:    map[string]string{"app": "consumer"},
+		},
+		Spec: corev1.PodSpec{
+			NodeName:   node,
+			Containers: []corev1.Container{{Name: "c", Image: "pause:3.10"}},
+		},
+	}
+	for _, opt := range opts {
+		opt(p)
+	}
+	return p
+}
+
+// WithPodLabels overrides the default label set entirely.
+func WithPodLabels(labels map[string]string) PodOption {
+	return func(p *corev1.Pod) {
+		p.SetLabels(labels)
+	}
+}
+
+// MirrorOption mutates a MxlFlowMirror under construction.
+type MirrorOption func(*mxlv1alpha1.MxlFlowMirror)
+
+// NewMirror builds a MxlFlowMirror with sensible defaults for unit
+// tests; envtest tests should usually let the reconciler under test
+// produce the mirror instead.
+func NewMirror(namespace, name string, opts ...MirrorOption) *mxlv1alpha1.MxlFlowMirror {
+	m := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     FlowID,
+			SourceNode: "src",
+			TargetNode: "dst",
+			Provider:   mxlv1alpha1.ProviderTCP,
+		},
+	}
+	for _, opt := range opts {
+		opt(m)
+	}
+	return m
+}
+
+// WithMirrorFlowID overrides the default flow.
+func WithMirrorFlowID(id string) MirrorOption {
+	return func(m *mxlv1alpha1.MxlFlowMirror) {
+		m.Spec.FlowID = id
+	}
+}


### PR DESCRIPTION
## Why

PR #11 was merged into main on its own. PRs #12, #13, #14, #15
and #16 were squash-merged into the intermediate
chore/test-tooling branch instead of main; the content has
review approval but never landed on the default branch.

## What

Cherry-picks the five squash commits from chore/test-tooling
onto main:

- test(api): cover types, deepcopy, scheme registration (#12)
- test(ipc): cover proto round-trip and enum stability (#13)
- test(operator): cover receiver reconciler and stub smoke paths (#14)
- test(agent): cover config, publishers, intent, intent socket, fanotify parser (#15)
- refactor(gateway): pass per-tick cgo work into the loops as funcs (#16)

No new code. Each commit is byte-identical to the one already
present on chore/test-tooling. The follow-up PR moves the
test(gateway) commit (#18) on top of this.