### PR TITLE
fix(chart): drive package-push through workflow_call

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -12,15 +12,27 @@ on:
       - 'charts/mxl-k8s/**'
       - 'config/crd/**'
       - '.github/workflows/chart.yml'
-  # release-please-action creates a GitHub release alongside the
-  # tag at chart-cut time. Using release:published here (instead
-  # of push:tags) sidesteps the GitHub Actions quirk that
-  # silently swallows tag-push events when push: also carries a
-  # paths filter (the path filter can't compute a meaningful
-  # diff for the first matching tag and the event is dropped).
-  # The meta job filters down to chart releases.
-  release:
-    types: [published]
+  # release-please.yml calls this workflow as a reusable workflow
+  # when a charts/mxl-k8s release tag has just been cut. Listening
+  # on release:published instead does not work: release-please-action
+  # creates the release with the default GITHUB_TOKEN, and events
+  # produced by GITHUB_TOKEN do not start downstream workflow runs.
+  # workflow_call (and workflow_dispatch, for manual recovery) are
+  # the documented exceptions, so we drive the release publish
+  # through them.
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "charts/mxl-k8s release tag to package (e.g. charts/mxl-k8s/v1.0.0-rc.2)"
+        type: string
+        required: true
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "charts/mxl-k8s release tag to package (e.g. charts/mxl-k8s/v1.0.0-rc.2). Leave empty for a dev build of HEAD."
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: write
@@ -50,7 +62,10 @@ jobs:
       version: ${{ steps.m.outputs.version }}
       release_tag: ${{ steps.m.outputs.release_tag }}
     env:
-      RELEASE_TAG: ${{ github.event.release.tag_name }}
+      # inputs.release_tag is set by both workflow_call (from
+      # release-please.yml) and workflow_dispatch. It is absent on
+      # pull_request / push.
+      INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
     steps:
       - id: m
         run: |
@@ -60,31 +75,26 @@ jobs:
           version=""
           release_tag=""
 
-          case "$GITHUB_EVENT_NAME" in
-            push)
-              # Only branch=main pushes reach this case; tag pushes are
-              # handled via the release:published event below to avoid
-              # the paths-filter quirk that drops tag-push events.
-              if [ "$GITHUB_REF" = "refs/heads/main" ]; then
-                # SemVer-valid prerelease build for the floating dev channel.
-                # OCI translates "+" to "_" at push time.
-                version="0.0.0-dev+sha.${short_sha}"
+          if [ -n "${INPUT_RELEASE_TAG:-}" ]; then
+            # Called for a tagged release. Accept only chart tags;
+            # anything else is a caller mistake worth failing on.
+            case "$INPUT_RELEASE_TAG" in
+              charts/mxl-k8s/v*.*.*)
+                version="${INPUT_RELEASE_TAG##*/v}"
+                release_tag="$INPUT_RELEASE_TAG"
                 publish=true
