### PR TITLE
fix(chart): align pod template name label with selector

### DIFF
--- a/charts/mxl-k8s/templates/_helpers.tpl
+++ b/charts/mxl-k8s/templates/_helpers.tpl
@@ -33,11 +33,21 @@ app.kubernetes.io/component: {{ .component }}
 {{- end -}}
 
 {{/*
-Per-component object labels = common labels + selector labels.
+Per-component object labels. Composes the chart-identity labels with
+mxlk8s.selectorLabels so spec.template.metadata.labels and
+spec.selector.matchLabels agree on app.kubernetes.io/name; mismatch
+makes the apiserver reject the workload at install time.
 */}}
 {{- define "mxlk8s.componentLabels" -}}
-{{ include "mxlk8s.labels" .Context }}
-app.kubernetes.io/component: {{ .component }}
+helm.sh/chart: {{ include "mxlk8s.chart" .Context }}
+app.kubernetes.io/managed-by: {{ .Context.Release.Service }}
+{{- if .Context.Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Context.Chart.AppVersion | quote }}
+{{- end }}
+{{ include "mxlk8s.selectorLabels" . }}
+{{- with .Context.Values.global.commonLabels }}
+{{ toYaml . }}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/mxl-k8s/tests/unit/daemonset-agent_test.yaml
+++ b/charts/mxl-k8s/tests/unit/daemonset-agent_test.yaml
@@ -20,6 +20,15 @@ tests:
           path: spec.template.spec.containers[0].args[0]
           value: --domain-path=/run/mxl/domain
 
+  - it: pod template name label matches the selector
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: mxl-k8s-agent
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: mxl-k8s-agent
+
   - it: mounts the whole /run/mxl so the intent socket is host-visible
     asserts:
       - equal:

--- a/charts/mxl-k8s/tests/unit/daemonset-gateway_test.yaml
+++ b/charts/mxl-k8s/tests/unit/daemonset-gateway_test.yaml
@@ -11,6 +11,15 @@ tests:
           path: spec.template.spec.dnsPolicy
           value: ClusterFirstWithHostNet
 
+  - it: pod template name label matches the selector
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: mxl-k8s-gateway
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: mxl-k8s-gateway
+
   - it: providers list joins on commas in the rendered arg
     set:
       gateway.flags.providers: [tcp, verbs, shm]

--- a/charts/mxl-k8s/tests/unit/deployment-operator_test.yaml
+++ b/charts/mxl-k8s/tests/unit/deployment-operator_test.yaml
@@ -22,6 +22,15 @@ tests:
     release:
       namespace: NAMESPACE
 
+  - it: pod template name label matches the selector
+    asserts:
+      - equal:
+          path: spec.selector.matchLabels["app.kubernetes.io/name"]
+          value: mxl-k8s-operator
+      - equal:
+          path: spec.template.metadata.labels["app.kubernetes.io/name"]
+          value: mxl-k8s-operator
+
   - it: renders structured flags as --key=value args
     asserts:
       - contains:


### PR DESCRIPTION
## Why

\`spec.selector.matchLabels\` is required to be a strict subset of \`spec.template.metadata.labels\`. The chart violated that for every Deployment/DaemonSet:

- \`mxlk8s.selectorLabels\` set \`app.kubernetes.io/name: <chart>-<component>\` (e.g. \`mxl-k8s-agent\`).
- \`mxlk8s.componentLabels\`, used for \`metadata.labels\` on the workload and on the pod template, included \`mxlk8s.labels\`, which set \`app.kubernetes.io/name: <chart>\` (e.g. \`mxl-k8s\`).

Helm install on EKS 1.35 against \`oci://ghcr.io/qvest-digital/mxl-k8s/charts/mxl-k8s\` 1.0.0-rc.2 failed with three identical errors of the form:

\`\`\`
DaemonSet.apps "mxl-k8s-gateway" is invalid: spec.template.metadata.labels: Invalid value: ...: \`selector\` does not match template \`labels\`
\`\`\`

## What changes

- \`mxlk8s.componentLabels\` now composes chart-identity labels (\`helm.sh/chart\`, \`app.kubernetes.io/managed-by\`, \`app.kubernetes.io/version\`, \`global.commonLabels\`) with \`mxlk8s.selectorLabels\` (per-component \`name\`, \`instance\`, \`component\`). \`mxlk8s.labels\` is left untouched and remains in use for chart-wide objects (\`namespace.yaml\`).
- Added a regression assertion in \`daemonset-agent_test.yaml\`, \`daemonset-gateway_test.yaml\`, and \`deployment-operator_test.yaml\` that pins \`spec.selector.matchLabels["app.kubernetes.io/name"]\` and \`spec.template.metadata.labels["app.kubernetes.io/name"]\` to the per-component value, so the next regression here fails \`helm unittest\`.

## Verification

- \`helm unittest charts/mxl-k8s -f 'tests/unit/*_test.yaml'\` -> 37 passed (3 new).
- \`helm lint charts/mxl-k8s\` -> clean.
- \`helm template\` against all five test scenarios (\`minimal-tcp\`, \`full-rdma\`, \`all-disabled\`, \`crds-only\`, \`custom-registry\`) renders without error.

closes #49