### PR TITLE
feat(chart): pin per-component image tags at package time

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -15,7 +15,7 @@ on:
     tags: ['charts/mxl-k8s/v*.*.*']
 
 permissions:
-  contents: read
+  contents: write
   packages: write
 
 concurrency:
@@ -30,6 +30,9 @@ env:
   HELM_SCHEMA_VERSION: "0.23.2"
   HELM_DOCS_VERSION: v1.14.2
   KUBECONFORM_VERSION: v0.6.7
+  # mikefarah/yq for in-place yaml editing of values.yaml at
+  # package-time. Pinned because we rely on `yq -i` semantics.
+  YQ_VERSION: v4.44.6
 
 jobs:
   meta:
@@ -179,6 +182,80 @@ jobs:
             --username "${{ github.actor }}" \
             --password-stdin
 
+      - name: Install yq
+        run: |
+          set -eu
+          curl -fsSL \
+            "https://github.com/mikefarah/yq/releases/download/${YQ_VERSION}/yq_linux_amd64" \
+            -o /usr/local/bin/yq
+          chmod +x /usr/local/bin/yq
+          yq --version
+
+      # Source values.yaml ships every <component>.image.tag empty so a
+      # `helm install ./charts/mxl-k8s` from a clone falls back to
+      # `v<Chart.AppVersion>` via templates/_helpers.tpl. The published
+      # artifact, by contrast, must pin each component to the actual tag
+      # `images.yml` produced for that component's last release: chart
+      # versions and component versions are independent. The branch below
+      # picks the right tag depending on what kind of chart build this is.
+      - name: Resolve per-component image tags into values.yaml
+        id: resolve
+        env:
+          VERSION: ${{ needs.meta.outputs.version }}
+        run: |
+          set -eu
+          components="operator agent gateway"
+
+          case "$VERSION" in
+            0.0.0-dev*)
+              # On push to main, images.yml publishes <component>:dev. The
+              # chart's :dev artifact tracks main HEAD images and pins them
+              # all to the dev tag.
+              kind=dev
+              for c in $components; do
+                yq -i ".${c}.image.tag = \"dev\"" charts/mxl-k8s/values.yaml
+              done
+              ;;
+            *-*)
+              # Chart prerelease (rc). Each component's current rc is in
+              # the prerelease manifest. The published image tag for that
+              # rc carries the `v` prefix (see images.yml).
+              kind=rc
+              for c in $components; do
+                v=$(jq -r ".\"${c}\"" .github/prerelease-manifest.json)
+                yq -i ".${c}.image.tag = \"v${v}\"" charts/mxl-k8s/values.yaml
+              done
+              ;;
+            *)
+              # Stable chart release. Each component's stable version is
+              # in the release manifest.
+              kind=stable
+              for c in $components; do
+                v=$(jq -r ".\"${c}\"" .github/release-manifest.json)
+                yq -i ".${c}.image.tag = \"v${v}\"" charts/mxl-k8s/values.yaml
+              done
+              ;;
+          esac
+
+          # Emit a Markdown table of resolved tags so the next step can
+          # paste it into either the GitHub release notes or the
+          # workflow summary.
+          {
+            echo "## Bundled component versions"
+            echo ""
+            echo "| Component | Image tag |"
+            echo "| --- | --- |"
+            for c in $components; do
+              t=$(yq ".${c}.image.tag" charts/mxl-k8s/values.yaml)
+              echo "| ${c} | \`${t}\` |"
+            done
+          } > /tmp/bundled.md
+
+          echo "kind=${kind}" >> "$GITHUB_OUTPUT"
+
+          echo "--- resolved values.yaml diff ---"
+          git --no-pager diff -- charts/mxl-k8s/values.yaml
+
       - name: Package chart
         env:
           VERSION: ${{ needs.meta.outputs.version }}
@@ -195,3 +272,21 @@ jobs:
           owner=$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')
           tgz=$(ls /tmp/chart/mxl-k8s-*.tgz)
           helm push "${tgz}" "oci://ghcr.io/${owner}/mxl-k8s/charts"
