### PR TITLE
ci(images): fix build/merge skip on workflow_call and isolate concurrency per release_tag

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -41,7 +41,11 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: images-${{ github.workflow }}-${{ github.ref }}
+  # Include release_tag so distinct workflow_call / workflow_dispatch
+  # backfills (one per component tag) get their own queue slot and
+  # don't cancel each other. PR / push / tag-event invocations key
+  # on the ref as before.
+  group: images-${{ github.workflow }}-${{ inputs.release_tag || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
@@ -272,7 +276,12 @@ jobs:
   # two arches into one multi-arch manifest list per tag.
   build:
     needs: meta
-    if: needs.meta.outputs.has_images == 'true'
+    # `!cancelled()` defeats the implicit success() check on needs.
+    # Without it, build would be skipped whenever a transitive need
+    # (the changes job, which is skipped for tag / workflow_call /
+    # workflow_dispatch events) was non-success, even though the
+    # explicit condition below would otherwise have run it.
+    if: ${{ !cancelled() && needs.meta.outputs.has_images == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -352,7 +361,7 @@ jobs:
   # manifest list, applying the full tag list computed by meta.
   merge:
     needs: [meta, build]
-    if: needs.meta.outputs.push == 'true' && needs.meta.outputs.has_images == 'true'
+    if: ${{ !cancelled() && needs.meta.outputs.push == 'true' && needs.meta.outputs.has_images == 'true' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false


### PR DESCRIPTION
Two distinct bugs surfaced when backfilling the missing component
image tags via `workflow_dispatch`. Both block the backfill path
and the regular workflow_call publish from release-please.yml.

## Bug 1: build/merge skip even when meta says has_images=true

The seven backfill dispatches I fired produced one of two
outcomes per run: cancelled (five of them, see Bug 2) or
"success with nothing built". On the latter, `meta`'s output
JSON included a valid one-element images list and
`has_images: "true"`, but `build` was skipped anyway -- so
ghcr.io still has no `:v<X>` tags for any component.

Root cause: GitHub Actions adds an implicit `success()` check on
top of any `if:` that doesn't itself contain a status function
(`success()`, `!cancelled()`, `failure()`, `always()`). With
`changes` skipped (intentional on tag / workflow_call /
workflow_dispatch events), the transitive needs chain has a
non-success entry, so the implicit `success()` fails, so `build`
is skipped regardless of what `has_images` says. `images-
summary` is unaffected because it already has `!cancelled()` --
which is how the pattern got identified.

Fix: prepend `!cancelled() &&` to the `if:` on `build` and
`merge`. The explicit status function disables the implicit
`success()` check.

## Bug 2: concurrency group cancelled five of seven backfills

Dispatching seven backfills in succession (one per missing
component tag) ended with only the first dispatched
(operator/v1.0.0-rc.1) and the last dispatched
(shim/v1.0.0-rc.2) actually running. Five in the middle were
cancelled with "Canceling since a higher priority waiting
request for images-images-refs/heads/main exists".

Root cause: `concurrency.group: images-...-${{ github.ref }}`.
Every dispatch from main has `github.ref = refs/heads/main`, so
all seven landed in the same group. With `cancel-in-progress:
false` the in-progress run keeps going, but only the most
recently queued waiting slot is kept; older queued slots get
cancelled. Result: dispatch 1 runs to completion, dispatches
2-6 get cancelled by 3-7 respectively, dispatch 7 runs after
dispatch 1 finishes.

Fix: include `inputs.release_tag` in the group key so distinct
backfills get separate queues. PR / push / tag-event paths fall
through to `github.ref` as before (no behaviour change for
those).

## After this merges

Re-dispatch the seven backfill commands; each gets its own
concurrency slot and actually publishes its `:v<X>` (plus `:pre`
for prereleases). I'll fire them again from main once this
lands.