### PR TITLE
fix(ci): set initial-version 1.0.0-rc.0 per package in stable config

### DIFF
--- a/.github/release-config.json
+++ b/.github/release-config.json
@@ -9,6 +9,7 @@
   "packages": {
     "api": {
       "component": "api",
+      "initial-version": "1.0.0-rc.0",
       "extra-files": [
         {
           "type": "json",
@@ -19,6 +20,7 @@
     },
     "ipc": {
       "component": "ipc",
+      "initial-version": "1.0.0-rc.0",
       "extra-files": [
         {
           "type": "json",
@@ -29,6 +31,7 @@
     },
     "agent": {
       "component": "agent",
+      "initial-version": "1.0.0-rc.0",
       "extra-files": [
         {
           "type": "json",
@@ -39,6 +42,7 @@
     },
     "operator": {
       "component": "operator",
+      "initial-version": "1.0.0-rc.0",
       "extra-files": [
         {
           "type": "json",
@@ -49,6 +53,7 @@
     },
     "gateway": {
       "component": "gateway",
+      "initial-version": "1.0.0-rc.0",
       "extra-files": [
         {
           "type": "json",
@@ -60,6 +65,7 @@
     "shim": {
       "release-type": "simple",
       "component": "shim",
+      "initial-version": "1.0.0-rc.0",
       "extra-files": [
         {
           "type": "json",
@@ -71,6 +77,7 @@
     "charts/mxl-k8s": {
       "release-type": "helm",
       "component": "charts/mxl-k8s",
+      "initial-version": "1.0.0-rc.0",
       "extra-files": [
         {
           "type": "json",


### PR DESCRIPTION
## Why

The first dispatched run of the (now-fixed) stable cycle proposed
`1.0.0` PRs for every package, including gateway, operator, agent,
and `charts/mxl-k8s` - components that had no rc tag yet. Each
proposal overwrote the queued rc.1 commit on the shared
`release-please--branches--main--components--<component>` branch,
so the four affected packages no longer have a prerelease PR open.

release-please-action does not gate stable proposals on the
existence of a prior prerelease tag. Without a per-package
baseline it treats a missing or `0.0.0` manifest entry as a fresh
project and bumps directly from conventional-commit history.

## What changes

Set `initial-version: "1.0.0-rc.0"` on every package in
`release-config.json`. Packages that already have an rc tag
(`api`, `ipc`, `shim`) keep proposing `1.0.0` stable as expected;
packages without an rc tag have no valid stable bump from a
prerelease-shaped baseline so the stable job leaves them alone.

## After this merges

1. Close PRs #4, #5, #6, #9 with branch deletion. Their branches
   hold stable `1.0.0` commits that the new config will not
   regenerate; deleting the branches lets the prerelease cycle
   recreate the rc.1 PRs on a fresh run.
2. `gh workflow run release-please.yml`. The prerelease job
   reopens rc.1 PRs for the four reset packages; the stable job
   leaves the existing `1.0.0` PRs for api/ipc/shim (#26, #27,
   #28) in place.