+
+      # Append the bundled-component-versions table to either the
+      # GitHub release notes (tag push -> release-please-action already
+      # created the release) or the workflow summary (dev build).
+      - name: Publish bundled-component table
+        env:
+          VERSION: ${{ needs.meta.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -eu
+          if [ "${{ github.ref_type }}" = "tag" ]; then
+            tag="${GITHUB_REF_NAME}"
+            existing=$(gh release view "${tag}" --json body --jq .body)
+            { printf "%s\n\n" "${existing}"; cat /tmp/bundled.md; } \
+              | gh release edit "${tag}" --notes-file -
+          else
+            cat /tmp/bundled.md >> "$GITHUB_STEP_SUMMARY"
+          fi

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -191,68 +191,19 @@ jobs:
           chmod +x /usr/local/bin/yq
           yq --version
 
-      # Source values.yaml ships every <component>.image.tag empty so a
-      # `helm install ./charts/mxl-k8s` from a clone falls back to
-      # `v<Chart.AppVersion>` via templates/_helpers.tpl. The published
-      # artifact, by contrast, must pin each component to the actual tag
-      # `images.yml` produced for that component's last release: chart
-      # versions and component versions are independent. The branch below
-      # picks the right tag depending on what kind of chart build this is.
+      # hack/chart-resolve-tags.sh patches charts/mxl-k8s/values.yaml
+      # in place with the right image tag per component, picking the
+      # source manifest from the chart's version: dev for 0.0.0-dev*,
+      # prerelease-manifest.json for rcs, release-manifest.json for
+      # stable. The script also writes a Markdown table of the
+      # resolved tags to stdout; we save it for the
+      # publish-bundled-component-table step below.
       - name: Resolve per-component image tags into values.yaml
-        id: resolve
         env:
           VERSION: ${{ needs.meta.outputs.version }}
         run: |
           set -eu
-          components="operator agent gateway"
-
-          case "$VERSION" in
-            0.0.0-dev*)
-              # On push to main, images.yml publishes <component>:dev. The
-              # chart's :dev artifact tracks main HEAD images and pins them
-              # all to the dev tag.
-              kind=dev
-              for c in $components; do
-                yq -i ".${c}.image.tag = \"dev\"" charts/mxl-k8s/values.yaml
-              done
-              ;;
-            *-*)
-              # Chart prerelease (rc). Each component's current rc is in
-              # the prerelease manifest. The published image tag for that
-              # rc carries the `v` prefix (see images.yml).
-              kind=rc
-              for c in $components; do
-                v=$(jq -r ".\"${c}\"" .github/prerelease-manifest.json)
-                yq -i ".${c}.image.tag = \"v${v}\"" charts/mxl-k8s/values.yaml
-              done
-              ;;
-            *)
-              # Stable chart release. Each component's stable version is
-              # in the release manifest.
-              kind=stable
-              for c in $components; do
-                v=$(jq -r ".\"${c}\"" .github/release-manifest.json)
-                yq -i ".${c}.image.tag = \"v${v}\"" charts/mxl-k8s/values.yaml
-              done
-              ;;
-          esac
-
-          # Emit a Markdown table of resolved tags so the next step can
-          # paste it into either the GitHub release notes or the
-          # workflow summary.
-          {
-            echo "## Bundled component versions"
-            echo ""
-            echo "| Component | Image tag |"
-            echo "| --- | --- |"
-            for c in $components; do
-              t=$(yq ".${c}.image.tag" charts/mxl-k8s/values.yaml)
-              echo "| ${c} | \`${t}\` |"
-            done
-          } > /tmp/bundled.md
-
-          echo "kind=${kind}" >> "$GITHUB_OUTPUT"
-
+          bash hack/chart-resolve-tags.sh "$VERSION" > /tmp/bundled.md
           echo "--- resolved values.yaml diff ---"
           git --no-pager diff -- charts/mxl-k8s/values.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -101,6 +101,23 @@ chart-check: chart-crd-sync chart-schema chart-docs
 		exit 1; \
 	fi
 
