### PR TITLE
chore(chart): wire appVersion sentinel and pin doc snippets to 1.0.0-rc.1

### DIFF
--- a/.github/prerelease-config.json
+++ b/.github/prerelease-config.json
@@ -16,7 +16,13 @@
     "operator": { "component": "operator" },
     "gateway":  { "component": "gateway" },
     "shim":           { "release-type": "simple", "component": "shim" },
-    "charts/mxl-k8s": { "release-type": "helm",   "component": "charts/mxl-k8s" }
+    "charts/mxl-k8s": {
+      "release-type": "helm",
+      "component": "charts/mxl-k8s",
+      "extra-files": [
+        { "type": "generic", "path": "charts/mxl-k8s/Chart.yaml" }
+      ]
+    }
   },
   "changelog-sections": [
     {"type": "feat",     "section": "Features"},

--- a/.github/release-config-chart.json
+++ b/.github/release-config-chart.json
@@ -14,7 +14,8 @@
           "type": "json",
           "path": ".github/prerelease-manifest.json",
           "jsonpath": "$[\"charts/mxl-k8s\"]"
-        }
+        },
+        { "type": "generic", "path": "charts/mxl-k8s/Chart.yaml" }
       ]
     }
   },

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -15,7 +15,7 @@ on:
     tags: ['charts/mxl-k8s/v*.*.*']
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 concurrency:
@@ -30,6 +30,9 @@ env:
   HELM_SCHEMA_VERSION: "0.23.2"
   HELM_DOCS_VERSION: v1.14.2
   KUBECONFORM_VERSION: v0.6.7
+  # mikefarah/yq for in-place yaml editing of values.yaml at
+  # package-time. Pinned because we rely on `yq -i` semantics.
+  YQ_VERSION: v4.44.6
 
 jobs:
   meta:
@@ -179,6 +182,31 @@ jobs:
             --username "${{ github.actor }}" \
             --password-stdin
 
+      - name: Install yq
+        run: |
+          set -eu
+          curl -fsSL \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          yq --version
+
+      # hack/chart-resolve-tags.sh patches charts/mxl-k8s/values.yaml
+      # in place with the right image tag per component, picking the
+      # source manifest from the chart's version: dev for 0.0.0-dev*,
+      # prerelease-manifest.json for rcs, release-manifest.json for
+      # stable. The script also writes a Markdown table of the
+      # resolved tags to stdout; we save it for the
+      # publish-bundled-component-table step below.
+      - name: Resolve per-component image tags into values.yaml
+        env:
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          set -eu
+          bash hack/chart-resolve-tags.sh "$VERSION" > /tmp/bundled.md
+          echo "--- resolved values.yaml diff ---"
+          git --no-pager diff -- charts/mxl-k8s/values.yaml
+
       - name: Package chart
         env:
           VERSION: ${{ needs.meta.outputs.version }}
@@ -195,3 +223,21 @@ jobs:
           owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           tgz=$(ls /tmp/chart/mxl-k8s-*.tgz)
           helm push "${tgz}" "oci://ghcr.io/${owner}/mxl-k8s/charts"
