### PR TITLE
fix(chart): drop broken appVersion tracking, listen on release event

### DIFF
--- a/.github/prerelease-config.json
+++ b/.github/prerelease-config.json
@@ -16,13 +16,7 @@
     "operator": { "component": "operator" },
     "gateway":  { "component": "gateway" },
     "shim":           { "release-type": "simple", "component": "shim" },
-    "charts/mxl-k8s": {
-      "release-type": "helm",
-      "component": "charts/mxl-k8s",
-      "extra-files": [
-        { "type": "generic", "path": "charts/mxl-k8s/Chart.yaml" }
-      ]
-    }
+    "charts/mxl-k8s": { "release-type": "helm", "component": "charts/mxl-k8s" }
   },
   "changelog-sections": [
     {"type": "feat",     "section": "Features"},

--- a/.github/release-config-chart.json
+++ b/.github/release-config-chart.json
@@ -8,15 +8,7 @@
   "prerelease": false,
   "packages": {
     "charts/mxl-k8s": {
-      "component": "charts/mxl-k8s",
-      "extra-files": [
-        {
-          "type": "json",
-          "path": ".github/prerelease-manifest.json",
-          "jsonpath": "$[\"charts/mxl-k8s\"]"
-        },
-        { "type": "generic", "path": "charts/mxl-k8s/Chart.yaml" }
-      ]
+      "component": "charts/mxl-k8s"
     }
   },
   "changelog-sections": [

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -12,7 +12,15 @@ on:
       - 'charts/mxl-k8s/**'
       - 'config/crd/**'
       - '.github/workflows/chart.yml'
-    tags: ['charts/mxl-k8s/v*.*.*']
+  # release-please-action creates a GitHub release alongside the
+  # tag at chart-cut time. Using release:published here (instead
+  # of push:tags) sidesteps the GitHub Actions quirk that
+  # silently swallows tag-push events when push: also carries a
+  # paths filter (the path filter can't compute a meaningful
+  # diff for the first matching tag and the event is dropped).
+  # The meta job filters down to chart releases.
+  release:
+    types: [published]
 
 permissions:
   contents: write
@@ -40,6 +48,9 @@ jobs:
     outputs:
       publish: ${{ steps.m.outputs.publish }}
       version: ${{ steps.m.outputs.version }}
+      release_tag: ${{ steps.m.outputs.release_tag }}
+    env:
+      RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
       - id: m
         run: |
@@ -47,25 +58,38 @@ jobs:
           short_sha="${GITHUB_SHA:0:7}"
           publish=false
           version=""
+          release_tag=""
 
           case "$GITHUB_EVENT_NAME" in
             push)
-              if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-                # refs/tags/charts/mxl-k8s/vX.Y.Z[-rc.N]
-                version="${GITHUB_REF_NAME##*/v}"
-                publish=true
-              elif [ "$GITHUB_REF" = "refs/heads/main" ]; then
+              # Only branch=main pushes reach this case; tag pushes are
+              # handled via the release:published event below to avoid
+              # the paths-filter quirk that drops tag-push events.
+              if [ "$GITHUB_REF" = "refs/heads/main" ]; then
                 # SemVer-valid prerelease build for the floating dev channel.
                 # OCI translates "+" to "_" at push time.
                 version="0.0.0-dev+sha.${short_sha}"
                 publish=true
               fi
               ;;
+            release)
+              # release-please-action published a release. Filter to
+              # chart tags only; other components publish their own
+              # release events that this workflow must ignore.
+              case "$RELEASE_TAG" in
+                charts/mxl-k8s/v*.*.*)
+                  version="${RELEASE_TAG##*/v}"
+                  release_tag="$RELEASE_TAG"
+                  publish=true
+                  ;;
+              esac
+              ;;
           esac
 
           {
             echo "publish=${publish}"
             echo "version=${version}"
+            echo "release_tag=${release_tag}"
           } >> "$GITHUB_OUTPUT"
 
   lint:

--- a/charts/mxl-k8s/Chart.yaml
+++ b/charts/mxl-k8s/Chart.yaml
@@ -4,7 +4,7 @@ description: Kubernetes control plane for MXL (Media eXchange Layer). Installs
   the operator, per-node agent and gateway, CRDs, and RBAC.
 type: application
 version: 1.0.0-rc.1