+# Pin per-component image tags in charts/mxl-k8s/values.yaml so a
+# local `helm install ./charts/mxl-k8s` or `helm template
+# ./charts/mxl-k8s` resolves to the same image tags the CI-published
+# chart would carry. `MODE` is one of `dev`, `rc`, `stable` (default
+# `rc`). The chart workflow runs the same script with the chart's
+# version at package time; local users can match either flow.
+# `make chart-resolve-reset` reverts values.yaml.
+MODE ?= rc
+
+.PHONY: chart-resolve
+chart-resolve:
+	@bash hack/chart-resolve-tags.sh $(MODE)
+
+.PHONY: chart-resolve-reset
+chart-resolve-reset:
+	git checkout -- charts/mxl-k8s/values.yaml
+
 HELM_SCHEMA ?= $(shell go env GOPATH)/bin/helm-schema
 HELM_DOCS   ?= $(shell go env GOPATH)/bin/helm-docs
 

--- a/charts/mxl-k8s/README.md
+++ b/charts/mxl-k8s/README.md
@@ -64,6 +64,28 @@ Track `:dev` instead of a semver range by setting `version: ">=0.0.0-0"`
 on the HelmRelease. The chart is published as `0.0.0-dev+sha.<short>`
 on every merge to `main`; Helm encodes the `+` as `_` in the OCI tag.
 
+## Per-component image versions
+
+Operator, agent, and gateway release independently from the chart;
+their versions can diverge. The published chart pins
+`<component>.image.tag` per component at package time so a chart
+release at `1.0.0-rc.5` can ship operator at `v1.0.0-rc.4`, agent at
+`v1.0.0-rc.5`, and gateway at `v1.0.0-rc.2` without the user
+touching values.
+
+The pinned table for each released chart appears in the chart's
+GitHub release notes
+(`https://github.com/qvest-digital/mxl-k8s/releases/tag/charts/mxl-k8s/v<X>`).
+The `:dev` chart pins every tag to `dev` so it tracks main HEAD
+images.
+
+A `helm install ./charts/mxl-k8s` from a clone of the repo (source
+values.yaml, no pin) falls back to `v<Chart.AppVersion>` for every
+component, which is fine for the rare case where the contributor
+wants the same version across all components from one checkout.
+
+`--set <comp>.image.tag=<tag>` overrides the pin as usual.
+
 ## Common overrides
 
 ### Minimal tcp deployment
@@ -140,11 +162,13 @@ Kubernetes: `>=1.28-0`
 | agent | object | `{"affinity":{},"args":[],"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":["SYS_ADMIN"],"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":false},"enabled":true,"extraContainers":[],"extraEnv":[],"extraVolumeMounts":[],"extraVolumes":[],"flags":{"domainPath":"/run/mxl/domain","healthProbeBindAddress":":8081","intentSocket":"/run/mxl/agent.sock","materializeTimeout":"5s","metricsBindAddress":":8080","resyncPeriod":"30s","zapLogLevel":"info"},"hostPath":{"run":"/run/mxl","type":"DirectoryOrCreate"},"image":{"digest":"","pullPolicy":"","repository":"agent","tag":""},"initContainers":[],"livenessProbe":{"httpGet":{"path":"/healthz","port":"probe"},"initialDelaySeconds":5},"metrics":{"service":{"enabled":true,"port":8080,"type":"ClusterIP"},"serviceMonitor":{"enabled":false,"interval":"30s","labels":{},"metricRelabelings":[],"relabelings":[],"scrapeTimeout":"10s"}},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{},"priorityClassName":"","readinessProbe":{"httpGet":{"path":"/readyz","port":"probe"},"initialDelaySeconds":2},"resources":{"limits":{},"requests":{"cpu":"25m","memory":"32Mi"}},"serviceAccount":{"annotations":{},"automountServiceAccountToken":true,"create":true,"labels":{},"name":""},"tolerations":[],"topologySpreadConstraints":[],"updateStrategy":{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}}` | Agent: per-node DaemonSet that watches the MXL domain via fanotify, publishes flow state, and serves the LD_PRELOAD intent socket. |
 | agent.containerSecurityContext.runAsNonRoot | bool | `false` | fanotify on /run/mxl/domain reads host inodes, so the agent currently runs as root. PSA-restricted environments cannot host the agent without a policy exception. |
 | agent.hostPath | object | `{"run":"/run/mxl","type":"DirectoryOrCreate"}` | hostPath layout. The agent mounts the whole /run/mxl so the intent socket lands on the host where consumer pods can see it. |
