### PR TITLE
feat(kind): add BUILD flag to kind-up for local vs CI image modes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -213,14 +213,26 @@ mocks-check: mocks
 # Override the cluster name with KIND_CLUSTER=<name>.
 # Use Podman instead of Docker: CONTAINER_RUNTIME=podman
 #   e.g. `make kind-up CONTAINER_RUNTIME=podman`
+#
+# Image source selector (BUILD):
+#   unset / BUILD=local  build the five component images locally and
+#                        kind-load them (existing behaviour).
+#   BUILD=<tag>          skip the local build; pull
+#                        ghcr.io/<owner>/mxl-k8s/<component>:<tag> for
+#                        every component, kind-load it, and rewrite
+#                        the demo manifests to reference it.
+#   e.g. `make kind-up BUILD=sha-abc1234`
+#        `make kind-up BUILD=v1.0.0-rc.3`
 
 KIND_CLUSTER ?= mxl-k8s-demo
 # Container runtime: "docker" (default) or "podman".
 CONTAINER_RUNTIME ?= docker
+# Image source: "local" (default) or a CI-produced image tag.
+BUILD ?= local
 
 .PHONY: kind-up
 kind-up:
-	KIND_CLUSTER=$(KIND_CLUSTER) CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) bash hack/kind-up.sh
+	KIND_CLUSTER=$(KIND_CLUSTER) CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) BUILD=$(BUILD) bash hack/kind-up.sh
 
 .PHONY: kind-down
 kind-down:

--- a/docs/KIND.md
+++ b/docs/KIND.md
@@ -134,3 +134,30 @@ make kind-down   CONTAINER_RUNTIME=podman
 With Podman the machine must be rootful and have enough memory
 for a three-node cluster; `kind-up.sh` checks this and prints
 the fix command if either condition isn't met.
+
+## Image source (`BUILD`)
+
+`make kind-up` builds the five component images locally by default
+and `kind load`s them into the cluster. This is `BUILD=local` (or
+`BUILD` unset).
+
+To skip the local build and use a CI-published image instead, pass
+the image tag:
+
+```sh
+make kind-up BUILD=v1.0.0-rc.3
+make kind-up BUILD=sha-abc1234
+```
+
+`kind-up.sh` resolves every component to
+`ghcr.io/qvest-digital/mxl-k8s/<component>:<BUILD>`, pulls it,
+loads it into KIND, and rewrites the rendered demo manifests so
+the workloads pull the same reference. Override the registry
+prefix with `IMAGE_REGISTRY=<prefix>` if needed.
+
+Empty or otherwise invalid `BUILD` values exit non-zero before
+any side effects:
+
+```
+ERROR: BUILD must be 'local' or a non-empty image tag
+```

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -14,14 +14,44 @@
 #
 # Set CONTAINER_RUNTIME=podman (or pass via the Makefile) to use
 # Podman instead of Docker.
+#
+# Set BUILD=<tag> to skip the local image build and use CI-produced
+# images instead. With BUILD unset or BUILD=local (the default) the
+# script builds the five component images locally as before. With
+# BUILD=<tag> the script pulls
+# ghcr.io/<owner>/mxl-k8s/<component>:<tag> for every component,
+# kind-loads it, and rewrites the demo manifests to reference it
+# via a generated kustomize overlay.
+#
+# Set IMAGE_REGISTRY=<prefix> to override the registry prefix used
+# in BUILD=<tag> mode. Default is ghcr.io/qvest-digital/mxl-k8s.
 
 set -euo pipefail
 
 CLUSTER_NAME="${KIND_CLUSTER:-mxl-k8s-demo}"
 CONTAINER_RUNTIME="${CONTAINER_RUNTIME:-docker}"
+BUILD="${BUILD-local}"
+IMAGE_REGISTRY="${IMAGE_REGISTRY:-ghcr.io/qvest-digital/mxl-k8s}"
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)"
 KIND_CONFIG="${REPO_ROOT}/hack/kind-config.yaml"
 KUBECTL=(kubectl --context "kind-${CLUSTER_NAME}")
