### PR TITLE
ci(images): build the release_tag's commit, not the workflow's ref

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -283,7 +283,16 @@ jobs:
     runs-on: ${{ matrix.runner.runs_on }}
     timeout-minutes: 60
     steps:
+      # When invoked with a release_tag (workflow_call from release-
+      # please.yml or workflow_dispatch backfilling a missed tag),
+      # check out the tag's commit rather than the workflow's
+      # triggering ref. The default ref is main HEAD, which can have
+      # drifted from the tag's content; building from there would
+      # publish "v<X>" tags pointing at a binary that isn't the
+      # tag's source.
       - uses: actions/checkout@v6
+        with:
+          ref: ${{ inputs.release_tag || github.ref }}
 
       - uses: docker/setup-buildx-action@v4
 


### PR DESCRIPTION
The build job's `actions/checkout` used the default ref. For the
`workflow_call` path that release-please.yml invokes right after
creating a tag this is fine -- main HEAD and the tag's commit
are the same SHA at that moment. For manual `workflow_dispatch`
backfill of an older tag they aren't: main may have moved on
between the tag and the backfill, and a build from main would
publish `:v<X>` image tags whose content doesn't match the git
tag's source.

Concrete trigger: backfilling `agent:v1.0.0-rc.2` from main HEAD
would include the access/stat/open shim-hook fix that was
merged after the tag was cut, which is exactly not what
`agent:v1.0.0-rc.2` should ship.

Fix: pass `ref: ${{ inputs.release_tag || github.ref }}` so the
checkout follows the release_tag input when present and falls
back to the natural ref otherwise. The workflow file itself is
still loaded from main (via the dispatch / call ref), so this
doesn't reintroduce the "old tag has no workflow_dispatch
trigger" problem.

Needed before backfilling the seven currently-missing image
tags via `gh workflow run images.yml -f release_tag=...`.