+| agent.image.tag | string | `""` | Image tag. Empty falls back to `v<Chart.AppVersion>` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the agent's last release produced; see the chart's GitHub release page for the per-component bundle table. |
 | crds | object | `{"skipInstall":false}` | CRD handling. The chart installs CRDs from its crds/ directory by default. Helm only installs them on first install and never deletes or upgrades them; Flux's HelmRelease.spec.{install,upgrade}.crds governs replace semantics. Set skipInstall=true when CRDs are managed by a separate Kustomization or operator framework. |
 | gateway | object | `{"affinity":{},"args":[],"containerSecurityContext":{"allowPrivilegeEscalation":false,"capabilities":{"add":[],"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":false},"dnsPolicy":"ClusterFirstWithHostNet","enabled":true,"extraContainers":[],"extraEnv":[],"extraVolumeMounts":[],"extraVolumes":[],"flags":{"bindAddress":"$(POD_IP)","domainPath":"/run/mxl/domain","healthProbeBindAddress":":8081","metricsBindAddress":":8080","providers":["tcp"],"resyncPeriod":"30s","zapLogLevel":"info"},"hostNetwork":true,"hostPath":{"domain":"/run/mxl/domain","type":"DirectoryOrCreate"},"image":{"digest":"","pullPolicy":"","repository":"gateway","tag":""},"initContainers":[],"livenessProbe":{"httpGet":{"path":"/healthz","port":"probe"},"initialDelaySeconds":5},"metrics":{"service":{"enabled":true,"port":8080,"type":"ClusterIP"},"serviceMonitor":{"enabled":false,"interval":"30s","labels":{},"metricRelabelings":[],"relabelings":[],"scrapeTimeout":"10s"}},"nodeSelector":{},"podAnnotations":{},"podLabels":{},"podSecurityContext":{},"priorityClassName":"","rdma":{"enabled":false,"extraEnv":[],"infinibandHostPath":"/dev/infiniband"},"readinessProbe":{"httpGet":{"path":"/readyz","port":"probe"},"initialDelaySeconds":2},"resources":{"limits":{},"requests":{"cpu":"100m","memory":"128Mi"}},"serviceAccount":{"annotations":{},"automountServiceAccountToken":true,"create":true,"labels":{},"name":""},"tolerations":[],"topologySpreadConstraints":[],"updateStrategy":{"rollingUpdate":{"maxUnavailable":1},"type":"RollingUpdate"}}` | Gateway: per-node DaemonSet that owns libmxl-fabrics handles and moves grains across the wire. Runs with hostNetwork so the fabric endpoint binds the node interface. |
 | gateway.containerSecurityContext.capabilities.add | list | `[]` | Additional caps beyond what rdma.enabled implies. |
 | gateway.flags.bindAddress | string | `"$(POD_IP)"` | Bind address for libmxl-fabrics endpoints. Default uses the downward-API POD_IP so each gateway binds its node IP. |
 | gateway.hostNetwork | bool | `true` | hostNetwork is required because the libmxl-fabrics TargetInfo embeds the host:port a peer dials; a CNI overlay IP would not be reachable cross-node. |
+| gateway.image.tag | string | `""` | Image tag. Empty falls back to `v<Chart.AppVersion>` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the gateway's last release produced; see the chart's GitHub release page for the per-component bundle table. |
 | gateway.rdma.enabled | bool | `false` | Add the capabilities and mounts the verbs/efa providers need. |
 | global | object | `{"commonAnnotations":{},"commonLabels":{},"image":{"pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"ghcr.io/qvest-digital/mxl-k8s"}}` | Global settings inherited by every component unless overridden. |
 | global.commonAnnotations | object | `{}` | Annotations added to every object the chart renders. |
