### PR TITLE
ci: publish component images via release-please workflow_call

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -3,11 +3,33 @@ name: images
 on:
   push:
     branches: [main]
-    # Per-component release tags (e.g. gateway/v0.0.1, api/v1.2.3).
-    # release-please produces these with the slash separator so they
-    # double as Go submodule version tags.
+    # Manual escape hatch: a developer pushing a tag from a shell.
+    # release-please-driven publishes go through workflow_call from
+    # release-please.yml because tags created by GITHUB_TOKEN do not
+    # start downstream workflow runs.
     tags: ['*/v*.*.*']
   pull_request:
+  # Invoked from release-please.yml once a per-component release
+  # tag has just been cut (operator/agent/gateway/shim). The tag
+  # is passed in via release_tag; meta resolves the image to
+  # publish from the tag's prefix.
+  workflow_call:
+    inputs:
+      release_tag:
+        description: "Per-component release tag (e.g. agent/v1.0.0-rc.2)"
+        type: string
+        required: true
+  # Manual recovery: re-run an image publish without waiting for a
+  # new tag. Leave release_tag empty to build the :dev / :sha-X
+  # tags for the current main, or pass <component>/v<X> to
+  # republish that exact tag.
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Per-component release tag (e.g. agent/v1.0.0-rc.2). Leave empty for a dev build of HEAD."
+        type: string
+        required: false
+        default: ""
 
 permissions:
   contents: read
@@ -31,6 +53,11 @@ jobs:
   # Tag-event builds bypass this filter entirely; a release tag is
   # an explicit "publish this image now" signal regardless of diff.
   changes:
+    # Diff-based filtering only makes sense for PR / push-to-branch
+    # events. Tag pushes, workflow_call and workflow_dispatch carry
+    # an explicit release_tag (or the dev-build sentinel) and
+    # bypass the per-image filter in meta.
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref_type == 'branch')
     runs-on: ubuntu-24.04
     timeout-minutes: 2
     outputs:
@@ -54,27 +81,38 @@ jobs:
             workflow:   ['.github/workflows/images.yml']
 
   # Compute the list of images to build and the registry references /
-  # tag lists each image should be published under. Centralised here so
-  # build and merge agree on what to publish.
+  # tag lists each image should be published under. Centralised here
+  # so build and merge agree on what to publish.
   #
-  # The images list is a JSON array consumed by the build matrix below.
-  # On a per-component tag push (e.g. gateway/v1.2.3) only the matching
-  # image is included. On main / PR events the list is filtered by the
-  # changes job; an unrelated diff publishes nothing.
+  # The images list is a JSON array consumed by the build matrix
+  # below. On a per-component tag push or a workflow_call/dispatch
+  # carrying release_tag, only the matching image is included. On
+  # main / PR events the list is filtered by the changes job; an
+  # unrelated diff publishes nothing.
   meta:
     needs: changes
+    # changes is skipped for tag pushes, workflow_call and
+    # workflow_dispatch (none of those rely on diff-based filtering),
+    # so meta must run even when its dependency was skipped.
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     outputs:
       images: ${{ steps.m.outputs.images }}
       push: ${{ steps.m.outputs.push }}
       has_images: ${{ steps.m.outputs.has_images }}
     env:
