### PR TITLE
docs: correct EFA instance-type requirement for the gateway

### DIFF
--- a/docs/RDMA.md
+++ b/docs/RDMA.md
@@ -81,9 +81,16 @@ host setup is AWS-specific.
 - `/dev/infiniband/uverbs0` is present once the module is loaded;
   no PFC or DSCP knobs to fuss with (EFA is its own protocol on
   the Nitro fabric).
-- Use one of the EFA-capable instance families. AWS publishes
-  the list per-region; broadly anything in the `c5n`, `c6gn`,
-  `c7gn`, `p4d`, `p5`, `m5dn`, `r5n` families and several others.
+- libmxl-fabrics moves grains over one-sided RDMA writes: the
+  initiator registers its source region with `FI_WRITE` and the
+  target registers its destination region with `FI_REMOTE_WRITE`.
+  EFA support alone is therefore not sufficient -- the instance
+  must also support RDMA write. Pick a row whose RDMA-write
+  column reads `Yes` in AWS's [Supported instance types
+  table](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types).
+  Setting up a flow on an EFA-enabled instance without RDMA-write
+  support fails at memory-region registration; upstream context
+  is in [dmf-mxl/mxl#516](https://github.com/dmf-mxl/mxl/issues/516).
 
 ### Per-pod
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -267,7 +267,9 @@ selects the libmxl-fabrics provider for the cross-node transfer:
 - `verbs`: Linux verbs / `librdmacm` / RoCE / InfiniBand. Needs
   RDMA hardware, kernel modules, and `/dev/infiniband`. See
   [`docs/RDMA.md`](./RDMA.md).
-- `efa`: AWS Elastic Fabric Adapter. Needs EFA-capable instances.
+- `efa`: AWS Elastic Fabric Adapter. Host setup and the
+  instance-type requirement (EFA support alone is not enough)
+  are documented in [`docs/RDMA.md`](./RDMA.md).
 - `shm`: host-local shared memory. Used between gateway endpoints
   that share a node.
 - `auto`: let libmxl-fabrics pick a provider at runtime.


### PR DESCRIPTION
The previous EFA prerequisite bullet in `docs/RDMA.md` listed
several Nitro v3 families (`c5n`, `m5dn`, `r5n`, ...) as suitable
EFA-capable hosts. EFA capability and RDMA-write capability are
separate properties of an EC2 instance, and libmxl-fabrics moves
grains over one-sided RDMA writes (`FI_WRITE` on the initiator,
`FI_REMOTE_WRITE` on the target). On instances that advertise EFA
without RDMA-write support the gateway fails at memory-region
registration.

Replace the family list with a pointer at the per-instance table
AWS publishes, name the column to filter on, and link the
upstream issue tracking the failure mode
([dmf-mxl/mxl#516](https://github.com/dmf-mxl/mxl/issues/516)).
`docs/USAGE.md` drops the free-standing "Needs EFA-capable
instances" sentence and defers to `docs/RDMA.md` so the
requirement lives in one place.