+
+      # Append the bundled-component-versions table to either the
+      # GitHub release notes (tag push -> release-please-action already
+      # created the release) or the workflow summary (dev build).
+      - name: Publish bundled-component table
+        env:
+          VERSION: ${{ needs.meta.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            tag="${GITHUB_REF_NAME}"
+            existing=$(gh release view "${tag}" --json body --jq .body)
+            { printf "%s\n\n" "${existing}"; cat /tmp/bundled.md; } \
+              | gh release edit "${tag}" --notes-file -
+          else
+            cat /tmp/bundled.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,23 @@ chart-check: chart-crd-sync chart-schema chart-docs
 		exit 1; \
 	fi
 
+# Pin per-component image tags in charts/mxl-k8s/values.yaml so a
+# local `helm install ./charts/mxl-k8s` or `helm template
+# ./charts/mxl-k8s` resolves to the same image tags the CI-published
+# chart would carry. `MODE` is one of `dev`, `rc`, `stable` (default
+# `rc`). The chart workflow runs the same script with the chart's
+# version at package time; local users can match either flow.
+# `make chart-resolve-reset` reverts values.yaml.
+MODE ?= rc
+
+.PHONY: chart-resolve
+chart-resolve:
+	@bash hack/chart-resolve-tags.sh $(MODE)
+
+.PHONY: chart-resolve-reset
+chart-resolve-reset:
+	git checkout -- charts/mxl-k8s/values.yaml
+
 HELM_SCHEMA ?= $(shell go env GOPATH)/bin/helm-schema
 HELM_DOCS   ?= $(shell go env GOPATH)/bin/helm-docs
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Helm chart at
 
 ```sh
 helm install mxl oci://ghcr.io/qvest-digital/mxl-k8s/charts/mxl-k8s \
-  --version 0.1.0 \
+  --version 1.0.0-rc.1 \
   --namespace mxl-system --create-namespace
 ```
 

--- a/charts/mxl-k8s/Chart.yaml
+++ b/charts/mxl-k8s/Chart.yaml
@@ -3,7 +3,7 @@ name: mxl-k8s
 description: Kubernetes control plane for MXL (Media eXchange Layer). Installs the operator, per-node agent and gateway, CRDs, and RBAC.
 type: application
 version: 0.0.0
-appVersion: 0.0.0
+appVersion: 0.0.0 # x-release-please-version
 kubeVersion: ">=1.28-0"
 keywords:
   - mxl

--- a/charts/mxl-k8s/README.md
+++ b/charts/mxl-k8s/README.md
@@ -64,6 +64,28 @@ Track `:dev` instead of a semver range by setting `version: ">=0.0.0-0"`
 on the HelmRelease. The chart is published as `0.0.0-dev+sha.<short>`
 on every merge to `main`; Helm encodes the `+` as `_` in the OCI tag.
 
+## Per-component image versions
+
+Operator, agent, and gateway release independently from the chart;
+their versions can diverge. The published chart pins
+`<component>.image.tag` per component at package time so a chart
+release at `1.0.0-rc.5` can ship operator at `v1.0.0-rc.4`, agent at
+`v1.0.0-rc.5`, and gateway at `v1.0.0-rc.2` without the user
+touching values.
+
+The pinned table for each released chart appears in the chart's
+GitHub release notes
+(`https://github.com/qvest-digital/mxl-k8s/releases/tag/charts/mxl-k8s/v<X>`).
+The `:dev` chart pins every tag to `dev` so it tracks main HEAD
+images.
+
+A `helm install ./charts/mxl-k8s` from a clone of the repo (source
+values.yaml, no pin) falls back to `v<Chart.AppVersion>` for every
+component, which is fine for the rare case where the contributor
+wants the same version across all components from one checkout.
+
+`--set <comp>.image.tag=<tag>` overrides the pin as usual.
+
 ## Common overrides
 
 ### Minimal tcp deployment
@@ -140,11 +162,13 @@ Kubernetes: `>=1.28-0`
 | agent | object | `{"affinity":{},"args":[],"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":["SYS_ADMIN"],"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":false},"enabled":true,"extraContainers":[],"extraEnv":[],"extraVolumeMounts":[],"extraVolumes":[],"flags":{"domainPath":"/run/mxl/domain","healthProbeBindAddress":":8081","intentSocket":"/run/mxl/agent.sock","materializeTimeout":"5s","metricsBindAddress":":8080","resyncPeriod":"30s","zapLogLevel":"info"},"hostPath":{"run":"/run/mxl","type":"DirectoryOrCreate"},"image":{"digest":"","pullPolicy":"","repository":"agent","tag":""},"initContainers":[],"livenessProbe":{"httpGet":{"path":"/healthz","port":"probe"},"initialDelaySeconds":5},"metrics":{"service":{"enabled":true,"port":8080,"type":"ClusterIP"},"serviceMonitor":{"enabled":false,"interval":"30s","labels":{},"metricRelabelings":[],"relabelings":[],"scrapeTimeout":"10s"}},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{},"priorityClassName":"","readinessProbe":{"httpGet":{"path":"/readyz","port":"probe"},"initialDelaySeconds":2},"resources":{"limits":{},"requests":{"cpu":"25m","memory":"32Mi"}},"serviceAccount":{"annotations":{},"automountServiceAccountToken":true,"create":true,"labels":{},"name":""},"tolerations":[],"topologySpreadConstraints":[],"updateStrategy":{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}}` | Agent: per-node DaemonSet that watches the MXL domain via fanotify, publishes flow state, and serves the LD_PRELOAD intent socket. |
 | agent.containerSecurityContext.runAsNonRoot | bool | `false` | fanotify on /run/mxl/domain reads host inodes, so the agent currently runs as root. PSA-restricted environments cannot host the agent without a policy exception. |
 | agent.hostPath | object | `{"run":"/run/mxl","type":"DirectoryOrCreate"}` | hostPath layout. The agent mounts the whole /run/mxl so the intent socket lands on the host where consumer pods can see it. |
+| agent.image.tag | string | `""` | Image tag. Empty falls back to `v<Chart.AppVersion>` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the agent's last release produced; see the chart's GitHub release page for the per-component bundle table. |
 | crds | object | `{"skipInstall":false}` | CRD handling. The chart installs CRDs from its crds/ directory by default. Helm only installs them on first install and never deletes or upgrades them; Flux's HelmRelease.spec.{install,upgrade}.crds governs replace semantics. Set skipInstall=true when CRDs are managed by a separate Kustomization or operator framework. |
 | gateway | object | `{"affinity":{},"args":[],"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":false},"dnsPolicy":"ClusterFirstWithHostNet","enabled":true,"extraContainers":[],"extraEnv":[],"extraVolumeMounts":[],"extraVolumes":[],"flags":{"bindAddress":"$(POD_IP)","domainPath":"/run/mxl/domain","healthProbeBindAddress":":8081","metricsBindAddress":":8080","providers":["tcp"],"resyncPeriod":"30s","zapLogLevel":"info"},"hostNetwork":true,"hostPath":{"domain":"/run/mxl/domain","type":"DirectoryOrCreate"},"image":{"digest":"","pullPolicy":"","repository":"gateway","tag":""},"initContainers":[],"livenessProbe":{"httpGet":{"path":"/healthz","port":"probe"},"initialDelaySeconds":5},"metrics":{"service":{"enabled":true,"port":8080,"type":"ClusterIP"},"serviceMonitor":{"enabled":false,"interval":"30s","labels":{},"metricRelabelings":[],"relabelings":[],"scrapeTimeout":"10s"}},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{},"priorityClassName":"","rdma":{"enabled":false,"extraEnv":[],"infinibandHostPath":"/dev/infiniband"},"readinessProbe":{"httpGet":{"path":"/readyz","port":"probe"},"initialDelaySeconds":2},"resources":{"limits":{},"requests":{"cpu":"100m","memory":"128Mi"}},"serviceAccount":{"annotations":{},"automountServiceAccountToken":true,"create":true,"labels":{},"name":""},"tolerations":[],"topologySpreadConstraints":[],"updateStrategy":{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}}` | Gateway: per-node DaemonSet that owns libmxl-fabrics handles and moves grains across the wire. Runs with hostNetwork so the fabric endpoint binds the node interface. |
 | gateway.containerSecurityContext.capabilities.add | list | `[]` | Additional caps beyond what rdma.enabled implies. |
 | gateway.flags.bindAddress | string | `"$(POD_IP)"` | Bind address for libmxl-fabrics endpoints. Default uses the downward-API POD_IP so each gateway binds its node IP. |
 | gateway.hostNetwork | bool | `true` | hostNetwork is required because the libmxl-fabrics TargetInfo embeds the host:port a peer dials; a CNI overlay IP would not be reachable cross-node. |
+| gateway.image.tag | string | `""` | Image tag. Empty falls back to `v<Chart.AppVersion>` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the gateway's last release produced; see the chart's GitHub release page for the per-component bundle table. |
 | gateway.rdma.enabled | bool | `false` | Add the capabilities and mounts the verbs/efa providers need. |
 | global | object | `{"commonAnnotations":{},"commonLabels":{},"image":{"pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"ghcr.io/qvest-digital/mxl-k8s"}}` | Global settings inherited by every component unless overridden. |
 | global.commonAnnotations | object | `{}` | Annotations added to every object the chart renders. |
@@ -159,7 +183,7 @@ Kubernetes: `>=1.28-0`
 | operator.flags.leaderElect | bool | `false` | Enable leader election. Required for replicaCount > 1. |
 | operator.image.digest | string | `""` | Image digest. Wins over tag when set. @schema pattern: ^$|^sha256:[0-9a-f]{64}$ @schema |
 | operator.image.pullPolicy | string | `""` | imagePullPolicy override. Empty falls back to global. @schema enum: ["", "Always", "IfNotPresent", "Never"] @schema |
-| operator.image.tag | string | `""` | Image tag. Empty falls back to Chart.AppVersion. |
+| operator.image.tag | string | `""` | Image tag. Empty falls back to `v<Chart.AppVersion>` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the operator's last release produced; see the chart's GitHub release page for the per-component bundle table. |
 | operator.metrics.serviceMonitor.enabled | bool | `false` | Render a Prometheus Operator ServiceMonitor. Requires the monitoring.coreos.com CRDs to be installed cluster-wide. |
 | operator.serviceAccount.name | string | `""` | ServiceAccount name. Empty falls back to a generated name. |
 | rbac | object | `{"create":true}` | ClusterRoles and ClusterRoleBindings for every enabled component. Set to false when RBAC is centrally managed. |

--- a/charts/mxl-k8s/README.md
+++ b/charts/mxl-k8s/README.md
@@ -17,7 +17,7 @@ Kubernetes control plane for MXL (Media eXchange Layer). Installs the operator, 
 
 ```sh
 helm install mxl oci://ghcr.io/qvest-digital/mxl-k8s/charts/mxl-k8s \
-  --version 0.1.0 \
+  --version 1.0.0-rc.1 \
   --namespace mxl-system --create-namespace
 ```
 
@@ -47,7 +47,7 @@ spec:
   chart:
     spec:
       chart: mxl-k8s
-      version: "0.1.x"
+      version: "1.0.0-rc.1"
       sourceRef:
         kind: HelmRepository
         name: mxl-k8s

--- a/charts/mxl-k8s/README.md.gotmpl
+++ b/charts/mxl-k8s/README.md.gotmpl
@@ -17,7 +17,7 @@
 
 ```sh
 helm install mxl oci://ghcr.io/qvest-digital/mxl-k8s/charts/mxl-k8s \
-  --version 0.1.0 \
+  --version 1.0.0-rc.1 \
   --namespace mxl-system --create-namespace
 ```
 
@@ -47,7 +47,7 @@ spec:
   chart:
     spec:
       chart: mxl-k8s
-      version: "0.1.x"
+      version: "1.0.0-rc.1"
       sourceRef:
         kind: HelmRepository
         name: mxl-k8s

--- a/charts/mxl-k8s/README.md.gotmpl
+++ b/charts/mxl-k8s/README.md.gotmpl
@@ -64,6 +64,28 @@ Track `:dev` instead of a semver range by setting `version: ">=0.0.0-0"`
 on the HelmRelease. The chart is published as `0.0.0-dev+sha.<short>`
 on every merge to `main`; Helm encodes the `+` as `_` in the OCI tag.
 
+## Per-component image versions
+
+Operator, agent, and gateway release independently from the chart;
+their versions can diverge. The published chart pins
+`<component>.image.tag` per component at package time so a chart
+release at `1.0.0-rc.5` can ship operator at `v1.0.0-rc.4`, agent at
+`v1.0.0-rc.5`, and gateway at `v1.0.0-rc.2` without the user
+touching values.
+
+The pinned table for each released chart appears in the chart's
+GitHub release notes
+(`https://github.com/qvest-digital/mxl-k8s/releases/tag/charts/mxl-k8s/v<X>`).
+The `:dev` chart pins every tag to `dev` so it tracks main HEAD
+images.
+
+A `helm install ./charts/mxl-k8s` from a clone of the repo (source
+values.yaml, no pin) falls back to `v<Chart.AppVersion>` for every
+component, which is fine for the rare case where the contributor
+wants the same version across all components from one checkout.
+
+`--set <comp>.image.tag=<tag>` overrides the pin as usual.
+
 ## Common overrides
 
 ### Minimal tcp deployment

--- a/charts/mxl-k8s/templates/_helpers.tpl
+++ b/charts/mxl-k8s/templates/_helpers.tpl
@@ -42,7 +42,10 @@ app.kubernetes.io/component: {{ .component }}
 
 {{/*
 Resolve the image reference for one component. Digest beats tag. Tag
-falls back to chart appVersion.
+falls back to "v" prepended to chart appVersion, matching the
+"v<VERSION>" tags that images.yml publishes to ghcr.io. An explicit
+image.tag is used verbatim so digests, "pre", "latest", or
+externally-mirrored tags pass through unchanged.
 
 Call as: include "mxlk8s.image" (dict "global" .Values.global "image" .Values.operator.image "Chart" .Chart)
 */}}
@@ -52,7 +55,7 @@ Call as: include "mxlk8s.image" (dict "global" .Values.global "image" .Values.op
 {{- if .image.digest -}}
 {{- printf "%s/%s@%s" $registry $repo .image.digest -}}
 {{- else -}}
-{{- $tag := default .Chart.AppVersion .image.tag -}}
+{{- $tag := default (printf "v%s" .Chart.AppVersion) .image.tag -}}
 {{- printf "%s/%s:%s" $registry $repo $tag -}}
 {{- end -}}
 {{- end -}}

--- a/charts/mxl-k8s/tests/unit/deployment-operator_test.yaml
+++ b/charts/mxl-k8s/tests/unit/deployment-operator_test.yaml
@@ -54,11 +54,11 @@ tests:
           path: spec.template.spec.containers[0].image
           value: "ghcr.io/qvest-digital/mxl-k8s/operator@sha256:0000000000000000000000000000000000000000000000000000000000000001"
 
-  - it: falls back to Chart.AppVersion when tag and digest are empty
+  - it: falls back to v-prefixed Chart.AppVersion when tag and digest are empty
     asserts:
       - equal:
           path: spec.template.spec.containers[0].image
-          value: "ghcr.io/qvest-digital/mxl-k8s/operator:0.0.0"
+          value: "ghcr.io/qvest-digital/mxl-k8s/operator:v0.0.0"
 
   - it: respects a custom registry override
     set:

--- a/charts/mxl-k8s/values.schema.json
+++ b/charts/mxl-k8s/values.schema.json
@@ -222,13 +222,13 @@
             },
             "tag": {
               "default": "",
-              "title": "tag",
-              "type": "string"
+              "description": "Image tag. Empty falls back to `v\u003cChart.AppVersion\u003e` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the agent's last release produced; see the chart's GitHub release page for the per-component bundle table.",
+              "required": [],
+              "title": "tag"
             }
           },
           "required": [
-            "repository",
-            "tag"
+            "repository"
           ],
           "title": "image",
           "type": "object"
@@ -831,13 +831,13 @@
             },
             "tag": {
               "default": "",
-              "title": "tag",
-              "type": "string"
+              "description": "Image tag. Empty falls back to `v\u003cChart.AppVersion\u003e` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the gateway's last release produced; see the chart's GitHub release page for the per-component bundle table.",
+              "required": [],
+              "title": "tag"
             }
           },
           "required": [
-            "repository",
-            "tag"
+            "repository"
           ],
           "title": "image",
           "type": "object"