-              fi
-              ;;
-            release)
-              # release-please-action published a release. Filter to
-              # chart tags only; other components publish their own
-              # release events that this workflow must ignore.
-              case "$RELEASE_TAG" in
-                charts/mxl-k8s/v*.*.*)
-                  version="${RELEASE_TAG##*/v}"
-                  release_tag="$RELEASE_TAG"
-                  publish=true
-                  ;;
-              esac
-              ;;
-          esac
+                ;;
+              *)
+                echo "::error::release_tag '${INPUT_RELEASE_TAG}' is not a charts/mxl-k8s tag"
+                exit 1
+                ;;
+            esac
+          elif [ "$GITHUB_EVENT_NAME" = "push" ] && [ "$GITHUB_REF" = "refs/heads/main" ]; then
+            # SemVer-valid prerelease build for the floating dev channel.
+            # OCI translates "+" to "_" at push time.
+            version="0.0.0-dev+sha.${short_sha}"
+            publish=true
+          fi
 
           {
             echo "publish=${publish}"
@@ -249,19 +259,20 @@ jobs:
           helm push "${tgz}" "oci://ghcr.io/${owner}/mxl-k8s/charts"
 
       # Append the bundled-component-versions table to either the
-      # GitHub release notes (tag push -> release-please-action already
-      # created the release) or the workflow summary (dev build).
+      # GitHub release notes (release_tag is set by the caller in
+      # release-please.yml, or by a manual workflow_dispatch) or
+      # the workflow summary (dev build off main).
       - name: Publish bundled-component table
         env:
           VERSION: ${{ needs.meta.outputs.version }}
+          RELEASE_TAG: ${{ needs.meta.outputs.release_tag }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eu
-          if [ "${{ github.ref_type }}" = "tag" ]; then
-            tag="${GITHUB_REF_NAME}"
-            existing=$(gh release view "${tag}" --json body --jq .body)
+          if [ -n "${RELEASE_TAG:-}" ]; then
+            existing=$(gh release view "${RELEASE_TAG}" --json body --jq .body)
             { printf "%s\n\n" "${existing}"; cat /tmp/bundled.md; } \
-              | gh release edit "${tag}" --notes-file -
+              | gh release edit "${RELEASE_TAG}" --notes-file -
           else
             cat /tmp/bundled.md >> "$GITHUB_STEP_SUMMARY"
           fi

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -47,6 +47,7 @@ jobs:
       gateway_released:  ${{ steps.rp.outputs['gateway--release_created'] }}
       shim_released:     ${{ steps.rp.outputs['shim--release_created'] }}
       chart_released:    ${{ steps.rp.outputs['charts/mxl-k8s--release_created'] }}
+      chart_tag:         ${{ steps.rp.outputs['charts/mxl-k8s--tag_name'] }}
     steps:
       - id: rp
         uses: googleapis/release-please-action@v5
@@ -141,8 +142,38 @@ jobs:
     if: >
       needs.prerelease.outputs.chart_released == 'true' ||
       (github.event_name == 'workflow_dispatch' && inputs.force_release == 'charts/mxl-k8s')
+    outputs:
+      chart_released: ${{ steps.rp.outputs['charts/mxl-k8s--release_created'] }}
+      chart_tag:      ${{ steps.rp.outputs['charts/mxl-k8s--tag_name'] }}
     steps:
-      - uses: googleapis/release-please-action@v5
+      - id: rp
+        uses: googleapis/release-please-action@v5
         with:
           config-file: .github/release-config-chart.json
           manifest-file: .github/release-manifest.json
+
+  # Once a charts/mxl-k8s tag is cut (rc from prerelease, or stable
+  # from release-chart), package and push the chart with per-component
+  # image tags pinned. This is a reusable workflow call because
+  # GITHUB_TOKEN-created release events do not start downstream
+  # workflow runs, so chart.yml cannot listen on release:published.
+  # workflow_call is explicitly excepted from that restriction.
+  package-chart-prerelease:
+    needs: [prerelease]
+    if: needs.prerelease.outputs.chart_released == 'true'
+    permissions:
+      contents: write
+      packages: write
+    uses: ./.github/workflows/chart.yml
+    with:
+      release_tag: ${{ needs.prerelease.outputs.chart_tag }}
+
+  package-chart-stable:
+    needs: [release-chart]
+    if: needs.release-chart.outputs.chart_released == 'true'
+    permissions:
+      contents: write
+      packages: write
+    uses: ./.github/workflows/chart.yml
+    with:
+      release_tag: ${{ needs.release-chart.outputs.chart_tag }}


### PR DESCRIPTION
## Why

The chart workflow listened on \`release: [published]\` so the chart-rc tag cut by release-please would trigger packaging and append the bundled-component table to the GitHub release notes. That works only when the release is published by a user account. release-please-action publishes with the default \`GITHUB_TOKEN\`, and per GitHub Actions design, events produced by \`GITHUB_TOKEN\` do not start new workflow runs except for \`workflow_dispatch\` and \`repository_dispatch\` (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication#using-the-github_token-in-a-workflow).

Concretely:

- \`charts/mxl-k8s/v1.0.0-rc.1\` "worked" only because the release was manually republished by a user after the workflow was wired up, which flipped the release author away from \`github-actions[bot]\` and fired the event from a non-bot identity.
- \`charts/mxl-k8s/v1.0.0-rc.2\` was published end-to-end by release-please-action. No release-event chart run was created. The push-to-main run that did fire took the dev branch in \`meta\` (\`version=0.0.0-dev+sha.<short>\`), so \`hack/chart-resolve-tags.sh\` pinned every component image tag to \`dev\`, and the bundled-component-versions table was appended to \`\$GITHUB_STEP_SUMMARY\` instead of the release notes.

## What changes

- Drop \`on.release\` from \`chart.yml\`. Add \`on.workflow_call\` (required \`release_tag\` input) and \`on.workflow_dispatch\` (optional \`release_tag\`, defaulting to a dev build).
- Rewrite the \`meta\` step to branch on \`inputs.release_tag\` first, with the push-to-main dev path preserved.
- Drive the release-notes-append step off \`needs.meta.outputs.release_tag\` instead of \`github.ref_type == 'tag'\`.
- In \`release-please.yml\`, expose \`charts/mxl-k8s--tag_name\` from both the prerelease job and the \`release-chart\` job, and add two reusable-workflow-call jobs that invoke \`chart.yml\` after each chart release is created. Both new jobs declare \`contents: write, packages: write\` job-level permissions; no PAT is required because \`workflow_call\` is excepted from the \`GITHUB_TOKEN\` propagation rule.

The existing \`pull_request\` and \`push\` triggers on \`chart.yml\` are unchanged, so PR validation and the dev-channel OCI push off \`main\` keep working as before.

## Repairing the rc.2 release

After this lands, kick off the chart packaging for the existing rc.2 tag manually:

\`\`\`
gh workflow run chart.yml --ref main -f release_tag=charts/mxl-k8s/v1.0.0-rc.2
\`\`\`

That will repackage the chart with the rc.2 component tags pinned, push it under that semver to the OCI registry (the existing \`0.0.0-dev+sha.dae4645\` artifact stays untouched), and append the bundled-component table to the release notes.