### PR TITLE
fix(ci): drop empty tag_name gate that blocks the stable release job

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,11 @@ name: release-please
 on:
   push:
     branches: [main]
+  # Manual trigger for the case where the stable cycle needs to be
+  # nudged without a fresh prerelease cut (e.g. after the gate fix
+  # below lands and the existing prerelease tags should still
+  # produce stable PRs).
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -18,7 +23,6 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       releases_created: ${{ steps.rp.outputs.releases_created }}
-      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       - id: rp
         uses: googleapis/release-please-action@v5
@@ -31,10 +35,23 @@ jobs:
   # PR can be opened. The release config's extra-files entries rewrite
   # .github/prerelease-manifest.json after a stable tag so subsequent
   # rcs for that component start from the new baseline.
+  #
+  # The gate is `releases_created == 'true'` alone. googleapis/release-
+  # please-action@v5 only populates the top-level `tag_name` output in
+  # single-package manifest mode; with multiple packages it stays empty
+  # and per-package outputs are used instead. Since the prerelease
+  # config has `prerelease: true` + `prerelease-type: rc`, every
+  # release this step produces is an rc by construction - the previous
+  # `contains(tag_name, 'rc')` check was redundant and broke the
+  # workflow for this multi-package repo.
+  #
+  # Triggering manually via workflow_dispatch runs the stable step too,
+  # which lets the stable PRs catch up to prerelease tags that already
+  # exist.
   release:
     runs-on: ubuntu-24.04
     needs: [prerelease]
-    if: needs.prerelease.outputs.releases_created == 'true' && contains(needs.prerelease.outputs.tag_name, 'rc')
+    if: github.event_name == 'workflow_dispatch' || needs.prerelease.outputs.releases_created == 'true'
     steps:
       - uses: googleapis/release-please-action@v5
         with:


### PR DESCRIPTION
## Why

The stable release job has been skipped on every prerelease merge.
The workflow run that cut `ipc/v1.0.0-rc.1` (commit `d2a6d29`)
shows the symptom: `prerelease` succeeds and creates the tag,
`release` is skipped, no stable `ipc 1.0.0` PR ever appears.

The gate read

```yaml
if: needs.prerelease.outputs.releases_created == 'true'
    && contains(needs.prerelease.outputs.tag_name, 'rc')
```

`googleapis/release-please-action@v5` only populates the top-level
`tag_name` output in single-package manifest mode. mxl-k8s's
prerelease manifest has seven packages, so `tag_name` stays empty
and `contains('', 'rc')` is `false` regardless of what got cut.
The same workflow file works in `go-mxl` because that repo's
manifest has a single `"."` package.

## What changes

- Drop the `contains(...)` clause. The prerelease config has
  `prerelease: true` and `prerelease-type: rc`, so every release
  this step can produce is an rc by construction; checking
  `releases_created == 'true'` already conveys that.
- Add `workflow_dispatch:` and let the stable job run on manual
  invocation. Without it the existing `ipc/v1.0.0-rc.1` tag
  cannot produce its stable `ipc 1.0.0` PR until *some other*
  rc gets cut on `main`.
- Drop the now-unused `tag_name` output declaration on the
  `prerelease` job.

## Verification

After merge:

1. Trigger the workflow once via
   `gh workflow run release-please.yml`.
2. The `release` job runs (no longer skipped) and proposes the
   matching stable PR for every component whose latest tag is an
   rc and whose stable manifest entry is `0.0.0`. Today that is
   `ipc`, `api`, and `shim`.