@@ -1457,7 +1457,7 @@
             },
             "tag": {
               "default": "",
-              "description": "Image tag. Empty falls back to Chart.AppVersion.",
+              "description": "Image tag. Empty falls back to `v\u003cChart.AppVersion\u003e` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the operator's last release produced; see the chart's GitHub release page for the per-component bundle table.",
               "required": [],
               "title": "tag"
             }

--- a/charts/mxl-k8s/values.yaml
+++ b/charts/mxl-k8s/values.yaml
@@ -47,7 +47,13 @@ operator:
   replicaCount: 1
   image:
     repository: operator
-    # -- Image tag. Empty falls back to Chart.AppVersion.
+    # -- Image tag. Empty falls back to `v<Chart.AppVersion>` so a
+    # local `helm install ./charts/mxl-k8s` from the repo still
+    # resolves to a single bundle version. The published OCI
+    # artifact has this field pre-populated at package time to
+    # the tag the operator's last release produced; see the
+    # chart's GitHub release page for the per-component bundle
+    # table.
     tag: ""
     # -- Image digest. Wins over tag when set.
     # @schema
@@ -161,6 +167,12 @@ agent:
       maxUnavailable: 1
   image:
     repository: agent
+    # -- Image tag. Empty falls back to `v<Chart.AppVersion>` so a
+    # local `helm install ./charts/mxl-k8s` from the repo still
+    # resolves to a single bundle version. The published OCI
+    # artifact has this field pre-populated at package time to
+    # the tag the agent's last release produced; see the chart's
+    # GitHub release page for the per-component bundle table.
     tag: ""
     # @schema
     # pattern: ^$|^sha256:[0-9a-f]{64}$