@@ -159,7 +183,7 @@ Kubernetes: `>=1.28-0`
 | operator.flags.leaderElect | bool | `false` | Enable leader election. Required for replicaCount > 1. |
 | operator.image.digest | string | `""` | Image digest. Wins over tag when set. @schema pattern: ^$|^sha256:[0-9a-f]{64}$ @schema |
 | operator.image.pullPolicy | string | `""` | imagePullPolicy override. Empty falls back to global. @schema enum: ["", "Always", "IfNotPresent", "Never"] @schema |
-| operator.image.tag | string | `""` | Image tag. Empty falls back to Chart.AppVersion. |
+| operator.image.tag | string | `""` | Image tag. Empty falls back to `v<Chart.AppVersion>` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the operator's last release produced; see the chart's GitHub release page for the per-component bundle table. |
 | operator.metrics.serviceMonitor.enabled | bool | `false` | Render a Prometheus Operator ServiceMonitor. Requires the monitoring.coreos.com CRDs to be installed cluster-wide. |
 | operator.serviceAccount.name | string | `""` | ServiceAccount name. Empty falls back to a generated name. |
 | rbac | object | `{"create":true}` | ClusterRoles and ClusterRoleBindings for every enabled component. Set to false when RBAC is centrally managed. |

--- a/charts/mxl-k8s/README.md.gotmpl
+++ b/charts/mxl-k8s/README.md.gotmpl
@@ -64,6 +64,28 @@ Track `:dev` instead of a semver range by setting `version: ">=0.0.0-0"`
 on the HelmRelease. The chart is published as `0.0.0-dev+sha.<short>`
 on every merge to `main`; Helm encodes the `+` as `_` in the OCI tag.
 
+## Per-component image versions
+
+Operator, agent, and gateway release independently from the chart;
+their versions can diverge. The published chart pins
+`<component>.image.tag` per component at package time so a chart
+release at `1.0.0-rc.5` can ship operator at `v1.0.0-rc.4`, agent at
+`v1.0.0-rc.5`, and gateway at `v1.0.0-rc.2` without the user
+touching values.
+
+The pinned table for each released chart appears in the chart's
+GitHub release notes
+(`https://github.com/qvest-digital/mxl-k8s/releases/tag/charts/mxl-k8s/v<X>`).
+The `:dev` chart pins every tag to `dev` so it tracks main HEAD
+images.
+
+A `helm install ./charts/mxl-k8s` from a clone of the repo (source
+values.yaml, no pin) falls back to `v<Chart.AppVersion>` for every
+component, which is fine for the rare case where the contributor
+wants the same version across all components from one checkout.
+
+`--set <comp>.image.tag=<tag>` overrides the pin as usual.
+
 ## Common overrides
 
 ### Minimal tcp deployment

--- a/charts/mxl-k8s/values.schema.json
+++ b/charts/mxl-k8s/values.schema.json
@@ -222,13 +222,13 @@
             },
             "tag": {
               "default": "",
-              "title": "tag",
-              "type": "string"
+              "description": "Image tag. Empty falls back to `v\u003cChart.AppVersion\u003e` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the agent's last release produced; see the chart's GitHub release page for the per-component bundle table.",
+              "required": [],
+              "title": "tag"
             }
           },
           "required": [
-            "repository",
-            "tag"
+            "repository"
           ],
           "title": "image",
           "type": "object"
@@ -831,13 +831,13 @@
             },
             "tag": {
               "default": "",
-              "title": "tag",
-              "type": "string"
+              "description": "Image tag. Empty falls back to `v\u003cChart.AppVersion\u003e` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the gateway's last release produced; see the chart's GitHub release page for the per-component bundle table.",
+              "required": [],
+              "title": "tag"
             }
           },
           "required": [
-            "repository",
-            "tag"
+            "repository"
           ],
           "title": "image",
           "type": "object"