-      CHANGED_OPERATOR:   ${{ needs.changes.outputs.operator }}
-      CHANGED_AGENT:      ${{ needs.changes.outputs.agent }}
-      CHANGED_GATEWAY:    ${{ needs.changes.outputs.gateway }}
-      CHANGED_SHIM:       ${{ needs.changes.outputs.shim }}
-      CHANGED_DEMO_TOOLS: ${{ needs.changes.outputs.demo_tools }}
-      CHANGED_WORKFLOW:   ${{ needs.changes.outputs.workflow }}
+      INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+      # When `changes` is skipped, needs.changes.outputs.<x> is the
+      # empty string. Defaulting to 'true' falls back to "build it"
+      # for the no-filter case (manual workflow_dispatch dev build);
+      # tag / release_tag paths bypass the wanted check entirely via
+      # `selected`.
+      CHANGED_OPERATOR:   ${{ needs.changes.outputs.operator   || 'true' }}
+      CHANGED_AGENT:      ${{ needs.changes.outputs.agent      || 'true' }}
+      CHANGED_GATEWAY:    ${{ needs.changes.outputs.gateway    || 'true' }}
+      CHANGED_SHIM:       ${{ needs.changes.outputs.shim       || 'true' }}
+      CHANGED_DEMO_TOOLS: ${{ needs.changes.outputs.demo_tools || 'true' }}
+      CHANGED_WORKFLOW:   ${{ needs.changes.outputs.workflow   || 'false' }}
     steps:
       - id: m
         run: |
@@ -110,23 +148,38 @@ jobs:
           selected=""
           declare -a extra_tags=()
 
-          if [ "$GITHUB_EVENT_NAME" = "push" ]; then
+          # tag_release applies the version-tag publish convention
+          # (:v<X>, plus :latest or :pre) from a "<component>/v<X>"
+          # ref. Shared by direct tag pushes and the release_tag
+          # input path so both produce identical tag lists.
+          tag_release() {
+            local ref="$1" version
+            selected="${ref%%/*}"
+            version="${ref#*/v}"
+            extra_tags+=("v${version}")
+            case "$version" in
+              *-*) extra_tags+=("pre") ;;
+              *)   extra_tags+=("latest") ;;
+            esac
+          }
+
+          if [ -n "${INPUT_RELEASE_TAG:-}" ]; then
+            push=true
+            case "$INPUT_RELEASE_TAG" in
+              */v*.*.*) ;;
+              *)
+                echo "::error::release_tag '${INPUT_RELEASE_TAG}' is not a <component>/v<X.Y.Z> tag"
+                exit 1
+                ;;
+            esac
+            tag_release "$INPUT_RELEASE_TAG"
+          elif [ "$GITHUB_EVENT_NAME" = "push" ]; then
             push=true
             if [ "$GITHUB_REF_TYPE" = "tag" ]; then
-              # refs/tags/<component>/v<version>
-              ref="$GITHUB_REF_NAME"
-              selected="${ref%%/*}"
-              version="${ref#*/v}"
-              extra_tags+=("v${version}")
-              case "$version" in
-                # SemVer prereleases (anything with a dash after the
-                # MAJOR.MINOR.PATCH triplet) move :pre, not :latest.
-                *-*) extra_tags+=("pre") ;;
-                *)   extra_tags+=("latest") ;;
-              esac
+              tag_release "$GITHUB_REF_NAME"
             else
-              # Push to main: :dev always tracks HEAD; :sha-<short> is
-              # the content-addressed handle.
+              # Push to main: :dev always tracks HEAD; :sha-<short>
+              # is the content-addressed handle.
               extra_tags+=("dev" "sha-${short_sha}")
             fi
           elif [ "$GITHUB_EVENT_NAME" = "pull_request" ] \

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -102,6 +102,11 @@ jobs:
       has_images: ${{ steps.m.outputs.has_images }}
     env:
       INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+      # head_commit is present on push events; empty otherwise. Used
+      # to detect release-please's own merge commits and defer their
+      # image publish to the workflow_call run that release-please.yml
+      # fires alongside, so the same content isn't built twice.
+      HEAD_COMMIT_MSG: ${{ github.event.head_commit.message }}
       # When `changes` is skipped, needs.changes.outputs.<x> is the
       # empty string. Defaulting to 'true' falls back to "build it"
       # for the no-filter case (manual workflow_dispatch dev build);
@@ -173,19 +178,51 @@ jobs:
                 ;;
             esac
             tag_release "$INPUT_RELEASE_TAG"