-appVersion: 0.0.0 # x-release-please-version
+appVersion: 0.0.0
 kubeVersion: ">=1.28-0"
 keywords:
   - mxl

--- a/charts/mxl-k8s/README.md
+++ b/charts/mxl-k8s/README.md
@@ -2,7 +2,7 @@
 
 Kubernetes control plane for MXL (Media eXchange Layer). Installs the operator, per-node agent and gateway, CRDs, and RBAC.
 
-![Version: 0.0.0](https://img.shields.io/badge/Version-0.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
+![Version: 1.0.0-rc.1](https://img.shields.io/badge/Version-1.0.0--rc.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.0.0](https://img.shields.io/badge/AppVersion-0.0.0-informational?style=flat-square)
 
 ## Prerequisites
 


### PR DESCRIPTION
## Two latent bugs that surfaced when PR #9 cut chart 1.0.0-rc.1

1. release-please-action prepends the package path to every
   `extra-files.path` entry on single-package configs. The
   chart's generic `Chart.yaml` updater resolved to
   `charts/mxl-k8s/charts/mxl-k8s/Chart.yaml` (nonexistent) and
   silently no-op'd, leaving `appVersion` at `0.0.0` even though
   the sentinel comment was in place. The release-please log
   confirms:
   ```
   ⚠ file charts/mxl-k8s/charts/mxl-k8s/Chart.yaml did not exist
   ```

2. The chart workflow's `on.push.tags` clause sat alongside a
   `paths:` filter. GitHub Actions evaluates the path filter
   against tag-push events too, and for the first matching tag
   of a series the filter can't compute a meaningful diff to
   apply against, so the workflow is silently skipped. The
   `charts/mxl-k8s/v1.0.0-rc.1` tag push therefore never
   triggered the chart workflow, and **no OCI artifact was
   published** for rc.1.

## Approach

Rather than fix (1) by correcting the extra-files path, **drop
appVersion tracking from release-please entirely**. There is no
single `appVersion` to track for a chart that bundles three
independently-versioned components - the published chart pins
operator/agent/gateway image tags per component via the
workflow's `chart-resolve-tags` step, so the appVersion fallback
in `mxlk8s.image` is not exercised for rendered manifests.
`Chart.yaml.appVersion` stays at `0.0.0` as a stable placeholder.

For (2), move tag handling from `push.tags` to
`release: types: [published]`. release-please-action creates a
GitHub release alongside every tag it cuts, so this catches
every chart cut and sidesteps the paths-filter quirk. The meta
job filters down to `charts/mxl-k8s` release tags so other
components' release events do not trigger a chart cut.

## What changes

- `.github/prerelease-config.json`: drop the chart's
  `extra-files` entry.
- `.github/release-config-chart.json`: drop both extra-files
  entries (the cross-package jsonpath entry was also broken).
- `charts/mxl-k8s/Chart.yaml`: drop the
  `# x-release-please-version` sentinel comment.
- `.github/workflows/chart.yml`: move tag handling to
  `release: types: [published]` and teach the meta job to filter
  by the release's tag prefix.
- `charts/mxl-k8s/README.md`: regenerated via `helm-docs` so the
  Version badge matches `Chart.yaml.version=1.0.0-rc.1`.

## Recovery after merge

The current `charts/mxl-k8s/v1.0.0-rc.1` tag points at the
broken commit (`0388c43`) and the OCI artifact was never
published. After this merges:

\`\`\`sh
gh release view charts/mxl-k8s/v1.0.0-rc.1 --json body --jq .body \
  > /tmp/rc1-body.md
gh release delete charts/mxl-k8s/v1.0.0-rc.1 --yes --cleanup-tag
gh release create charts/mxl-k8s/v1.0.0-rc.1 <merge-sha> \
  --notes-file /tmp/rc1-body.md
\`\`\`

The `release create` fires `release: published`, the chart
workflow runs against the tag, and the OCI artifact lands at
`oci://ghcr.io/qvest-digital/mxl-k8s/charts/mxl-k8s:1.0.0-rc.1`.