### PR TITLE
fix: make kind-up script compatible with bash 3

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -176,6 +176,20 @@ the work that produced it. The same rules apply to PR descriptions.
   build tag `mxl_integration`. The CI lint/vet/build jobs don't run
   them.
 
+## Shell scripts
+
+- All bash scripts under `hack/` (and anything else invoked from the
+  Makefile) must run on bash 3.2. macOS still ships
+  `/bin/bash` 3.2.57, and `make` recipes resolve bare `bash` via
+  `PATH`, which on a default macOS install hits `/bin/bash` first.
+- No `declare -A` / associative arrays, no `${var,,}` / `${var^^}`
+  case conversion, no `mapfile` / `readarray`, no `[[ ... =~ ]]` with
+  capture groups via `BASH_REMATCH` assumptions that differ in 3.2,
+  no `${!prefix*}` indirect expansion tricks beyond what 3.2 supports.
+  Use parallel indexed arrays in place of associative arrays.
+- Verify a script parses under the system bash before committing:
+  `/bin/bash -n hack/<script>.sh`.
+
 ## Test
 
 - Assertions use `github.com/stretchr/testify/require` (plus `assert`

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -22,12 +22,19 @@ KUBECTL=(kubectl --context "kind-${CLUSTER_NAME}")
 MIRROR_TIMEOUT_SECS="${MIRROR_TIMEOUT_SECS:-180}"
 ROLLOUT_TIMEOUT_SECS="${ROLLOUT_TIMEOUT_SECS:-180}"
 
-declare -A IMAGES=(
-  [docker/operator.Dockerfile]=local/mxl-operator:dev
-  [docker/agent.Dockerfile]=local/mxl-domain-agent:dev
-  [docker/gateway.Dockerfile]=local/mxl-fabrics-gateway:dev
-  [docker/shim.Dockerfile]=local/mxl-shim:dev
-  [docker/demo-tools.Dockerfile]=local/mxl-demo-tools:dev
+IMAGE_DOCKERFILES=(
+  docker/operator.Dockerfile
+  docker/agent.Dockerfile
+  docker/gateway.Dockerfile
+  docker/shim.Dockerfile
+  docker/demo-tools.Dockerfile
+)
+IMAGE_TAGS=(
+  local/mxl-operator:dev
+  local/mxl-domain-agent:dev
+  local/mxl-fabrics-gateway:dev
+  local/mxl-shim:dev
+  local/mxl-demo-tools:dev
 )
 
 log()  { printf '\n=== %s ===\n' "$*" >&2; }
@@ -39,8 +46,9 @@ need kubectl
 
 log "Building images"
 cd "$REPO_ROOT"
-for dockerfile in "${!IMAGES[@]}"; do
-  tag="${IMAGES[$dockerfile]}"
+for i in "${!IMAGE_DOCKERFILES[@]}"; do
+  dockerfile="${IMAGE_DOCKERFILES[$i]}"
+  tag="${IMAGE_TAGS[$i]}"
   echo "  -> ${tag}"
   docker build -q -f "${dockerfile}" -t "${tag}" . > /dev/null
 done
@@ -53,7 +61,7 @@ else
 fi
 
 log "Loading images into the cluster"
-for tag in "${IMAGES[@]}"; do
+for tag in "${IMAGE_TAGS[@]}"; do
   echo "  -> ${tag}"
   kind load docker-image --name "$CLUSTER_NAME" "$tag"
 done


### PR DESCRIPTION
macOS still ships with Bash 3 due to licensing issues. To prevent Mac users from running into issues, make the shell scripts Bash 3 compatible