@@ -1457,7 +1457,7 @@
             },
             "tag": {
               "default": "",
-              "description": "Image tag. Empty falls back to Chart.AppVersion.",
+              "description": "Image tag. Empty falls back to `v\u003cChart.AppVersion\u003e` so a local `helm install ./charts/mxl-k8s` from the repo still resolves to a single bundle version. The published OCI artifact has this field pre-populated at package time to the tag the operator's last release produced; see the chart's GitHub release page for the per-component bundle table.",
               "required": [],
               "title": "tag"
             }

--- a/charts/mxl-k8s/values.yaml
+++ b/charts/mxl-k8s/values.yaml
@@ -47,7 +47,13 @@ operator:
   replicaCount: 1
   image:
     repository: operator
-    # -- Image tag. Empty falls back to Chart.AppVersion.
+    # -- Image tag. Empty falls back to `v<Chart.AppVersion>` so a
+    # local `helm install ./charts/mxl-k8s` from the repo still
+    # resolves to a single bundle version. The published OCI
+    # artifact has this field pre-populated at package time to
+    # the tag the operator's last release produced; see the
+    # chart's GitHub release page for the per-component bundle
+    # table.
     tag: ""
     # -- Image digest. Wins over tag when set.
     # @schema
@@ -161,6 +167,12 @@ agent:
       maxUnavailable: 1
   image:
     repository: agent
+    # -- Image tag. Empty falls back to `v<Chart.AppVersion>` so a
+    # local `helm install ./charts/mxl-k8s` from the repo still
+    # resolves to a single bundle version. The published OCI
+    # artifact has this field pre-populated at package time to
+    # the tag the agent's last release produced; see the chart's
+    # GitHub release page for the per-component bundle table.
     tag: ""
     # @schema
     # pattern: ^$|^sha256:[0-9a-f]{64}$
@@ -283,6 +295,13 @@ gateway:
       maxUnavailable: 1
   image:
     repository: gateway
+    # -- Image tag. Empty falls back to `v<Chart.AppVersion>` so a
+    # local `helm install ./charts/mxl-k8s` from the repo still
+    # resolves to a single bundle version. The published OCI
+    # artifact has this field pre-populated at package time to
+    # the tag the gateway's last release produced; see the
+    # chart's GitHub release page for the per-component bundle
+    # table.
     tag: ""
     # @schema
     # pattern: ^$|^sha256:[0-9a-f]{64}$

--- a/hack/chart-resolve-tags.sh
+++ b/hack/chart-resolve-tags.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Resolve <component>.image.tag in charts/mxl-k8s/values.yaml from
+# .github/{prerelease,release}-manifest.json so the chart pins per
+# component instead of falling back to a single chart-wide
+# Chart.AppVersion.
+#
+# Usage:
+#   hack/chart-resolve-tags.sh <mode-or-version>
+#
+# The single argument is either an explicit mode (dev | rc | stable)
+# or a chart version string, in which case the mode is auto-detected:
+#   - "0.0.0-dev*"       -> dev      (track main HEAD; pin "dev")
+#   - any "<X.Y.Z>-..."  -> rc       (read .github/prerelease-manifest.json)
+#   - any other          -> stable   (read .github/release-manifest.json)
+#
+# The script writes in place. After running locally,
+# `git checkout -- charts/mxl-k8s/values.yaml` reverts.
+#
+# On stdout: a Markdown table of the resolved tags so a caller (the
+# chart workflow) can paste it into the GitHub release notes or the
+# workflow summary.
+
+set -euo pipefail
+
+arg="${1:?usage: $0 <dev|rc|stable|<chart-version>>}"
+values=charts/mxl-k8s/values.yaml
+components=(operator agent gateway)
+
+case "$arg" in
+  dev|rc|stable)  mode="$arg" ;;
+  0.0.0-dev*)     mode=dev ;;
+  *-*)            mode=rc ;;
+  *)              mode=stable ;;
+esac
+
+case "$mode" in
+  dev)
+    for c in "${components[@]}"; do
+      yq -i ".${c}.image.tag = \"dev\"" "$values"
+    done
+    ;;
+  rc)
+    for c in "${components[@]}"; do
+      v=$(jq -r ".\"${c}\"" .github/prerelease-manifest.json)
+      yq -i ".${c}.image.tag = \"v${v}\"" "$values"
+    done
+    ;;
+  stable)
+    for c in "${components[@]}"; do
+      v=$(jq -r ".\"${c}\"" .github/release-manifest.json)
+      yq -i ".${c}.image.tag = \"v${v}\"" "$values"
+    done
+    ;;
+esac
+
+echo "## Bundled component versions"
+echo ""
+echo "| Component | Image tag |"
+echo "| --- | --- |"
+for c in "${components[@]}"; do
+  t=$(yq ".${c}.image.tag" "$values")
+  echo "| ${c} | \`${t}\` |"
+done