+
+# Validate BUILD before any side effects. Empty string is rejected;
+# "local" enables the local-build path; anything else is treated as
+# a CI image tag.
+case "$BUILD" in
+  "")
+    echo "ERROR: BUILD must be 'local' or a non-empty image tag" >&2
+    exit 2
+    ;;
+  local)
+    BUILD_MODE=local
+    ;;
+  *)
+    BUILD_MODE=tag
+    BUILD_TAG="$BUILD"
+    ;;
+esac
 
 # When using podman, tell KIND to use the podman provider.
 if [[ "$CONTAINER_RUNTIME" == "podman" ]]; then
@@ -31,6 +61,9 @@ fi
 MIRROR_TIMEOUT_SECS="${MIRROR_TIMEOUT_SECS:-180}"
 ROLLOUT_TIMEOUT_SECS="${ROLLOUT_TIMEOUT_SECS:-300}"
 
+# Parallel arrays: Dockerfile / local dev tag / CI component name /
+# image reference as it appears in examples/*-demo manifests. Kept
+# index-aligned so bash 3.2 (no associative arrays) can iterate them.
 IMAGE_DOCKERFILES=(
   docker/operator.Dockerfile
   docker/agent.Dockerfile
@@ -38,13 +71,34 @@ IMAGE_DOCKERFILES=(
   docker/shim.Dockerfile
   docker/demo-tools.Dockerfile
 )
-IMAGE_TAGS=(
+IMAGE_LOCAL_TAGS=(
   local/mxl-operator:dev
   local/mxl-domain-agent:dev
   local/mxl-fabrics-gateway:dev
   local/mxl-shim:dev
   local/mxl-demo-tools:dev
 )
+IMAGE_COMPONENTS=(
+  operator
+  agent
+  gateway
+  shim
+  demo-tools
+)
+
+# Resolve the image-tag list this run actually loads into KIND.
+# In local mode this is IMAGE_LOCAL_TAGS verbatim. In tag mode it
+# becomes ghcr.io/<owner>/mxl-k8s/<component>:<BUILD_TAG>.
+IMAGE_TAGS=()
+if [[ "$BUILD_MODE" == "local" ]]; then
+  for tag in "${IMAGE_LOCAL_TAGS[@]}"; do
+    IMAGE_TAGS+=("$tag")
+  done
+else
+  for comp in "${IMAGE_COMPONENTS[@]}"; do
+    IMAGE_TAGS+=("${IMAGE_REGISTRY}/${comp}:${BUILD_TAG}")
+  done
+fi
 
 log()  { printf '\n=== %s ===\n' "$*" >&2; }
 need() { command -v "$1" >/dev/null 2>&1 || { echo "missing required tool: $1" >&2; exit 1; }; }
@@ -67,14 +121,23 @@ if [[ "$CONTAINER_RUNTIME" == "podman" ]]; then
   fi
 fi
 
-log "Building images"
-cd "$REPO_ROOT"
-for i in "${!IMAGE_DOCKERFILES[@]}"; do
-  dockerfile="${IMAGE_DOCKERFILES[$i]}"
-  tag="${IMAGE_TAGS[$i]}"
-  echo "  -> ${tag}"
-  $CONTAINER_RUNTIME build -q -f "${dockerfile}" -t "${tag}" . > /dev/null
-done
+if [[ "$BUILD_MODE" == "local" ]]; then
+  log "Building images"
+  cd "$REPO_ROOT"
+  for i in "${!IMAGE_DOCKERFILES[@]}"; do
+    dockerfile="${IMAGE_DOCKERFILES[$i]}"
+    tag="${IMAGE_TAGS[$i]}"
+    echo "  -> ${tag}"
+    $CONTAINER_RUNTIME build -q -f "${dockerfile}" -t "${tag}" . > /dev/null
+  done
+else
+  log "Pulling CI images (BUILD=${BUILD_TAG})"
+  cd "$REPO_ROOT"
+  for tag in "${IMAGE_TAGS[@]}"; do
+    echo "  -> ${tag}"
+    $CONTAINER_RUNTIME pull "${tag}"
+  done
+fi
 
 CLUSTER_REUSED=false
 if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
@@ -99,8 +162,15 @@ for tag in "${IMAGE_TAGS[@]}"; do
     # Podman stores unqualified images under localhost/, but Kubernetes
     # resolves them as docker.io/. Re-tag so containerd inside the
     # KIND nodes finds them under the name the pods actually request.
-    canonical="docker.io/${tag}"
-    $CONTAINER_RUNTIME tag "$tag" "$canonical" 2>/dev/null || true
+    # Skip the docker.io re-tag for already-qualified references (CI
+    # images already carry a registry component).
+    case "$tag" in
+      */*/*) canonical="$tag" ;;
+      *)     canonical="docker.io/${tag}" ;;
+    esac
+    if [[ "$canonical" != "$tag" ]]; then
+      $CONTAINER_RUNTIME tag "$tag" "$canonical" 2>/dev/null || true
+    fi
     tmptar="$(mktemp "${TMPDIR:-/tmp}/kind-image-XXXXXX")"
     $CONTAINER_RUNTIME save -o "$tmptar" "$canonical"
     kind load image-archive --name "$CLUSTER_NAME" "$tmptar"
@@ -109,6 +179,49 @@ for tag in "${IMAGE_TAGS[@]}"; do
     kind load docker-image --name "$CLUSTER_NAME" "$tag"
   fi
 done
+
+# In BUILD=<tag> mode the demo manifests still reference local/...:dev.
+# Render examples/tcp-demo once with kustomize, then rewrite each
+# component image reference to the resolved CI image. The rendered
+# manifest is applied below in place of the kustomization directory.
+# In local mode the kustomization is applied directly (byte-for-byte
+# identical behaviour to today).
+RENDERED_MANIFEST=""
+if [[ "$BUILD_MODE" == "tag" ]]; then
+  RENDERED_MANIFEST="$(mktemp "${TMPDIR:-/tmp}/mxl-kind-demo-XXXXXX.yaml")"
+  trap 'rm -f "$RENDERED_MANIFEST"' EXIT
+  "${KUBECTL[@]}" kustomize "${REPO_ROOT}/examples/tcp-demo/" > "${RENDERED_MANIFEST}.in"
+  # Stream-replace local/<name>:dev with the resolved CI reference.
+  # IMAGE_LOCAL_TAGS[i] always maps to IMAGE_TAGS[i] by index.
+  sed_args=()
+  for i in "${!IMAGE_LOCAL_TAGS[@]}"; do
+    src="${IMAGE_LOCAL_TAGS[$i]}"
+    dst="${IMAGE_TAGS[$i]}"
+    # Escape '/' and '&' for sed's replacement field.
+    src_esc=$(printf '%s' "$src" | sed -e 's/[\/&]/\\&/g')
+    dst_esc=$(printf '%s' "$dst" | sed -e 's/[\/&]/\\&/g')
+    sed_args+=("-e" "s/${src_esc}/${dst_esc}/g")
+  done
+  sed "${sed_args[@]}" "${RENDERED_MANIFEST}.in" > "$RENDERED_MANIFEST"
+  rm -f "${RENDERED_MANIFEST}.in"
+  # Sanity check: every IMAGE_LOCAL_TAGS reference must be gone from
+  # the rendered output. If one remains, the demo would silently pull
+  # a local/...:dev image that isn't loaded.
+  for src in "${IMAGE_LOCAL_TAGS[@]}"; do
+    if grep -q "$src" "$RENDERED_MANIFEST"; then
+      echo "ERROR: image ${src} still present in rendered demo manifest" >&2
+      exit 1
+    fi
+  done
+fi
+
+apply_demo() {
+  if [[ "$BUILD_MODE" == "tag" ]]; then
+    "${KUBECTL[@]}" apply -f "$RENDERED_MANIFEST"
+  else
+    "${KUBECTL[@]}" apply -k "${REPO_ROOT}/examples/tcp-demo/"
+  fi
+}
 
 log "Installing CRDs"
 # Apply the CRDs in their own pass first so the demo's resources
@@ -124,7 +237,7 @@ log "Installing CRDs"
   mxlnodecapabilities.mxl.qvest-digital.com
 
 log "Applying examples/tcp-demo"
-"${KUBECTL[@]}" apply -k "${REPO_ROOT}/examples/tcp-demo/"
+apply_demo
 
 # On re-runs the kubelet caches images by tag, so re-loading a :dev
 # image doesn't get picked up by existing pods. Force a rollout
@@ -140,7 +253,7 @@ if [[ "$CLUSTER_REUSED" == "true" ]]; then
   # still Terminating leaves the new pod in limbo (apply observes
   # the live object and treats it as a no-op).
   "${KUBECTL[@]}" -n mxl-system delete pod mxl-tcp-demo-writer mxl-tcp-demo-reader --ignore-not-found --force --grace-period=0
-  "${KUBECTL[@]}" apply -k "${REPO_ROOT}/examples/tcp-demo/"
+  apply_demo
 fi
 
 log "Waiting for control-plane workloads (timeout ${ROLLOUT_TIMEOUT_SECS}s)"

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -17,7 +17,7 @@
 #
 # Set BUILD=<tag> to skip the local image build and use CI-produced
 # images instead. With BUILD unset or BUILD=local (the default) the
-# script builds the five component images locally as before. With
+# script builds the five component images locally. With
 # BUILD=<tag> the script pulls
 # ghcr.io/<owner>/mxl-k8s/<component>:<tag> for every component,
 # kind-loads it, and rewrites the demo manifests to reference it
@@ -184,8 +184,7 @@ done
 # Render examples/tcp-demo once with kustomize, then rewrite each
 # component image reference to the resolved CI image. The rendered
 # manifest is applied below in place of the kustomization directory.
-# In local mode the kustomization is applied directly (byte-for-byte
-# identical behaviour to today).
+# In local mode the kustomization is applied directly.
 RENDERED_MANIFEST=""
 if [[ "$BUILD_MODE" == "tag" ]]; then
   RENDERED_MANIFEST="$(mktemp "${TMPDIR:-/tmp}/mxl-kind-demo-XXXXXX.yaml")"


### PR DESCRIPTION
`make kind-up` today always builds the five component images
locally with `docker build` and `kind load`s the resulting
`local/mxl-*:dev` references into the cluster. CI publishes the
same components to `ghcr.io/qvest-digital/mxl-k8s/<component>:<tag>`,
but there is no way to point `kind-up` at those CI artifacts —
every reviewer has to rebuild from scratch on a clean checkout,
and a smoke-test against a tagged release requires editing the
hack script.

Add a single `BUILD` knob on `make kind-up` (forwarded to
`hack/kind-up.sh`) that selects between the two modes:

- `BUILD` unset or `BUILD=local`: existing behaviour, byte-for-byte.
- `BUILD=<tag>`: skip `docker build`, pull
  `ghcr.io/qvest-digital/mxl-k8s/<component>:<tag>` for each of
  the five components, `kind load docker-image` each one, then
  render `examples/tcp-demo` with `kubectl kustomize` and rewrite
  the `local/mxl-*:dev` references to the CI references before
  `kubectl apply -f`. A final scan refuses to apply if any
  `local/mxl-*:dev` reference survived the rewrite.
- Empty or otherwise invalid `BUILD`: exit non-zero with
  `ERROR: BUILD must be 'local' or a non-empty image tag` before
  any side effects.

`IMAGE_REGISTRY` overrides the registry prefix for environments
that mirror GHCR. The in-tree `examples/tcp-demo/kustomization.yaml`
is left untouched so the local path keeps using `kubectl apply -k`
unchanged.