+            # This run IS the release publish for the matching
+            # component. The push-to-main run that fired alongside is
+            # skipped (see the release-please-commit detection below),
+            # so add :dev and :sha-<short> here too. The commit being
+            # tagged is the current main HEAD by release-please's
+            # construction, so :dev tracking HEAD stays consistent.
+            extra_tags+=("dev" "sha-${short_sha}")
           elif [ "$GITHUB_EVENT_NAME" = "push" ]; then
-            push=true
             if [ "$GITHUB_REF_TYPE" = "tag" ]; then
+              push=true
               tag_release "$GITHUB_REF_NAME"
             else
-              # Push to main: :dev always tracks HEAD; :sha-<short>
-              # is the content-addressed handle.
-              extra_tags+=("dev" "sha-${short_sha}")
+              # Push to main: :dev tracks HEAD; :sha-<short> is the
+              # content-addressed handle. Defer release-please's own
+              # merge commits to the workflow_call invocation from
+              # release-please.yml so the same content isn't built
+              # twice (push-to-main run alongside workflow_call run).
+              # release-please's PR titles always start with
+              # "chore(main): release "; the squash-merge subject
+              # carries that prefix verbatim.
+              case "${HEAD_COMMIT_MSG%%$'\n'*}" in
+                "chore(main): release "*)
+                  echo "Release-please merge commit; image publish deferred to workflow_call from release-please.yml."
+                  push=false
+                  # Empty the wanted set so the loop below produces
+                  # an empty images list and build/merge skip.
+                  for k in "${!wanted[@]}"; do wanted[$k]=false; done
+                  ;;
+                *)
+                  push=true
+                  extra_tags+=("dev" "sha-${short_sha}")
+                  ;;
+              esac
             fi
           elif [ "$GITHUB_EVENT_NAME" = "pull_request" ] \
               && [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
             push=true
             extra_tags+=("pr-${{ github.event.number }}-${short_sha}")
+          elif [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            # Manual recovery with an empty release_tag: republish
+            # :dev and :sha-<short> for the current HEAD on every
+            # image. Same effect as a push-to-main run, but on
+            # demand.
+            push=true
+            extra_tags+=("dev" "sha-${short_sha}")
           fi
 
           # Build the images JSON. For fork PRs (push=false) we still

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -28,8 +28,16 @@ jobs:
   release-please:
     runs-on: ubuntu-24.04
     outputs:
-      chart_released: ${{ steps.rp.outputs['charts/mxl-k8s--release_created'] }}
-      chart_tag:      ${{ steps.rp.outputs['charts/mxl-k8s--tag_name'] }}
+      chart_released:    ${{ steps.rp.outputs['charts/mxl-k8s--release_created'] }}
+      chart_tag:         ${{ steps.rp.outputs['charts/mxl-k8s--tag_name'] }}
+      operator_released: ${{ steps.rp.outputs['operator--release_created'] }}
+      operator_tag:      ${{ steps.rp.outputs['operator--tag_name'] }}
+      agent_released:    ${{ steps.rp.outputs['agent--release_created'] }}
+      agent_tag:         ${{ steps.rp.outputs['agent--tag_name'] }}
+      gateway_released:  ${{ steps.rp.outputs['gateway--release_created'] }}
+      gateway_tag:       ${{ steps.rp.outputs['gateway--tag_name'] }}
+      shim_released:     ${{ steps.rp.outputs['shim--release_created'] }}
+      shim_tag:          ${{ steps.rp.outputs['shim--tag_name'] }}
     steps:
       - id: rp
         uses: googleapis/release-please-action@v5
@@ -52,3 +60,52 @@ jobs:
     uses: ./.github/workflows/chart.yml
     with:
       release_tag: ${{ needs.release-please.outputs.chart_tag }}
+
+  # Per-component image publishes. Same workflow_call-instead-of-
+  # tag-event reason as the chart above: tags pushed by GITHUB_TOKEN
+  # do not start downstream runs, so images.yml has to be invoked
+  # directly. Each job is gated on its component's release_created
+  # so an unrelated release cycle costs nothing.
+  publish-operator-image:
+    needs: [release-please]
+    if: needs.release-please.outputs.operator_released == 'true'
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: read
+    uses: ./.github/workflows/images.yml
+    with:
+      release_tag: ${{ needs.release-please.outputs.operator_tag }}
+
+  publish-agent-image:
+    needs: [release-please]
+    if: needs.release-please.outputs.agent_released == 'true'
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: read
+    uses: ./.github/workflows/images.yml
+    with:
+      release_tag: ${{ needs.release-please.outputs.agent_tag }}
+
+  publish-gateway-image:
+    needs: [release-please]
+    if: needs.release-please.outputs.gateway_released == 'true'
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: read
+    uses: ./.github/workflows/images.yml
+    with:
+      release_tag: ${{ needs.release-please.outputs.gateway_tag }}
+
+  publish-shim-image:
+    needs: [release-please]
+    if: needs.release-please.outputs.shim_released == 'true'
+    permissions:
+      contents: read
+      packages: write
+      pull-requests: read
+    uses: ./.github/workflows/images.yml
+    with:
+      release_tag: ${{ needs.release-please.outputs.shim_tag }}


### PR DESCRIPTION
## Root cause

`images.yml` listened on tag pushes for per-component release
tags (`*/v*.*.*`), but release-please-action creates those tags
with `GITHUB_TOKEN`, and tag pushes by `GITHUB_TOKEN` do **not**
start downstream workflow runs (documented GitHub limitation).
Result: every release-please-cut component tag since rc.1
landed in git, but `images.yml` never fired and ghcr.io is left
with only `:dev`, `:sha-X`, and `:pr-N` tags. No `:v1.0.0-rc.x`,
no `:pre`.

`chart.yml` has had the same limitation since day one and
already routes around it via `workflow_call` from
`release-please.yml`. This PR mirrors that pattern for
component images.

## Changes

- `images.yml` gains a `workflow_call` entry-point with a
  `release_tag` input (e.g. `agent/v1.0.0-rc.2`) and a
  `workflow_dispatch` one for manual recovery. `meta` resolves
  the image to publish from the tag prefix and the version tag
  list (`:v<X>` plus `:pre` or `:latest`) from its suffix.
  Direct tag pushes and the new input path share a
  `tag_release` helper so they produce identical tag lists.
- `changes` (paths-filter) is now gated to PR / push-to-branch
  events. Tag pushes, `workflow_call`, and `workflow_dispatch`
  skip it because they carry an explicit `release_tag` (or, for
  dispatch with no tag, fall through to a dev build). `meta` is
  `if: !cancelled()` and falls back to `'true'` defaults on
  `CHANGED_*` so it runs cleanly when `changes` was skipped.
- `release-please.yml` exposes per-component
  `release_created` / `tag_name` outputs and adds
  `publish-{operator,agent,gateway,shim}-image` jobs that
  `workflow_call` `images.yml` with the matching tag. Each is
  gated on its component's `release_created`; unrelated release
  cycles cost nothing.

## After this lands

Every new release-please-cut component tag also publishes the
corresponding image's `:v<version>` and `:pre` (or `:latest` for
stable) tags. No code change to any module.

## Backfilling the existing missing tags

Tags that landed without a matching image publish:

```
agent/v1.0.0-rc.1   agent/v1.0.0-rc.2
gateway/v1.0.0-rc.1 gateway/v1.0.0-rc.2
operator/v1.0.0-rc.1
shim/v1.0.0-rc.1    shim/v1.0.0-rc.2
```

Backfill per tag via the workflow_dispatch entry-point:

```sh
gh workflow run images.yml -f release_tag=agent/v1.0.0-rc.2
gh workflow run images.yml -f release_tag=gateway/v1.0.0-rc.2
# one invocation per tag
```

## Verification

Both workflow YAMLs parse cleanly. Real verification comes from
the next release-please-cut component tag after this merges.