### PR DESCRIPTION
## Why

operator, agent, and gateway release independently from the chart;
their versions can diverge. The current setup falls back every
empty `image.tag` to `Chart.AppVersion` so the chart and the
components would have to ship in lockstep, otherwise the fallback
resolves to image references that ghcr.io does not carry.

## What changes

`.github/workflows/chart.yml`'s `package-push` job gains two
steps before `helm package`:

1. Install `yq` (mikefarah/yq, pinned).
2. Branch on `meta.outputs.version` and rewrite each
   `<component>.image.tag` in `charts/mxl-k8s/values.yaml`
   in-place:
   - `0.0.0-dev*` -> pin to `"dev"` for operator/agent/gateway,
     matching the `:dev` images that `images.yml` publishes on
     every push to `main`.
   - `<semver>-*` (rc) -> read each component's current rc from
     `.github/prerelease-manifest.json`, pin to `"v<version>"`.
   - `<semver>` (stable) -> same from
     `.github/release-manifest.json`.

The same step emits a Markdown table of resolved tags. After the
chart is pushed:

- **Tag push**: fetch the release release-please-action just
  created, append `## Bundled component versions` to its body.
  The release page is self-contained for downstream consumers.
- **Dev build (push to main)**: append the table to the workflow
  `$GITHUB_STEP_SUMMARY` (no release page exists).

`charts/mxl-k8s/values.yaml`'s `image.tag` comments are extended
on all three components to document both behaviours; the chart
README (`charts/mxl-k8s/README.md.gotmpl` + regenerated `.md`)
gets a new `## Per-component image versions` section.

The repo-side `values.yaml` stays at `tag: ""` so a contributor
running `helm install ./charts/mxl-k8s` from a clone still gets
the `v<Chart.AppVersion>` fallback - useful when testing the
chart from source.

## Stacked on PR #36

The chart's `Chart.yaml` appVersion sentinel and the doc pins
land in PR #36; this PR depends on the chart README the same
flow generates. Once #36 merges, this PR's base auto-retargets
to main.

## Verification

After this lands (and a chart release):

1. `helm pull oci://ghcr.io/qvest-digital/mxl-k8s/charts/mxl-k8s --version 1.0.0-rc.X`
   then `tar xzf` and `yq '.operator.image.tag,.agent.image.tag,.gateway.image.tag' mxl-k8s/values.yaml`
   shows the pinned `v<version>` tags from the prerelease
   manifest at that point in time.
2. The GitHub release page for `charts/mxl-k8s/v1.0.0-rc.X` shows
   the `## Bundled component versions` table appended.
3. A push to `main` builds the dev chart; the workflow's Summary
   tab shows the same table for the `:dev`-pinned chart.
4. `helm template mxl ./charts/mxl-k8s` from a clone still
   renders `v<Chart.AppVersion>` everywhere (source values.yaml
   unchanged).
5. `helm install --set operator.image.tag=v1.0.0-rc.0 ...` still
   overrides the workflow-set pin (helm `--set` precedes default
   values).