### PR TITLE
chore: contributor-review pass on docs, comments, and typography

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,10 @@ Four pieces, all running inside the cluster:
   `MxlFlowMirror` per (flow, target-node). Multiple consumers on
   the same node share a single mirror.
 - An **LD_PRELOAD shim** in consumer pods turns the first
-  `openat` on a not-yet-materialised flow into a synchronous
-  wait on the local agent. Consumer code calls
-  `mxlCreateFlowReader` the same way it does on a single node.
+  libmxl probe (`access`, `stat`, `open`, ...) for a not-yet-
+  materialised flow into a synchronous wait on the local agent.
+  Consumer code calls `mxlCreateFlowReader` the same way it does
+  on a single node.
 
 The CRDs (`MxlFlow`, `MxlReceiver`, `MxlFlowMirror`,
 `MxlDomain`, `MxlNodeCapabilities`) describe flows, who wants
@@ -67,12 +68,10 @@ identity provider, and upstream `dmf-mxl` respectively.
 
 `libmxl` and `libmxl-fabrics` are linked from
 [`dmf-mxl/mxl`](https://github.com/dmf-mxl/mxl) through the
-[`go-mxl`](https://github.com/qvest-digital/go-mxl) bindings. The
-first release will track upstream `dmf-mxl/mxl` directly once a
-small set of changes lands there. FlowReader / FlowWriter
-semantics, grain layout, and the shape of `flow_def.json` remain
-upstream's design; mxl-k8s is the cluster orchestration around
-them.
+[`go-mxl`](https://github.com/qvest-digital/go-mxl) bindings.
+FlowReader / FlowWriter semantics, grain layout, and the shape
+of `flow_def.json` remain upstream's design; mxl-k8s is the
+cluster orchestration around them.
 
 See [`ROADMAP.md`](ROADMAP.md) for the feature roadmap.
 

--- a/agent/cmd/mxl-domain-agent/main.go
+++ b/agent/cmd/mxl-domain-agent/main.go
@@ -87,7 +87,7 @@ func run(args []string) error {
 		NodeName:   cfg.NodeName,
 	}
 	if err := flowPub.InitialSync(ctx); err != nil {
-		// Initial sync failures are logged, not fatal — the fanotify
+		// Initial sync failures are logged, not fatal -- the fanotify
 		// stream will reconcile when entries change.
 		setupLog.Error(err, "initial flow sync failed")
 	}

--- a/agent/internal/domainpublisher/publisher.go
+++ b/agent/internal/domainpublisher/publisher.go
@@ -29,7 +29,7 @@ type Publisher struct {
 }
 
 // Name is the metadata.name used for this agent's MxlDomain. One
-// MxlDomain per (node, domain path) — we use the node name for v0
+// MxlDomain per (node, domain path) -- we use the node name for v0
 // (assumes one domain per node).
 func (p *Publisher) Name() string {
 	return p.NodeName

--- a/agent/internal/fanotify/doc.go
+++ b/agent/internal/fanotify/doc.go
@@ -3,6 +3,6 @@
 // modification events (CREATE / MOVED_TO / DELETE / MOVED_FROM) on
 // a single inode-marked directory.
 //
-// Requires kernel ≥ 5.17 and CAP_SYS_ADMIN. Building on non-Linux
+// Requires kernel >= 5.17 and CAP_SYS_ADMIN. Building on non-Linux
 // platforms yields an empty package.
 package fanotify

--- a/agent/internal/fanotify/watcher_linux.go
+++ b/agent/internal/fanotify/watcher_linux.go
@@ -51,7 +51,7 @@ type Watcher struct {
 }
 
 // New initializes a fanotify watcher in FAN_REPORT_DFID_NAME mode.
-// Requires kernel ≥ 5.17 and CAP_SYS_ADMIN.
+// Requires kernel >= 5.17 and CAP_SYS_ADMIN.
 func New() (*Watcher, error) {
 	fd, err := unix.FanotifyInit(
 		unix.FAN_CLASS_NOTIF|unix.FAN_REPORT_DFID_NAME|unix.FAN_CLOEXEC,

--- a/agent/internal/flowpublisher/publisher.go
+++ b/agent/internal/flowpublisher/publisher.go
@@ -85,7 +85,7 @@ func (p *Publisher) PublishAppeared(ctx context.Context, dirName string) error {
 		if !apierrors.IsAlreadyExists(err) {
 			return fmt.Errorf("create MxlFlow: %w", err)
 		}
-		// Already there — leave spec alone (writers may have richer
+		// Already there -- leave spec alone (writers may have richer
 		// metadata than us), just refresh our location entry.
 		l.V(1).Info("MxlFlow already exists", "flowID", flowID)
 	} else {
@@ -121,7 +121,7 @@ func (p *Publisher) isMirrorTarget(ctx context.Context, flowID string) (bool, er
 }
 
 // PublishVanished updates the MxlFlow status to mark this node's
-// location as Stale. The MxlFlow itself is left in place — other
+// location as Stale. The MxlFlow itself is left in place -- other
 // nodes may still hold a mirror.
 func (p *Publisher) PublishVanished(ctx context.Context, dirName string) error {
 	flowID, ok := FlowIDFromDirName(dirName)

--- a/agent/internal/intent/dispatcher.go
+++ b/agent/internal/intent/dispatcher.go
@@ -1,13 +1,14 @@
 // Package intent handles on-demand MxlFlowMirror materialization.
 //
-// A consumer pod that tries to open a flow_def.json for a flow not
-// yet present on this node hits ENOENT. The libmxl-intent.so shim
-// inside the pod intercepts that ENOENT and asks this dispatcher
-// (via the agent's UDS) to materialize the flow. Materialize walks
-// the same handshake the operator uses for declarative
-// MxlReceivers — look up the source node, ensure the
-// MxlFlowMirror, wait for the gateway to mark it Ready — and then
-// returns success so the shim can retry the open.
+// A consumer pod that probes a flow that has not yet materialised
+// on this node hits ENOENT (libmxl calls access/stat/open against
+// the <id>.mxl-flow directory and the files inside it). The
+// libmxl-intent.so shim intercepts that ENOENT and asks this
+// dispatcher (via the agent's UDS) to materialize the flow.
+// Materialize walks the same handshake the operator uses for
+// declarative MxlReceivers -- look up the source node, ensure the
+// MxlFlowMirror, wait for the gateway to mark it Ready -- and
+// returns success so the shim can retry the original call.
 package intent
 
 import (

--- a/agent/internal/intentsock/server.go
+++ b/agent/internal/intentsock/server.go
@@ -3,9 +3,13 @@
 // shim) to ask for on-demand flow materialization.
 //
 // The wire protocol is one line-delimited JSON request per
-// connection:
+// connection. The path is any absolute path under a flow's
+// <uuid>.mxl-flow directory (the directory itself, the access
+// file, flow_def.json, ...). The dispatcher only uses the path
+// to extract the flow id, so it does not matter which entry the
+// shim happened to intercept first:
 //
-//	{"path":"/run/mxl/domain/<uuid>.mxl-flow/flow_def.json"}\n
+//	{"path":"/run/mxl/domain/<uuid>.mxl-flow/<anything>"}\n
 //
 // followed by one line-delimited JSON response from the agent:
 //
@@ -36,8 +40,9 @@ import (
 )
 
 // MaterializeDispatcher is the contract the Server expects from the
-// intent dispatcher: given a peer PID and a flow_def.json path, drive
-// the mirror to Ready (or surface a terminal error).
+// intent dispatcher: given a peer PID and an absolute path under a
+// flow's <uuid>.mxl-flow directory, drive the mirror to Ready (or
+// surface a terminal error).
 //
 // The narrow interface keeps the server testable without pulling in
 // the full intent package; *intent.Dispatcher satisfies it

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -6,10 +6,10 @@ pure Go.
 
 ## Toolchain
 
-- Go ≥ 1.26
-- A C/C++ toolchain (clang-19 or gcc), CMake ≥ 3.20, Ninja, pkg-config.
-- Linux kernel ≥ 5.9 on the host that will run the agent (for
-  `fanotify` directory-event support).
+- Go >= 1.26
+- A C/C++ toolchain (clang-19 or gcc), CMake >= 3.20, Ninja, pkg-config.
+- Linux kernel >= 5.17 on the host that will run the agent. The
+  agent's `fanotify` watcher needs `FAN_REPORT_DFID_NAME`.
 
 ## Pure-Go modules
 
@@ -81,11 +81,6 @@ pkg-config --exists libmxl libmxl-fabrics && echo OK
 for m in agent gateway; do (cd "$m" && go build ./... && go vet ./...); done
 ```
 
-> The `agent` module requires `github.com/qvest-digital/go-mxl` and the
-> `gateway` module requires `github.com/qvest-digital/go-mxl/fabrics`.
-> Both must be tagged on the proxy before these builds succeed without
-> a `go.work`-level replace.
-
 ## Integration tests
 
 Integration tests under the `mxl_integration` build tag exercise a real
@@ -96,10 +91,3 @@ libmxl install (and, for the gateway, real fabric endpoints):
 ```
 
 The default unit/vet/build jobs don't run these.
-
-## Future direction
-
-The local recipe above is the baseline. A devcontainer image that bakes
-in the toolchain, the pinned libmxl, and libfabric is on the roadmap;
-when it lands, this document will move the manual recipe to an appendix
-and recommend the devcontainer for everyday work.

--- a/docs/KIND.md
+++ b/docs/KIND.md
@@ -67,14 +67,13 @@ mxl-domain-agent-...            1/1     Running   0
 mxl-fabrics-gateway-...         1/1     Running   0
 mxl-fabrics-gateway-...         1/1     Running   0
 mxl-operator-...                1/1     Running   0
-mxl-tcp-demo-reader             1/1     Running   1 or 2
+mxl-tcp-demo-reader             1/1     Running   0
 mxl-tcp-demo-writer             1/1     Running   0
 ```
 
-The reader's small restart count comes from the LD_PRELOAD shim
-exiting and being restarted by the kubelet a couple of times
-while the mirror materialises on its node. Once the mirror is
-`Ready` it stays up.
+The LD_PRELOAD shim blocks the reader's first libmxl probe until
+the agent has the mirror materialised, so the reader reaches
+`Running` without a CrashLoop.
 
 ```sh
 kubectl --context kind-mxl-k8s-demo -n mxl-system logs pod/mxl-tcp-demo-reader

--- a/docs/RDMA.md
+++ b/docs/RDMA.md
@@ -12,10 +12,10 @@ on the worker nodes for either provider to actually work.
 
 - Kernel modules for the NIC vendor: `mlx5_ib` (Mellanox / NVIDIA
   ConnectX), `bnxt_re` (Broadcom Stingray), `irdma` (Intel E810),
-  `qedr` (Marvell FastLinQ), `efa` is its own provider — see
+  `qedr` (Marvell FastLinQ), `efa` is its own provider -- see
   below.
 - `rdma-core` userspace (provides `libibverbs`, `librdmacm`,
-  `ibstat`, `rdma`, …). Most distros' default package set.
+  `ibstat`, `rdma`, ...). Most distros' default package set.
 - `RLIMIT_MEMLOCK` set to `infinity` or at least multiple GiB.
   Common patterns:
   - `/etc/security/limits.d/rdma.conf`:
@@ -27,7 +27,7 @@ on the worker nodes for either provider to actually work.
     `LimitMEMLOCK=infinity` in the runtime's systemd unit.
   - The mxl-fabrics-gateway pod also asks for `SYS_RESOURCE` so
     it can raise its own limit if the host default is low.
-- `/dev/infiniband/{rdma_cm,uverbs0,…}` present and readable by
+- `/dev/infiniband/{rdma_cm,uverbs0,...}` present and readable by
   the container user. The gateway DaemonSet bind-mounts
   `/dev/infiniband` into the pod.
 - For RoCEv2 specifically: a network fabric configured with PFC
@@ -93,7 +93,7 @@ host setup is AWS-specific.
 - `--providers=efa` on the gateway DaemonSet.
 - `MxlFlowMirror.spec.provider: efa` (or
   `MxlReceiver.spec.provider: efa`).
-- Multus is *not* the right tool for EFA pods — EFA is exposed
+- Multus is *not* the right tool for EFA pods -- EFA is exposed
   via the host's network namespace. `hostNetwork: true` on the
   gateway DaemonSet (as in the rdma-demo example) keeps the
   configuration straightforward.
@@ -108,9 +108,9 @@ provider. A misconfiguration (e.g. `--providers=verbs` on a node
 without InfiniBand) surfaces at the first `MxlFlowMirror` Setup
 rather than at boot.
 
-Real per-provider probing — a synthetic flow created at startup
-to exercise each declared provider — is a deliberate follow-up;
-see the project's deferred-work memory.
+Real per-provider probing (a synthetic flow created at startup
+to exercise each declared provider) is a deliberate follow-up,
+not present in this release.
 
 ## Troubleshooting
 

--- a/docs/architecture/01-system-context.md
+++ b/docs/architecture/01-system-context.md
@@ -4,12 +4,12 @@
 
 mxl-k8s is a control plane that wraps two upstream shared libraries:
 
-- **libmxl** — a shared-memory media SDK. A producer process calls
+- **libmxl** -- a shared-memory media SDK. A producer process calls
   `mxlCreateFlowWriter` and a consumer process calls
   `mxlCreateFlowReader`. Both expect to see the same domain directory
   on the local filesystem; flows materialise as
   `<flowID>.mxl-flow/{flow_def.json, data, grains/}` under that path.
-- **libmxl-fabrics** — a cross-node transport for libmxl flows. It
+- **libmxl-fabrics** -- a cross-node transport for libmxl flows. It
   registers libmxl's shared-memory regions with libfabric, lets a
   remote initiator RDMA grain payload + header into them, and
   coordinates the handshake through a serialised `TargetInfo` blob
@@ -43,30 +43,30 @@ node, and then get out of the way of the data path.
 
 ## Actors
 
-- **Writer pod** — a user's producer. Calls libmxl to create the
+- **Writer pod** -- a user's producer. Calls libmxl to create the
   flow files on the producer node's tmpfs domain. mxl-k8s does not
   spawn or schedule it.
-- **Consumer pod** — a user's consumer. Calls libmxl to open a
+- **Consumer pod** -- a user's consumer. Calls libmxl to open a
   FlowReader. It opts into on-demand materialization by `LD_PRELOAD`-
   ing `libmxl-intent.so`, which intercepts the libc calls libmxl
   makes (`openat`, `open`, `access`, `stat`, `lstat`) against
   anything under a `.mxl-flow/` directory and asks the local agent
   to materialize the flow before retrying.
-- **Operator** (`operator/cmd/mxl-operator`) — single Deployment,
+- **Operator** (`operator/cmd/mxl-operator`) -- single Deployment,
   cluster-scoped. Its only active reconciler is
   `receiver.Reconciler`, which turns each `MxlReceiver` into one
   `MxlFlowMirror` per distinct target node. The other reconcilers
   it registers (`flow`, `mirror`, `domain`, `nodecaps`) are observer-
-  only — they log events and write nothing.
-- **Agent** (`agent/cmd/mxl-domain-agent`) — DaemonSet. Watches the
+  only -- they log events and write nothing.
+- **Agent** (`agent/cmd/mxl-domain-agent`) -- DaemonSet. Watches the
   node's tmpfs domain with `fanotify`, publishes `MxlFlow.status.
   locations` and `MxlDomain.status` for this node, and serves the
   intent UDS at `/run/mxl/agent.sock`.
-- **Gateway** (`gateway/cmd/mxl-fabrics-gateway`) — DaemonSet, runs
+- **Gateway** (`gateway/cmd/mxl-fabrics-gateway`) -- DaemonSet, runs
   with `hostNetwork: true`. Hosts the source and target
   `MxlFlowMirror` reconcilers and the capabilities publisher in one
   controller-runtime Manager.
-- **Kubernetes API server** — the only cluster-wide state. Every
+- **Kubernetes API server** -- the only cluster-wide state. Every
   cross-node coordination message (TargetInfo handoff, origin
   publication, capability advertisement) is a CR update.
 

--- a/docs/architecture/02-components.md
+++ b/docs/architecture/02-components.md
@@ -2,7 +2,7 @@
 
 mxl-k8s ships four runtime artefacts plus one wire-contract package.
 Each owns a specific slice of state and watches a specific set of CRDs.
-This page steps through them in turn — one focused diagram per
+This page steps through them in turn -- one focused diagram per
 component, showing the workflow rather than a labelled rectangle.
 
 ## CRD ownership at a glance
@@ -16,7 +16,7 @@ component, showing the workflow rather than a labelled rectangle.
 | `MxlNodeCapabilities` | Cluster (per-node) | gateway | gateway | operator (observe), gateway |
 
 The RBAC verbs that encode this table live in
-`+kubebuilder:rbac` markers next to each reconciler — most
+`+kubebuilder:rbac` markers next to each reconciler -- most
 authoritatively
 [`operator/internal/receiver/controller.go:35-40`](../../operator/internal/receiver/controller.go)
 and
@@ -24,7 +24,7 @@ and
 
 ## Operator
 
-`operator/cmd/mxl-operator` — single Deployment, cluster-scoped,
+`operator/cmd/mxl-operator` -- single Deployment, cluster-scoped,
 leader-elected (`LeaderElectionID:
 "mxl-operator.mxl.qvest-digital.com"`,
 [`main.go:56`](../../operator/cmd/mxl-operator/main.go)).
@@ -34,7 +34,7 @@ them mutates state, and that's the one that matters here:
 ![Operator: receiver.Reconciler reconcile workflow](./diagrams/02-operator.drawio.svg)
 
 The four other reconcilers (`flow`, `mirror`, `domain`, `nodecaps`)
-register at startup but log only — they're observer code paths that
+register at startup but log only -- they're observer code paths that
 exist to mark the reconciler scaffolding so future status-aggregation
 work has a hook. They write nothing.
 
@@ -55,7 +55,7 @@ Two correctness details worth flagging while looking at the diagram:
 
 ## Gateway
 
-`gateway/cmd/mxl-fabrics-gateway` — DaemonSet, `hostNetwork: true`.
+`gateway/cmd/mxl-fabrics-gateway` -- DaemonSet, `hostNetwork: true`.
 A single controller-runtime Manager hosts three concurrent
 activities, sharing one libmxl + libmxl-fabrics handle pair:
 
@@ -64,7 +64,7 @@ activities, sharing one libmxl + libmxl-fabrics handle pair:
 The two reconcilers are filtered on `spec.targetNode` and
 `spec.sourceNode` respectively. They operate on disjoint mirror sets
 (one mirror has exactly one of each), and they own their own
-finalizers — so libmxl + libfabric handles get torn down before the
+finalizers -- so libmxl + libfabric handles get torn down before the
 CR disappears, regardless of which side the gateway is acting on.
 
 The target-side lifecycle is worth its own diagram because the
@@ -76,7 +76,7 @@ fabric side *without* closing the `mxl.Writer`, so consumer pods'
 
 Two transitions in particular are easy to miss:
 
-- **Pod restart** lands in `Materializing` again, not `Ready` — the
+- **Pod restart** lands in `Materializing` again, not `Ready` -- the
   in-memory `targetEntry` map is empty after restart, the fast-path
   declines, and the slow path reopens the writer. This also rotates
   `TargetInfo`, which the source side picks up through its
@@ -85,7 +85,7 @@ Two transitions in particular are easy to miss:
   ([`target.go:375`](../../gateway/internal/mirror/target.go)),
   which closes only the fabric triple
   (`Regions`/`Target`/`Info`). The `mxl.Writer` is intentionally
-  retained — the on-disk flow definition and any consumer
+  retained -- the on-disk flow definition and any consumer
   `FlowReader` handles point at it.
 
 The choice of `ReadGrainNonBlocking` over the blocking variant is
@@ -97,9 +97,9 @@ builds.
 
 ## Agent
 
-`agent/cmd/mxl-domain-agent` — DaemonSet. Two concurrent workflows
+`agent/cmd/mxl-domain-agent` -- DaemonSet. Two concurrent workflows
 share a controller-runtime `client.Client` but are otherwise
-independent — fanotify can run with the intent socket disabled (set
+independent -- fanotify can run with the intent socket disabled (set
 `--intent-socket-path=""`) and vice versa.
 
 ![Agent: passive observation + active intent paths](./diagrams/02-agent.drawio.svg)
@@ -124,11 +124,11 @@ schedule.
 
 ## Shim
 
-`shim/libmxl-intent.c` — a tiny LD_PRELOAD library. No CRD access,
-no Kubernetes client, no daemon — it speaks only to the local
+`shim/libmxl-intent.c` -- a tiny LD_PRELOAD library. No CRD access,
+no Kubernetes client, no daemon -- it speaks only to the local
 agent's UDS.
 
-![Shim: openat() decision flow](./diagrams/02-shim.drawio.svg)
+![Shim: ENOENT decision flow](./diagrams/02-shim.drawio.svg)
 
 The narrowness of the path test is deliberate: the shim is loaded
 into every process the consumer pod runs, including the dynamic
@@ -149,26 +149,26 @@ The decision to use LD_PRELOAD rather than a kernel-level mechanism
 is forced by what libmxl exposes:
 
 - libmxl has no "flow not present" callback hook on the FlowReader
-  side — it just returns `FLOW_NOT_FOUND`.
+  side -- it just returns `FLOW_NOT_FOUND`.
 - fanotify `FAN_OPEN_PERM` would let us intercept `open` syscalls
   with a permission decision, but the kernel only consults
   permission events for paths that resolve to an inode. An `openat`
   that's about to return `ENOENT` never fires the event.
-- Intercepting the libc syscall stub in userspace, scoped to a
-  single suffix, is the simplest place where we can both see the
-  attempted open *and* still call the real `openat` after the
-  agent has materialized the file.
+- Intercepting libc symbols in userspace, scoped to paths under
+  `<id>.mxl-flow`, is the simplest place where the shim can both
+  see the attempted call *and* re-issue it after the agent has
+  materialised the file.
 
 ## `ipc/v1` is a contract, not a runtime
 
 [`ipc/v1/control.proto`](../../ipc/v1/control.proto) defines a
 `LocalControl` gRPC service (`OpenMirror`, `CloseMirror`,
-`ListLocalEndpoints`) intended for agent → gateway local control
+`ListLocalEndpoints`) intended for agent -> gateway local control
 over a UDS. The proto's own header is explicit: "Cross-node gateway
 coordination happens through the Kubernetes API by way of
 `MxlFlowMirror`; there is no gateway-to-gateway gRPC surface in this
 version." No code outside of the generated bindings imports
-`ipc/v1` in the current tree — it's a forward-looking contract,
+`ipc/v1` in the current tree -- it's a forward-looking contract,
 nothing more.
 
 ## End-to-end: applying an `MxlReceiver`
@@ -176,8 +176,8 @@ nothing more.
 The per-component workflows above describe what each process does in
 isolation. This sequence shows how they line up in time when a user
 applies an `MxlReceiver` and a cross-node mirror reaches `Ready`.
-The intent-driven path (LD_PRELOAD shim → agent UDS) joins at step
-5 — the agent and the operator's reconciler use the same
+The intent-driven path (LD_PRELOAD shim -> agent UDS) joins at step
+5 -- the agent and the operator's reconciler use the same
 deterministic `MirrorName`, so the on-demand path and the
 declarative path converge on a single `MxlFlowMirror`.
 
@@ -204,21 +204,21 @@ The eight steps in order:
    isn't ready, it sets `phase=Pending` with a 10s requeue and
    exits.
 5. **Operator creates one `MxlFlowMirror` per distinct target
-   node.** Mirrors where `target == sourceNode` are skipped — the
+   node.** Mirrors where `target == sourceNode` are skipped -- the
    writer's own node already has the flow.
 6. **Target-node gateway's `TargetReconciler` wakes** on the
    `MxlFlowMirror` event and walks the libmxl-fabrics handshake:
-   `mxl.Instance.NewWriter` → `fabrics.RegionsForFlowWriter` →
-   `fabrics.Instance.NewTarget` → `Target.Setup` →
+   `mxl.Instance.NewWriter` -> `fabrics.RegionsForFlowWriter` ->
+   `fabrics.Instance.NewTarget` -> `Target.Setup` ->
    `TargetInfo.MarshalString`. It patches
    `MxlFlowMirror.status.targetInfo` and `phase=Ready`, then starts
    the progress goroutine.
 7. **Source-node gateway's `SourceReconciler` wakes** on the
-   mirror's status update — it has `Watches(MxlFlowMirror)` *and*
+   mirror's status update -- it has `Watches(MxlFlowMirror)` *and*
    `Watches(MxlFlow)`. It opens
-   `mxl.Instance.NewReader` →
-   `fabrics.RegionsForFlowReader` → `fabrics.Instance.NewInitiator`
-   → `Initiator.Setup` → `ParseTargetInfo` → `AddTarget`, then
+   `mxl.Instance.NewReader` ->
+   `fabrics.RegionsForFlowReader` -> `fabrics.Instance.NewInitiator`
+   -> `Initiator.Setup` -> `ParseTargetInfo` -> `AddTarget`, then
    spawns the transfer goroutine.
 8. **Operator's `receiver.Reconciler` wakes** on the mirror's
    status update via its `Watches(MxlFlowMirror)` and patches

--- a/docs/architecture/03-node-anatomy.md
+++ b/docs/architecture/03-node-anatomy.md
@@ -18,7 +18,7 @@ Three things matter here:
 
 - **`/run/mxl` is a tmpfs**, not a backed mount. The bytes live in
   page-cache RAM. Nothing survives a node reboot. mxl-k8s does not
-  provision the mount — that is left to the host's init system or a
+  provision the mount -- that is left to the host's init system or a
   privileged bootstrap step. The agent reports the state it observes
   via `MxlDomain.status` (`capacityBytes`, `freeBytes`,
   `fanotifyReady`), but does not create the mount itself.
@@ -27,7 +27,7 @@ Three things matter here:
   `<flowID>.mxl-flow/{flow_def.json,data,grains/}`; closing the
   writer removes them. This is why the gateway's TargetReconciler
   recovery path keeps `mxl.Writer` alive even when the libfabric
-  side died — releasing the writer would remove the on-disk flow
+  side died -- releasing the writer would remove the on-disk flow
   definition and invalidate every consumer pod's `FlowReader`
   handle on the same node.
 - **`agent.sock` is a per-node singleton.** The agent binds it at
@@ -58,7 +58,7 @@ Two things to read out of the diagram:
   libfabric memory region** over that mapping. libfabric needs to
   know the (virtual address, length, `rkey`) triple before a remote
   peer can RDMA into the region. Writer and consumer pods don't
-  participate in libfabric at all — they only see the libmxl
+  participate in libfabric at all -- they only see the libmxl
   HeadIndex semantics.
 
 The per-grain narrative captured in the diagram is the same one as
@@ -73,7 +73,7 @@ a single node:
 - **Target side.** The RDMA write lands in this node's registered
   region, which *is* a slice of this node's tmpfs file. The target
   gateway calls `ReadGrainNonBlocking` to learn the index, then
-  `Writer.OpenGrain(i).Commit` — a metadata-only HeadIndex bump
+  `Writer.OpenGrain(i).Commit` -- a metadata-only HeadIndex bump
   because the payload bytes were already placed by RDMA. The
   consumer's `FlowReader` sees the HeadIndex move (same tmpfs
   pages, mapped read-only) and `GetGrain` returns a pointer into
@@ -92,18 +92,18 @@ table:
 
 | Process | mounts `/run/mxl/domain` | mounts `/run/mxl/agent.sock` | linked / preloaded libraries |
 | --- | --- | --- | --- |
-| writer pod | rw | — | libmxl |
+| writer pod | rw | -- | libmxl |
 | consumer pod | rw | rw (bind-mount of the socket file) | libmxl + libmxl-intent.so via `LD_PRELOAD` |
 | agent DaemonSet | rw | rw (binds, listens) | libmxl |
-| gateway DaemonSet | rw | — | libmxl + libmxl-fabrics + libfabric provider |
+| gateway DaemonSet | rw | -- | libmxl + libmxl-fabrics + libfabric provider |
 
 The LD_PRELOAD shim is delivered through a small two-container
 pattern: an initContainer copies the prebuilt `libmxl-intent.so`
-into a shared `emptyDir`, the main container's
-`LD_PRELOAD=/var/run/mxl-intent/libmxl-intent.so` (or
-`MXL_INTENT_SOCK` plus a custom path) picks it up. The shim itself
-has no daemon, no Kubernetes client, and no state — see
-[02-components](./02-components.md#shim).
+into a shared `emptyDir`, and the main container's
+`LD_PRELOAD=/opt/mxl-intent/libmxl-intent.so` picks it up. The
+default agent socket path can be overridden with
+`MXL_INTENT_SOCK`. The shim itself has no daemon, no Kubernetes
+client, and no state -- see [02-components](./02-components.md#shim).
 
 ## Why these per-node choices
 
@@ -118,7 +118,7 @@ view:
   on the node maps the same memory. PersistentVolumes would mean
   per-pod views, which would defeat the zero-copy story.
 - **Bind-mount of `/run/mxl/agent.sock` into consumer pods.** The
-  alternative — a TCP listener on localhost — would force the shim
+  alternative -- a TCP listener on localhost -- would force the shim
   to use a different syscall path and lose `SO_PEERCRED`-based
   caller identification. A UDS file fits the shim's "intercept the
   libmxl probe and block" model with minimal surface.
@@ -148,26 +148,26 @@ Steps for one grain index *N*:
    reads the new `HeadIndex` from `Reader.Runtime()`, and for each
    `idx > lastSent` calls `GetGrainNonBlocking(idx)` followed by
    `Initiator.TransferGrain(idx, 0, slices)`. The grain is read
-   from the gateway's mapping of the *same tmpfs file* — the
+   from the gateway's mapping of the *same tmpfs file* -- the
    bytes never leave RAM on this node.
 3. **libfabric** performs an RDMA write into the target node's
    registered region. For the `tcp` provider this is a sequence of
    socket sends to the remote target; for `verbs`/EFA it is a real
    one-sided RDMA. In both cases the payload + grain header land
-   *directly in the target's ring slot* — no intermediate buffer
+   *directly in the target's ring slot* -- no intermediate buffer
    on the target gateway.
 4. **Target gateway's progress goroutine** polls
    `Target.ReadGrainNonBlocking`. On success it returns the index
    that just completed; on `ErrNotReady` it sleeps 1 ms and loops.
 5. **Target gateway** calls `commitArrivedGrain(writer, idx)`,
    which is `Writer.OpenGrain(idx)` followed immediately by
-   `Commit(TotalSlices, 0)`. This does not copy data — the payload
+   `Commit(TotalSlices, 0)`. This does not copy data -- the payload
    and header are already in place. The Commit only advances the
    local flow's `HeadIndex` so consumer FlowReaders on this node
    see the new grain.
 6. **Consumer pod's FlowReader** sees `HeadIndex >= N` on its next
    `GetGrain(N)` call. The grain bytes are returned via a pointer
-   into the consumer's mmap of the local data file — zero-copy on
+   into the consumer's mmap of the local data file -- zero-copy on
    the consumer side as well.
 
 Three details from the diagram are worth pulling out:
@@ -178,12 +178,12 @@ Three details from the diagram are worth pulling out:
   fatal "poll failed" in release builds (the `EINTR` filter is
   gated on `#if ENABLE_DEBUG`). Go's async preemption sends SIGURG
   to running goroutines ~50/sec since Go 1.14, and that's the
-  signal a blocking `ReadGrain` receives via the libfabric thread —
-  tearing the endpoint down every 10–60 seconds in steady state.
+  signal a blocking `ReadGrain` receives via the libfabric thread --
+  tearing the endpoint down every 10-60 seconds in steady state.
   Polling from Go avoids blocking inside libfabric and sidesteps
-  the signal-interaction. A workaround for the upstream libfabric
-  bug is carried in libmxl fork PR #17, but the non-blocking path
-  remains the correct shape regardless.
+  the signal interaction. An upstream-libfabric workaround exists
+  in the libmxl fork, but the non-blocking path is the correct
+  shape regardless of whether the workaround is in place.
 - **Why `Commit` is metadata-only on the target.** The payload +
   header bytes were RDMA'd into the ring slot by the remote
   initiator *before* `ReadGrain` reported the index as ready. What
@@ -210,6 +210,6 @@ is unreachable, `TransferGrain` errors are logged and the loop
 continues, falling further behind the writer until the producer
 wraps the ring and grains start being overwritten in tmpfs before
 they're sent. Consumer reads honour libmxl's normal grain-ring
-semantics — if the consumer is too slow it will start receiving
+semantics -- if the consumer is too slow it will start receiving
 "grain aged out" errors from `GetGrain`. mxl-k8s does not
 interpose on this; the ring is libmxl's, not ours.

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -21,7 +21,7 @@ Every diagram is stored as a `*.drawio.svg` file under
 whose root element carries a URL-encoded `mxfile` in its `content`
 attribute, and whose body is a rendered preview of that XML.
 
-The XML inside `content="…"` is the source of truth; the SVG body
+The XML inside `content="..."` is the source of truth; the SVG body
 beneath it is a cache drawio regenerates on save. To edit:
 
 1. Open the file in VS Code with the

--- a/examples/rdma-demo/README.md
+++ b/examples/rdma-demo/README.md
@@ -2,7 +2,7 @@
 
 Same end-to-end slice as `tcp-demo`, configured for the
 `libmxl-fabrics` **verbs** provider. Grains move between gateway
-pods over RDMA via libibverbs / librdmacm — typically RoCEv2 on
+pods over RDMA via libibverbs / librdmacm -- typically RoCEv2 on
 ethernet NICs, native InfiniBand on IB fabrics, with EFA as a
 close cousin (see `docs/RDMA.md` for AWS specifics).
 
@@ -26,7 +26,7 @@ The cluster must actually have RDMA-capable NICs and the matching
 host-side drivers. See `docs/RDMA.md` for the full prerequisite
 list; quick summary:
 
-- Linux kernel ≥ 5.17 (same as tcp-demo) on the worker nodes.
+- Linux kernel >= 5.17 (same as tcp-demo) on the worker nodes.
 - `ibverbs`, `rdma-core`, and the NIC-specific kernel modules
   (e.g. `mlx5_ib` for Mellanox / NVIDIA ConnectX, `bnxt_re` for
   Broadcom, `irdma` for Intel E810) loaded on the host.

--- a/examples/tcp-demo/03-gateway.yaml
+++ b/examples/tcp-demo/03-gateway.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       serviceAccountName: mxl-fabrics-gateway
       # hostNetwork so the libmxl-fabrics TCP endpoint listens on the
-      # node's interface — TargetInfo embeds host:port, which any peer
+      # node's interface -- TargetInfo embeds host:port, which any peer
       # gateway can dial across the cluster.
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet

--- a/examples/tcp-demo/21-reader.yaml
+++ b/examples/tcp-demo/21-reader.yaml
@@ -1,9 +1,10 @@
 # Consumer pod for the demo. Opens the flow on its local MXL domain
 # with the `read-grain` example binary from go-mxl, which prints a
 # one-line summary of each grain it observes. The libmxl-intent.so
-# LD_PRELOAD shim turns the initial ENOENT (the mirror hasn't
-# materialized yet on this node) into a synchronous wait on the
-# agent's UDS — so read-grain's first open already sees the
+# LD_PRELOAD shim turns libmxl's first ENOENT probe (access/stat
+# on the <flowID>.mxl-flow directory before the mirror has
+# materialised) into a synchronous wait on the agent's UDS, so
+# the reader's first mxlCreateFlowReader already sees the
 # mirrored flow.
 #
 # Anti-affinity forces the pod onto a different node than the

--- a/examples/tcp-demo/README.md
+++ b/examples/tcp-demo/README.md
@@ -1,7 +1,7 @@
 # tcp-demo
 
-End-to-end exercise of `MxlReceiver` → operator → `MxlFlowMirror` →
-gateway → `libmxl-fabrics` TCP transfer between two k3s nodes.
+End-to-end exercise of `MxlReceiver` -> operator -> `MxlFlowMirror` ->
+gateway -> `libmxl-fabrics` TCP transfer between two k3s nodes.
 
 ## What it does
 
@@ -40,13 +40,13 @@ first open is the declaration".
 
 ## Prerequisites
 
-- A two-node Linux cluster, kernel ≥ 5.17 on the worker nodes
+- A two-node Linux cluster, kernel >= 5.17 on the worker nodes
   (fanotify `FAN_REPORT_DFID_NAME`).
 - Worker nodes can reach each other on the host network (libmxl-
   fabrics' TCP endpoint listens on the gateway pod's host IP via
   `hostNetwork: true`).
 - A CNI that allows host-network pods to talk to each other (any
-  default — flannel, calico, cilium — is fine).
+  default -- flannel, calico, cilium -- is fine).
 
 ## Build the images
 

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -361,7 +361,7 @@ func runTargetProgressLoop(
 // commitArrivedGrain advances the local flow's HeadIndex for a grain
 // whose payload + header were already filled in by the remote
 // initiator's RDMA write. OpenGrain returns a writable handle aliasing
-// the ring slot — we leave the slot bytes untouched and Commit so the
+// the ring slot -- we leave the slot bytes untouched and Commit so the
 // flow metadata catches up.
 func commitArrivedGrain(writer *mxl.Writer, idx uint64) error {
 	ga, err := writer.OpenGrain(idx)

--- a/hack/kind-down.sh
+++ b/hack/kind-down.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# kind-down.sh — delete the demo KIND cluster.
+# kind-down.sh -- delete the demo KIND cluster.
 
 set -euo pipefail
 

--- a/hack/kind-status.sh
+++ b/hack/kind-status.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# kind-status.sh — quick at-a-glance view of the demo's state.
+# kind-status.sh -- quick at-a-glance view of the demo's state.
 
 set -euo pipefail
 

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# kind-up.sh — bring up a KIND cluster, build & load the mxl-k8s
+# kind-up.sh -- bring up a KIND cluster, build & load the mxl-k8s
 # images, apply examples/tcp-demo, and wait for the MxlFlowMirror
 # to reach Ready.
 #
@@ -8,7 +8,7 @@
 # reloads them, and re-applies the demo. Pair with `hack/kind-down.sh`
 # to start clean.
 #
-# Requires: docker, kind ≥ 0.20, kubectl, a Linux kernel ≥ 5.17 on
+# Requires: docker, kind >= 0.20, kubectl, a Linux kernel >= 5.17 on
 # the host (KIND nodes share it; the agent's fanotify needs
 # FAN_REPORT_DFID_NAME).
 
@@ -82,7 +82,7 @@ if "${KUBECTL[@]}" -n mxl-system get deploy/mxl-operator >/dev/null 2>&1; then
   log "Rolling out latest images"
   "${KUBECTL[@]}" -n mxl-system rollout restart deploy/mxl-operator ds/mxl-domain-agent ds/mxl-fabrics-gateway || true
 fi
-# Wait for the deletes to complete — re-applying while a pod is
+# Wait for the deletes to complete -- re-applying while a pod is
 # still Terminating leaves the new pod in limbo (apply observes
 # the live object and treats it as a no-op).
 "${KUBECTL[@]}" -n mxl-system delete pod mxl-tcp-demo-writer mxl-tcp-demo-reader --ignore-not-found

--- a/shim/README.md
+++ b/shim/README.md
@@ -45,7 +45,7 @@ The agent replies with either:
 {"ok":true}
 ```
 
-(meaning the open should now succeed — the shim retries it) or:
+(meaning the open should now succeed -- the shim retries it) or:
 
 ```json
 {"ok":false,"error":"<reason>"}


### PR DESCRIPTION
A fresh read of the tree, looking for the things that would make
a new contributor stop and ask "wait, is this still right?". Two
commits, kept separate so the typography churn does not bury the
factual edits.

## Stale claims fixed

- README and the two agent intent packages still framed the shim
  as an `openat`-only intercept on `flow_def.json`. After the
  shim grew `access`/`stat`/`open`/`lstat` hooks and a
  directory-component matcher, that narrative has been wrong.
  Rewrite to describe libmxl's actual first probe.
- `docs/BUILD.md` required kernel 5.9 -- every other prereq doc
  says 5.17 (the `FAN_REPORT_DFID_NAME` version). Align.
- `docs/BUILD.md` still warned that go-mxl needed proxy tagging
  "before these builds succeed". go-mxl is on the proxy at
  `v1.0.0-rc.5`. Drop the note.
- `docs/BUILD.md` "Future direction" paragraph promised a
  devcontainer that does not exist. Drop.
- `docs/KIND.md` predicted the demo reader would land in
  `RESTARTS=1 or 2`. After #41 the shim blocks correctly and the
  reader reaches Running with zero restarts; align the
  expectation.
- `docs/RDMA.md` ended the capability-publisher section with
  "see the project's deferred-work memory" -- a reference into a
  tool's private state. Replace with a flat statement.
- `docs/architecture/02-components.md` still labelled the shim
  flowchart "openat() decision flow" and described the intercept
  as scoped to "a single suffix". Both updated.
- `docs/architecture/03-node-anatomy.md` prescribed
  `/var/run/mxl-intent/` while every manifest in tree uses
  `/opt/mxl-intent/`. It also cross-referenced an external
  libmxl-fork PR number; numbers drift, so drop the number and
  keep the rationale.

## Typography pass

Replace em-dashes (`--`), en-dashes (`-`), arrows (`->`),
ellipsis (`...`), `>=`/`<=`, and curly quotes with the keyboard
equivalents across docs, shell scripts, manifests, and source
comments. The contributor guide already asks for ASCII outside
generated files; this closes the remaining drift in
non-generated sources. `CLAUDE.md` and the drawio SVG sources
are untouched.

## What I deliberately did not touch

- `config/crd` vs `charts/mxl-k8s/crds`: looks like duplication
  but the chart copies from `config/crd` via
  `make chart-crd-sync` and `chart-check` enforces the sync.
  Legitimate.
- `examples/tcp-demo` vs `examples/rdma-demo`: substantial
  overlap, but the rdma-demo carries provider-specific knobs
  and host-setup needs that the tcp one does not. Keep separate.
- `ipc/v1` is imported nowhere; the architecture doc already
  flags it as a forward-looking contract.
- `CLAUDE.md` -- the contributor guide itself, authored content,
  not mine to reword.

## Verification

- `go build` passes on the agent and gateway modules.
- `go test ./internal/intent/ ./internal/intentsock/` on the
  agent passes.
- `LD_LIBRARY_PATH=/opt/libmxl/lib go test ./...` on the gateway
  passes.
- `make chart-check` runs clean -- no drift in
  `charts/mxl-k8s/README.md` or `values.schema.json` from this
  series.