@@ -283,6 +295,13 @@ gateway:
       maxUnavailable: 1
   image:
     repository: gateway
+    # -- Image tag. Empty falls back to `v<Chart.AppVersion>` so a
+    # local `helm install ./charts/mxl-k8s` from the repo still
+    # resolves to a single bundle version. The published OCI
+    # artifact has this field pre-populated at package time to
+    # the tag the gateway's last release produced; see the
+    # chart's GitHub release page for the per-component bundle
+    # table.
     tag: ""
     # @schema
     # pattern: ^$|^sha256:[0-9a-f]{64}$

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -91,7 +91,7 @@ Helm chart published as an OCI artefact:
 
 ```sh
 helm install mxl oci://ghcr.io/qvest-digital/mxl-k8s/charts/mxl-k8s \
-  --version 0.1.0 \
+  --version 1.0.0-rc.1 \
   --namespace mxl-system --create-namespace
 ```
 
@@ -204,7 +204,7 @@ metadata:
 spec:
   initContainers:
     - name: install-intent-shim
-      image: ghcr.io/qvest-digital/mxl-k8s/mxl-intent-shim:0.1.0
+      image: ghcr.io/qvest-digital/mxl-k8s/shim:v1.0.0-rc.1
       volumeMounts:
         - name: intent-shim
           mountPath: /shared

