### PR TITLE
ci: gate ci.yml and images.yml jobs on per-component path filters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,69 @@ env:
   ENVTEST_K8S_VERSION: "1.31.0"
 
 jobs:
+  # Compute which downstream jobs actually need to run by comparing
+  # the PR (or push) diff against the per-module dependency map. The
+  # filters here are part of each module's "what depends on me"
+  # contract: if a module starts importing a sibling, that sibling
+  # must be added to the importing module's filter list so the test
+  # job re-runs when the dependency changes. See CLAUDE.md.
+  changes:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      api:          ${{ steps.f.outputs.api }}
+      ipc:          ${{ steps.f.outputs.ipc }}
+      operator:     ${{ steps.f.outputs.operator }}
+      agent:        ${{ steps.f.outputs.agent }}
+      gateway:      ${{ steps.f.outputs.gateway }}
+      generated:    ${{ steps.f.outputs.generated }}
+      ipc_proto:    ${{ steps.f.outputs.ipc_proto }}
+      pure_go:      ${{ steps.f.outputs.pure_go }}
+      workflow:     ${{ steps.f.outputs.workflow }}
+      test_modules: ${{ steps.m.outputs.test_modules }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: f
+        with:
+          # Each filter lists the path globs whose change forces the
+          # downstream jobs that consume this filter to run.
+          # operator/agent/gateway include api/** because all three
+          # import api/v1alpha1; ipc is currently imported by no Go
+          # code in this tree, so it propagates to its own checks
+          # only. Keep go.work* on every Go filter so a workspace
+          # bump retests every module.
+          filters: |
+            api:       ['api/**', 'go.work*']
+            ipc:       ['ipc/**', 'go.work*']
+            operator:  ['operator/**', 'api/**', 'go.work*']
+            agent:     ['agent/**', 'api/**', 'go.work*']
+            gateway:   ['gateway/**', 'api/**', 'go.work*']
+            generated: ['api/**', 'operator/**', 'Makefile']
+            ipc_proto: ['ipc/v1/control.proto', 'ipc/buf.*', 'Makefile']
+            pure_go:   ['api/**', 'ipc/**', 'operator/**', 'agent/**', 'go.work*']
+            workflow:  ['.github/workflows/ci.yml']
+      - id: m
+        # Build the JSON matrix of pure-Go modules whose tests need
+        # to re-run. A workflow-file change expands the set to
+        # everything (safer than guessing which jobs the edit
+        # touched).
+        run: |
+          set -eu
+          if [ '${{ steps.f.outputs.workflow }}' = 'true' ]; then
+            echo 'test_modules=["api","ipc","operator","agent"]' >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          modules='[]'
+          [ '${{ steps.f.outputs.api }}'      = 'true' ] && modules=$(jq -c '. + ["api"]'      <<<"$modules")
+          [ '${{ steps.f.outputs.ipc }}'      = 'true' ] && modules=$(jq -c '. + ["ipc"]'      <<<"$modules")
+          [ '${{ steps.f.outputs.operator }}' = 'true' ] && modules=$(jq -c '. + ["operator"]' <<<"$modules")
+          [ '${{ steps.f.outputs.agent }}'    = 'true' ] && modules=$(jq -c '. + ["agent"]'    <<<"$modules")
+          echo "test_modules=$modules" >> "$GITHUB_OUTPUT"
+
   lint:
+    needs: changes
+    if: needs.changes.outputs.pure_go == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -57,6 +119,8 @@ jobs:
   # docs/BUILD.md) when go-mxl ships a new release; renovate also
   # picks it up.
   gateway:
+    needs: changes
+    if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.5
@@ -84,6 +148,8 @@ jobs:
         run: cd gateway && go build ./...
 
   manifests-check:
+    needs: changes
+    if: needs.changes.outputs.generated == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -105,6 +171,8 @@ jobs:
           fi
 
   ipc-check:
+    needs: changes
+    if: needs.changes.outputs.ipc_proto == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
@@ -128,13 +196,17 @@ jobs:
   # The test job runs unit tests for every pure-Go module in a matrix.
   # Each shard produces a JUnit XML and a coverage profile; the report
   # job downloads them and publishes a single check + PR comment.
+  # The matrix is computed from the changes filter so only modules
+  # whose dependency set moved are exercised.
   test:
+    needs: changes
+    if: needs.changes.outputs.test_modules != '[]'
     runs-on: ubuntu-24.04
     timeout-minutes: 15
     strategy:
       fail-fast: false
       matrix:
-        module: [api, ipc, operator, agent]
+        module: ${{ fromJSON(needs.changes.outputs.test_modules) }}
     steps:
       - uses: actions/checkout@v6
 
@@ -196,6 +268,8 @@ jobs:
   # links libmxl + libmxl-fabrics. Tests themselves use mocked
   # interfaces, but the production code must still compile.
   test-gateway:
+    needs: changes
+    if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
       image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.5
@@ -233,11 +307,12 @@ jobs:
   # Aggregates per-module results into a single check + PR comment.
   # dorny/test-reporter publishes JUnit XML as a GitHub check with
   # per-failure source annotations. octocov consumes the coverage
-  # profiles and reports a per-package + total summary.
+  # profiles and reports a per-package + total summary. Skipped
+  # entirely when every test job upstream was skipped.
   report:
     needs: [test, test-gateway]
+    if: ${{ !cancelled() && (needs.test.result == 'success' || needs.test-gateway.result == 'success') }}
     runs-on: ubuntu-24.04
-    if: always()
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v6
@@ -259,3 +334,26 @@ jobs:
 
       - uses: k1LoW/octocov-action@v1
         if: hashFiles('bin/cover-*.out') != ''
+
+  # Branch-protection target. Always runs, succeeds only when every
+  # required upstream job is in `success` or `skipped` state. Without
+  # this gate, branch protection would need to enumerate every
+  # conditional job individually and would block PRs that legitimately
+  # skipped one (skipped checks count as "not satisfied" otherwise).
+  ci-summary:
+    needs: [changes, lint, gateway, manifests-check, ipc-check, test, test-gateway, report]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Verify upstream jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -eu
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          bad=$(echo "$NEEDS" | jq '[.[] | select(.result == "failure" or .result == "cancelled")] | length')
+          if [ "$bad" -ne 0 ]; then
+            echo "::error::$bad required job(s) failed or were cancelled"
+            exit 1
+          fi

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -12,6 +12,11 @@ on:
 permissions:
   contents: read
   packages: write
+  # dorny/paths-filter calls the PR Files API for pull_request
+  # events; without pull-requests:read GITHUB_TOKEN can't list the
+  # changed files and the action fails with
+  # "Resource not accessible by integration".
+  pull-requests: read
 
 concurrency:
   group: images-${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -18,20 +18,58 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Per-image filter for PR / push-to-main events. Each filter lists
+  # every input that the image's docker build context actually
+  # depends on. See CLAUDE.md for the contract: when a Dockerfile
+  # starts COPYing a new sibling module, that module must be added
+  # here so the image rebuilds on the dependency's changes.
+  # Tag-event builds bypass this filter entirely; a release tag is
+  # an explicit "publish this image now" signal regardless of diff.
+  changes:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      operator:   ${{ steps.f.outputs.operator }}
+      agent:      ${{ steps.f.outputs.agent }}
+      gateway:    ${{ steps.f.outputs.gateway }}
+      shim:       ${{ steps.f.outputs.shim }}
+      demo_tools: ${{ steps.f.outputs.demo_tools }}
+      workflow:   ${{ steps.f.outputs.workflow }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: f
+        with:
+          filters: |
+            operator:   ['docker/operator.Dockerfile', 'operator/**', 'api/**', 'go.work*']
+            agent:      ['docker/agent.Dockerfile', 'agent/**', 'api/**', 'go.work*']
+            gateway:    ['docker/gateway.Dockerfile', 'gateway/**', 'api/**', 'go.work*']
+            shim:       ['docker/shim.Dockerfile', 'shim/**']
+            demo_tools: ['docker/demo-tools.Dockerfile']
+            workflow:   ['.github/workflows/images.yml']
+
   # Compute the list of images to build and the registry references /
   # tag lists each image should be published under. Centralised here so
   # build and merge agree on what to publish.
   #
   # The images list is a JSON array consumed by the build matrix below.
-  # On main / PR all five images are included; on a per-component tag
-  # push (e.g. gateway/v1.2.3) only the matching image is included so
-  # an unrelated component's image isn't re-published.
+  # On a per-component tag push (e.g. gateway/v1.2.3) only the matching
+  # image is included. On main / PR events the list is filtered by the
+  # changes job; an unrelated diff publishes nothing.
   meta:
+    needs: changes
     runs-on: ubuntu-24.04
     outputs:
       images: ${{ steps.m.outputs.images }}
       push: ${{ steps.m.outputs.push }}
       has_images: ${{ steps.m.outputs.has_images }}
+    env:
+      CHANGED_OPERATOR:   ${{ needs.changes.outputs.operator }}
+      CHANGED_AGENT:      ${{ needs.changes.outputs.agent }}
+      CHANGED_GATEWAY:    ${{ needs.changes.outputs.gateway }}
+      CHANGED_SHIM:       ${{ needs.changes.outputs.shim }}
+      CHANGED_DEMO_TOOLS: ${{ needs.changes.outputs.demo_tools }}
+      CHANGED_WORKFLOW:   ${{ needs.changes.outputs.workflow }}
     steps:
       - id: m
         run: |
@@ -48,6 +86,20 @@ jobs:
             "shim|docker/shim.Dockerfile"
             "demo-tools|docker/demo-tools.Dockerfile"
           )
+
+          # Per-image change flags from the changes job. A workflow-
+          # file edit expands the set to all images so an edit cannot
+          # silently exclude an image from the publish surface.
+          declare -A wanted=(
+            [operator]="$CHANGED_OPERATOR"
+            [agent]="$CHANGED_AGENT"
+            [gateway]="$CHANGED_GATEWAY"
+            [shim]="$CHANGED_SHIM"
+            [demo-tools]="$CHANGED_DEMO_TOOLS"
+          )
+          if [ "$CHANGED_WORKFLOW" = "true" ]; then
+            for k in "${!wanted[@]}"; do wanted[$k]=true; done
+          fi
 
           push=false
           selected=""
@@ -79,15 +131,20 @@ jobs:
           fi
 
           # Build the images JSON. For fork PRs (push=false) we still
-          # include every image so the build matrix exercises every
-          # Dockerfile; just nothing gets pushed.
+          # include every image we'd otherwise build so the matrix
+          # exercises the Dockerfiles; nothing gets pushed.
           images='['
           first=true
           for entry in "${all[@]}"; do
             name="${entry%%|*}"
             dockerfile="${entry#*|}"
-            if [ -n "$selected" ] && [ "$name" != "$selected" ]; then
-              continue
+            if [ -n "$selected" ]; then
+              # Tag-driven release: include only the matching image.
+              if [ "$name" != "$selected" ]; then continue; fi
+            else
+              # Push/PR: respect the per-image filter from the changes
+              # job. Unaffected images skip the build entirely.
+              if [ "${wanted[$name]:-false}" != "true" ]; then continue; fi
             fi
             image="${prefix}/${name}"
             tags=""
@@ -237,3 +294,26 @@ jobs:
         run: |
           first=$(echo '${{ matrix.image.tags }}' | cut -d, -f1)
           docker buildx imagetools inspect "$first"
+
+  # Branch-protection target. Always runs, succeeds only when every
+  # required upstream job is in `success` or `skipped` state. Without
+  # this gate, branch protection would need to enumerate every
+  # conditional job individually and would block PRs that legitimately
+  # skipped one.
+  images-summary:
+    needs: [changes, meta, build, merge]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Verify upstream jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -eu
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          bad=$(echo "$NEEDS" | jq '[.[] | select(.result == "failure" or .result == "cancelled")] | length')
+          if [ "$bad" -ne 0 ]; then
+            echo "::error::$bad required job(s) failed or were cancelled"
+            exit 1
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -214,6 +214,25 @@ the work that produced it. The same rules apply to PR descriptions.
   a coverage summary via `octocov`. Both run in the `report` job that
   fans in artifacts from the per-module test jobs.
 
+## CI path filters
+
+`ci.yml` and `images.yml` each open with a `changes` job
+(`dorny/paths-filter@v3`) that scopes every downstream job to the
+diff. Two consequences for contributors:
+
+- The filter list is part of each module's "what depends on me"
+  contract. If a Go module starts importing a sibling that it
+  didn't before, that sibling's path glob must be added to the
+  importing module's filter in `ci.yml`. Same for `images.yml`:
+  if a Dockerfile starts COPYing a sibling module, that module
+  goes on the image's filter. Without the update the dependent
+  job stops re-running when its dependency moves.
+- Branch protection requires only the `ci-summary` / `images-
+  summary` jobs (which run unconditionally and fail iff any
+  required upstream is in `failure` / `cancelled`). Do not add
+  individual conditional jobs to the required-checks list -- a
+  skipped check on an unrelated diff would block the PR.
+
 ## When in doubt
 
 Ask the maintainer before changing the public Go API of `api` or `ipc`,


### PR DESCRIPTION
Both CI workflows ran every job on every PR/push regardless of
diff scope. A doc-only PR rebuilt all five multi-arch images and
reran the full Go test matrix. With `chart.yml` already path-
scoped this was the last remaining fan-out left untrimmed.

## What changes

- **`changes` job at the top of each workflow** uses
  `dorny/paths-filter@v3` to map the diff to per-component flags.
  Each filter is the union of paths the downstream job actually
  consumes -- `operator`, `agent`, `gateway` each include
  `api/**` because all three import `api/v1alpha1`; `ipc` is
  imported by no Go code in this tree, so it propagates to its
  own checks only.
- **`ci.yml`**: `lint`, `gateway`, `manifests-check`,
  `ipc-check`, `test-gateway` gate on `if:`. The `test` matrix is
  built dynamically from a `test_modules` JSON output, so only
  changed pure-Go modules get exercised. `report` skips when no
  test job produced artefacts.
- **`images.yml`**: the `meta` job filters the image list to
  those whose docker context (Dockerfile + the modules it COPYs)
  changed. Tag-event publishes bypass the filter entirely -- a
  release tag is an explicit "publish this image now" signal
  regardless of diff scope.
- **`ci-summary` / `images-summary`** always run, fail iff any
  required upstream is in `failure` / `cancelled`. Skipped is
  fine. Branch protection should require only these summaries.

## CLAUDE.md note

A new `## CI path filters` subsection names the filter list as
each module's "what depends on me" contract: if a Go module
starts importing a sibling, that sibling's glob must be added to
the importing module's filter; if a Dockerfile starts `COPY`ing
a sibling, that sibling goes on the image's filter. Also records
the branch-protection guidance (require only the summary jobs).

## Expected wall-clock savings

- doc-only PR: every Go and image job skipped (only summaries
  run). ~30s instead of ~15 min.
- chart-only PR: `ci.yml` Go jobs skipped, images skipped,
  `chart.yml` runs as today. Saves ~10 min.
- single-module PR (e.g. only `agent/**`): that module's test
  cell + that image build; the other three modules and four
  images skip. Saves ~7-10 min.

## Branch-protection action item for the maintainer

After this merges, update the required-checks list to:

- `ci-summary` (replaces `lint`, `gateway`, `manifests-check`,
  `ipc-check`, `test`, `test-gateway`, `report`)
- `images-summary` (replaces `meta`, `build`, `merge`)

Other workflows (`chart.yml`, `release-please.yml`) are
unchanged.

## Verification

Both workflows parse cleanly (`python3 -c "import yaml;
yaml.safe_load(...)"`). Real timing comes from the first PRs
after merge; the wall-clock claims above are based on the
existing per-job durations.