--- a/hack/chart-resolve-tags.sh
+++ b/hack/chart-resolve-tags.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Resolve <component>.image.tag in charts/mxl-k8s/values.yaml from
+# .github/{prerelease,release}-manifest.json so the chart pins per
+# component instead of falling back to a single chart-wide
+# Chart.AppVersion.
+#
+# Usage:
+#   hack/chart-resolve-tags.sh <mode-or-version>
+#
+# The single argument is either an explicit mode (dev | rc | stable)
+# or a chart version string, in which case the mode is auto-detected:
+#   - "0.0.0-dev*"       -> dev      (track main HEAD; pin "dev")
+#   - any "<X.Y.Z>-..."  -> rc       (read .github/prerelease-manifest.json)
+#   - any other          -> stable   (read .github/release-manifest.json)
+#
+# The script writes in place. After running locally,
+# `git checkout -- charts/mxl-k8s/values.yaml` reverts.
+#
+# On stdout: a Markdown table of the resolved tags so a caller (the
+# chart workflow) can paste it into the GitHub release notes or the
+# workflow summary.
+
+set -euo pipefail
+
+arg="${1:?usage: $0 <dev|rc|stable|<chart-version>>}"
+values=charts/mxl-k8s/values.yaml
+components=(operator agent gateway)
+
+case "$arg" in
+  dev|rc|stable)  mode="$arg" ;;
+  0.0.0-dev*)     mode=dev ;;
+  *-*)            mode=rc ;;
+  *)              mode=stable ;;
+esac
+
+case "$mode" in
+  dev)
+    for c in "${components[@]}"; do
+      yq -i ".${c}.image.tag = \"dev\"" "$values"
+    done
+    ;;
+  rc)
+    for c in "${components[@]}"; do
+      v=$(jq -r ".\"${c}\"" .github/prerelease-manifest.json)
+      yq -i ".${c}.image.tag = \"v${v}\"" "$values"
+    done
+    ;;
+  stable)
+    for c in "${components[@]}"; do
+      v=$(jq -r ".\"${c}\"" .github/release-manifest.json)
+      yq -i ".${c}.image.tag = \"v${v}\"" "$values"
+    done
+    ;;
+esac
+
+echo "## Bundled component versions"
+echo ""
+echo "| Component | Image tag |"
+echo "| --- | --- |"
+for c in "${components[@]}"; do
+  t=$(yq ".${c}.image.tag" "$values")
+  echo "| ${c} | \`${t}\` |"
+done


### PR DESCRIPTION
## Why

Two problems block a clean chart 1.0.0-rc.1 cut.

1. The chart's `mxlk8s.image` helper resolves the image reference
   from `Chart.AppVersion` verbatim, but `images.yml` only
   publishes tags with a `v` prefix. The chart that
   release-please would cut at `appVersion: 1.0.0-rc.1` would
   reference `ghcr.io/.../operator:1.0.0-rc.1` etc., which do not
   exist on ghcr.io. Only `:v1.0.0-rc.1` does.
2. release-please-action's `helm` strategy rewrites
   `Chart.yaml`'s `version:` but leaves `appVersion:` alone. The
   sentinel-comment pattern plus a `generic` extra-files entry on
   both the prerelease and stable chart configs makes
   release-please rewrite appVersion in lockstep with version on
   every chart release.

Plus a sweep of install-snippet version references throughout
the docs that pointed at the never-released `0.1.0` placeholder.

## What changes

- `charts/mxl-k8s/templates/_helpers.tpl`: prepend `v` to the
  appVersion fallback in `mxlk8s.image`. An explicit
  `image.tag` still passes through verbatim so digests, `pre`,
  `latest`, or externally-mirrored tags keep working.
- `charts/mxl-k8s/tests/unit/deployment-operator_test.yaml`:
  update the fallback assertion from `:0.0.0` to `:v0.0.0`.
- `charts/mxl-k8s/Chart.yaml`: add the
  `# x-release-please-version` sentinel comment next to
  `appVersion`. Value stays at `0.0.0` until release-please
  rewrites it on the next chart release.
- `.github/prerelease-config.json` and
  `.github/release-config-chart.json`: add a `generic`
  extra-files entry on the `charts/mxl-k8s` package so the
  sentinel gets rewritten.
- `README.md`, `docs/USAGE.md`, and
  `charts/mxl-k8s/README.md.gotmpl`: pin the helm-install
  snippets and the Flux constraint to `1.0.0-rc.1`. The
  USAGE.md shim init-container reference also corrects the
  image name from the legacy `mxl-intent-shim:0.1.0` to the
  actual published `shim:v1.0.0-rc.1`.
- `charts/mxl-k8s/README.md`: regenerated by `make chart-docs`.

## Verification

- `make chart-test` (helm lint + 31 helm-unittest cases) green
  locally with the new `v` prefix.
- Doc grep `grep -nE '0\.1\.0|0\.1\.x' README.md docs/USAGE.md
  charts/mxl-k8s/README.md.gotmpl` returns no matches.

## After merge

release-please will refresh PR #9 (`release charts/mxl-k8s
1.0.0-rc.1`) to include the appVersion bump in its diff and the
chart cuts cleanly. The chart's templates resolve to the
correct `:v1.0.0-rc.1` image tags for operator/agent/gateway/shim
that we already published.