### PR TITLE
ci(images): add kind-integration job spinning up KIND on built images

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -71,6 +71,7 @@ jobs:
       shim:       ${{ steps.f.outputs.shim }}
       demo_tools: ${{ steps.f.outputs.demo_tools }}
       workflow:   ${{ steps.f.outputs.workflow }}
+      kind:       ${{ steps.f.outputs.kind }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -83,6 +84,15 @@ jobs:
             shim:       ['docker/shim.Dockerfile', 'shim/**']
             demo_tools: ['docker/demo-tools.Dockerfile']
             workflow:   ['.github/workflows/images.yml']
+            kind:
+              - 'docker/**'
+              - 'hack/kind-*'
+              - 'examples/**'
+              - 'config/crd/**'
+              - 'config/rbac/**'
+              - 'charts/mxl-k8s/**'
+              - 'Makefile'
+              - '.github/workflows/images.yml'
 
   # Compute the list of images to build and the registry references /
   # tag lists each image should be published under. Centralised here
@@ -104,8 +114,19 @@ jobs:
       images: ${{ steps.m.outputs.images }}
       push: ${{ steps.m.outputs.push }}
       has_images: ${{ steps.m.outputs.has_images }}
+      kind_wanted: ${{ steps.m.outputs.kind_wanted }}
+      sha_short: ${{ steps.m.outputs.sha_short }}
     env:
       INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+      # kind-integration eligibility (kind_wanted in meta script):
+      # - PR: changes.kind == true OR PR carries the run-kind label
+      # - push to main (branch): changes.kind == true (and not a
+      #   release-please merge -- see push branch in meta)
+      # - workflow_dispatch with empty release_tag: always true
+      # - tag push or workflow_call with release_tag: false (the kind
+      #   path is a pre-release smoke test, not a release gate)
+      CHANGED_KIND:       ${{ needs.changes.outputs.kind       || 'false' }}
+      PR_LABELS_JSON:     ${{ toJSON(github.event.pull_request.labels.*.name) }}
       # head_commit is present on push events; empty otherwise. Used
       # to detect release-please's own merge commits and defer their
       # image publish to the workflow_call run that release-please.yml
@@ -268,7 +289,48 @@ jobs:
             echo "push=${push}"
             echo "images=${images}"
             echo "has_images=${has_images}"
+            echo "sha_short=${short_sha}"
           } >> "$GITHUB_OUTPUT"
+
+          # kind_wanted: whether kind-integration should run for this
+          # invocation. Computed here so the build job can decide
+          # whether to upload the per-image docker-save tarballs the
+          # kind-integration job consumes.
+          kind_wanted=false
+          case "$GITHUB_EVENT_NAME" in
+            pull_request)
+              if [ "$CHANGED_KIND" = "true" ]; then
+                kind_wanted=true
+              elif echo "${PR_LABELS_JSON:-[]}" | grep -q '"run-kind"'; then
+                kind_wanted=true
+              fi
+              ;;
+            push)
+              # Tag push: not a kind path. release-please merge: same.
+              if [ "$GITHUB_REF_TYPE" = "branch" ] \
+                  && [ "$GITHUB_REF" = "refs/heads/main" ] \
+                  && [ "$CHANGED_KIND" = "true" ] \
+                  && [ "$push" = "true" ]; then
+                kind_wanted=true
+              fi
+              ;;
+            workflow_dispatch)
+              # Manual run on HEAD (no release_tag) gets a kind run.
+              # release_tag backfills go through the workflow_call /
+              # release path -- those don't run kind.
+              if [ -z "${INPUT_RELEASE_TAG:-}" ]; then
+                kind_wanted=true
+              fi
+              ;;
+          esac
+
+          # Without any image to build there is nothing for kind to
+          # exercise; short-circuit so the job skips cleanly.
+          if [ "$has_images" != "true" ]; then
+            kind_wanted=false
+          fi
+
+          echo "kind_wanted=${kind_wanted}" >> "$GITHUB_OUTPUT"
 
   # Per-image, per-arch build. Each cell builds on the matching native
   # runner and (when push=true) writes a per-digest entry to GHCR. The
@@ -357,6 +419,32 @@ jobs:
           if-no-files-found: error
           retention-days: 1
 
+      # kind-integration consumes a single-arch (amd64) tarball per
+      # image; build it once here on the amd64 leg, reusing the build
+      # cache the digest push just populated. The tarball is named
+      # for the sha-<short> ref so the kind-integration job can `kind
+      # load image-archive` it and the demo manifests can reference
+      # ${IMAGE}:sha-<short> directly.
+      - name: Build kind tarball
+        if: needs.meta.outputs.kind_wanted == 'true' && matrix.runner.arch == 'amd64'
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ${{ matrix.image.dockerfile }}
+          platforms: linux/amd64
+          tags: ${{ matrix.image.image }}:sha-${{ needs.meta.outputs.sha_short }}
+          outputs: type=docker,dest=${{ runner.temp }}/kind-image-${{ matrix.image.name }}.tar
+          cache-from: type=gha,scope=${{ matrix.image.name }}-amd64
+
+      - name: Upload kind tarball
+        if: needs.meta.outputs.kind_wanted == 'true' && matrix.runner.arch == 'amd64'
+        uses: actions/upload-artifact@v7
+        with:
+          name: kind-image-${{ matrix.image.name }}
+          path: ${{ runner.temp }}/kind-image-${{ matrix.image.name }}.tar
+          if-no-files-found: error
+          retention-days: 1
+
   # Stitch the per-arch digests of each image into one multi-arch
   # manifest list, applying the full tag list computed by meta.
   merge:
@@ -408,13 +496,84 @@ jobs:
           first=$(echo '${{ matrix.image.tags }}' | cut -d, -f1)
           docker buildx imagetools inspect "$first"
 
+  # Bring up a KIND cluster on the runner, load the per-image tarballs
+  # the build job uploaded, and exercise `make kind BUILD=sha-<short>`.
+  # Runs only when meta.kind_wanted is true (PR path filter or
+  # `run-kind` label; push to main matching the kind path filter; manual
+  # workflow_dispatch on HEAD). Tag-event / release publish runs skip
+  # kind by design -- the kind path is a pre-release smoke test, not a
+  # release gate.
+  kind-integration:
+    needs: [meta, build]
+    if: ${{ !cancelled() && needs.meta.outputs.kind_wanted == 'true' && needs.build.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Download image tarballs
+        uses: actions/download-artifact@v8
+        with:
+          path: ${{ runner.temp }}/kind-images
+          pattern: kind-image-*
+          merge-multiple: true
+
+      - name: Install kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Create KIND cluster
+        uses: helm/kind-action@v1
+        with:
+          cluster_name: mxl-k8s-ci
+          config: hack/kind-config.yaml
+          wait: 60s
+
+      - name: Run make kind
+        env:
+          BUILD: sha-${{ needs.meta.outputs.sha_short }}
+          IMAGE_REPO: ghcr.io/${{ github.repository_owner }}/mxl-k8s
+          IMAGE_TARS: ${{ runner.temp }}/kind-images
+          KIND_CLUSTER: mxl-k8s-ci
+        run: |
+          # IMAGE_REPO must be lowercased; github.repository_owner is
+          # already lowercased in the meta script but the action
+          # context carries the original case. Match that path.
+          IMAGE_REPO="$(echo "$IMAGE_REPO" | tr '[:upper:]' '[:lower:]')" \
+            make kind \
+              BUILD="$BUILD" \
+              IMAGE_REPO="$IMAGE_REPO" \
+              IMAGE_TARS="$IMAGE_TARS" \
+              KIND_CLUSTER="$KIND_CLUSTER"
+
+      - name: Diagnostics on failure
+        if: failure()
+        run: |
+          set +e
+          mkdir -p "${RUNNER_TEMP}/kind-diagnostics"
+          ctx="kind-mxl-k8s-ci"
+          kubectl --context "$ctx" get all -A                                           > "${RUNNER_TEMP}/kind-diagnostics/all.txt"        2>&1
+          kubectl --context "$ctx" describe pods -A                                     > "${RUNNER_TEMP}/kind-diagnostics/pods.txt"       2>&1
+          kubectl --context "$ctx" -n mxl-system logs ds/mxl-fabrics-gateway --tail=200 > "${RUNNER_TEMP}/kind-diagnostics/gateway.log"   2>&1
+          kubectl --context "$ctx" -n mxl-system logs ds/mxl-domain-agent --tail=200    > "${RUNNER_TEMP}/kind-diagnostics/agent.log"     2>&1
+          kubectl --context "$ctx" -n mxl-system logs deploy/mxl-operator --tail=200    > "${RUNNER_TEMP}/kind-diagnostics/operator.log"  2>&1
+          kubectl --context "$ctx" -n mxl-system get mxlflowmirrors -o yaml             > "${RUNNER_TEMP}/kind-diagnostics/mirrors.yaml"  2>&1
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: kind-diagnostics-${{ github.run_id }}
+          path: ${{ runner.temp }}/kind-diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
+
   # Branch-protection target. Always runs, succeeds only when every
   # required upstream job is in `success` or `skipped` state. Without
   # this gate, branch protection would need to enumerate every
   # conditional job individually and would block PRs that legitimately
   # skipped one.
   images-summary:
-    needs: [changes, meta, build, merge]
+    needs: [changes, meta, build, merge, kind-integration]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     timeout-minutes: 2

--- a/Makefile
+++ b/Makefile
@@ -218,6 +218,29 @@ KIND_CLUSTER ?= mxl-k8s-demo
 # Container runtime: "docker" (default) or "podman".
 CONTAINER_RUNTIME ?= docker
 
+# `make kind` accepts an externally-built image set via BUILD=<tag>;
+# with BUILD unset it behaves like `kind-up` (local docker build of
+# the `local/mxl-*:dev` set). CI uses BUILD=sha-<short> together with
+# IMAGE_TARS pointing at a directory of `docker save` tarballs the
+# build job uploaded; local users typically run `make kind-up` instead.
+#
+# BUILD=<tag>       use ${IMAGE_REPO}/<name>:${BUILD} for every image
+#                   (operator, agent, gateway, shim, demo-tools).
+# IMAGE_REPO=<ref>  registry prefix; defaults to the project's GHCR
+#                   namespace.
+# IMAGE_TARS=<dir>  load images from `<dir>/kind-image-<name>.tar`
+#                   instead of pulling from the registry. CI uses
+#                   this so kind never round-trips through GHCR.
+BUILD       ?=
+IMAGE_REPO  ?= ghcr.io/qvest-digital/mxl-k8s
+IMAGE_TARS  ?=
+
+.PHONY: kind
+kind:
+	KIND_CLUSTER=$(KIND_CLUSTER) CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) \
+	BUILD=$(BUILD) IMAGE_REPO=$(IMAGE_REPO) IMAGE_TARS=$(IMAGE_TARS) \
+	    bash hack/kind-up.sh
+
 .PHONY: kind-up
 kind-up:
 	KIND_CLUSTER=$(KIND_CLUSTER) CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) bash hack/kind-up.sh

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -23,6 +23,17 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../" && pwd)"
 KIND_CONFIG="${REPO_ROOT}/hack/kind-config.yaml"
 KUBECTL=(kubectl --context "kind-${CLUSTER_NAME}")
 
+# When BUILD is set, use externally-built images under
+# ${IMAGE_REPO}/<name>:${BUILD} instead of rebuilding `local/mxl-*:dev`
+# locally. CI sets IMAGE_TARS=<dir> so each image loads from
+# <dir>/kind-image-<name>.tar (no GHCR round-trip); without IMAGE_TARS
+# the script falls back to pulling from the registry. The demo
+# manifests still reference `local/mxl-*:dev` in tree; the BUILD path
+# patches the live workloads with `kubectl set image` after apply.
+BUILD="${BUILD:-}"
+IMAGE_REPO="${IMAGE_REPO:-ghcr.io/qvest-digital/mxl-k8s}"
+IMAGE_TARS="${IMAGE_TARS:-}"
+
 # When using podman, tell KIND to use the podman provider.
 if [[ "$CONTAINER_RUNTIME" == "podman" ]]; then
   export KIND_EXPERIMENTAL_PROVIDER=podman
@@ -44,6 +55,16 @@ IMAGE_TAGS=(
   local/mxl-fabrics-gateway:dev
   local/mxl-shim:dev
   local/mxl-demo-tools:dev
+)
+# Parallel to IMAGE_TAGS. Names match the kind-image-<name>.tar
+# artefacts the images.yml workflow uploads and the components in
+# the meta script's `all` list.
+IMAGE_CI_NAMES=(
+  operator
+  agent
+  gateway
+  shim
+  demo-tools
 )
 
 log()  { printf '\n=== %s ===\n' "$*" >&2; }
@@ -67,14 +88,41 @@ if [[ "$CONTAINER_RUNTIME" == "podman" ]]; then
   fi
 fi
 
-log "Building images"
+log "Preparing images"
 cd "$REPO_ROOT"
-for i in "${!IMAGE_DOCKERFILES[@]}"; do
-  dockerfile="${IMAGE_DOCKERFILES[$i]}"
-  tag="${IMAGE_TAGS[$i]}"
-  echo "  -> ${tag}"
-  $CONTAINER_RUNTIME build -q -f "${dockerfile}" -t "${tag}" . > /dev/null
-done
+if [[ -z "$BUILD" ]]; then
+  # Local developer path: build the `local/mxl-*:dev` set from the
+  # working tree.
+  for i in "${!IMAGE_DOCKERFILES[@]}"; do
+    dockerfile="${IMAGE_DOCKERFILES[$i]}"
+    tag="${IMAGE_TAGS[$i]}"
+    echo "  -> ${tag} (building)"
+    $CONTAINER_RUNTIME build -q -f "${dockerfile}" -t "${tag}" . > /dev/null
+  done
+else
+  # CI path: every image already exists as ${IMAGE_REPO}/<name>:${BUILD}.
+  # With IMAGE_TARS set, load each one from a `docker save` archive
+  # (the artefact the images.yml build job uploaded); otherwise pull
+  # the manifest list off the registry. The build manifest deliberately
+  # mirrors the per-component naming the meta script in images.yml
+  # uses (operator / agent / gateway / shim / demo-tools).
+  for i in "${!IMAGE_CI_NAMES[@]}"; do
+    name="${IMAGE_CI_NAMES[$i]}"
+    ref="${IMAGE_REPO}/${name}:${BUILD}"
+    if [[ -n "$IMAGE_TARS" ]]; then
+      tar="${IMAGE_TARS}/kind-image-${name}.tar"
+      if [[ ! -f "$tar" ]]; then
+        echo "ERROR: BUILD=${BUILD} but ${tar} is missing." >&2
+        exit 1
+      fi
+      echo "  -> ${ref} (loading ${tar})"
+      $CONTAINER_RUNTIME load -i "$tar" >/dev/null
+    else
+      echo "  -> ${ref} (pulling)"
+      $CONTAINER_RUNTIME pull "$ref" >/dev/null
+    fi
+  done
+fi
 
 CLUSTER_REUSED=false
 if kind get clusters 2>/dev/null | grep -qx "$CLUSTER_NAME"; then
@@ -93,20 +141,33 @@ else
 fi
 
 log "Loading images into the cluster"
-for tag in "${IMAGE_TAGS[@]}"; do
-  echo "  -> ${tag}"
+if [[ -z "$BUILD" ]]; then
+  REFS_TO_LOAD=("${IMAGE_TAGS[@]}")
+else
+  REFS_TO_LOAD=()
+  for name in "${IMAGE_CI_NAMES[@]}"; do
+    REFS_TO_LOAD+=("${IMAGE_REPO}/${name}:${BUILD}")
+  done
+fi
+for ref in "${REFS_TO_LOAD[@]}"; do
+  echo "  -> ${ref}"
   if [[ "$CONTAINER_RUNTIME" == "podman" ]]; then
     # Podman stores unqualified images under localhost/, but Kubernetes
     # resolves them as docker.io/. Re-tag so containerd inside the
     # KIND nodes finds them under the name the pods actually request.
-    canonical="docker.io/${tag}"
-    $CONTAINER_RUNTIME tag "$tag" "$canonical" 2>/dev/null || true
+    # ghcr.io/* refs are already fully qualified and skip this step.
+    if [[ "$ref" != *"/"*"/"* ]]; then
+      canonical="docker.io/${ref}"
+      $CONTAINER_RUNTIME tag "$ref" "$canonical" 2>/dev/null || true
+    else
+      canonical="$ref"
+    fi
     tmptar="$(mktemp "${TMPDIR:-/tmp}/kind-image-XXXXXX")"
     $CONTAINER_RUNTIME save -o "$tmptar" "$canonical"
     kind load image-archive --name "$CLUSTER_NAME" "$tmptar"
     rm -f "$tmptar"
   else
-    kind load docker-image --name "$CLUSTER_NAME" "$tag"
+    kind load docker-image --name "$CLUSTER_NAME" "$ref"
   fi
 done
 
@@ -124,7 +185,45 @@ log "Installing CRDs"
   mxlnodecapabilities.mxl.qvest-digital.com
 
 log "Applying examples/tcp-demo"
-"${KUBECTL[@]}" apply -k "${REPO_ROOT}/examples/tcp-demo/"
+# When BUILD is set, redirect the demo's image references via a
+# throwaway kustomize overlay. kustomize's `images:` transformer
+# rewrites every container that references `local/mxl-*:dev` to the
+# externally-built ${IMAGE_REPO}/<name>:${BUILD} ref, including bare
+# Pods (`kubectl set image` does not support `kind: Pod`). The overlay
+# lives under the shell's temp dir so it never enters the repo.
+APPLY_DIR="${REPO_ROOT}/examples/tcp-demo/"
+DEMO_OVERLAY=""
+if [[ -n "$BUILD" ]]; then
+  DEMO_OVERLAY="$(mktemp -d "${TMPDIR:-/tmp}/kind-demo-overlay-XXXXXX")"
+  # kustomize rejects absolute paths in `resources`; symlink the
+  # in-tree base into the overlay so the relative path resolves.
+  ln -s "${REPO_ROOT}/examples/tcp-demo" "${DEMO_OVERLAY}/base"
+  cat > "${DEMO_OVERLAY}/kustomization.yaml" <<EOF
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - base
+images:
+  - name: local/mxl-operator
+    newName: ${IMAGE_REPO}/operator
+    newTag: ${BUILD}
+  - name: local/mxl-domain-agent
+    newName: ${IMAGE_REPO}/agent
+    newTag: ${BUILD}
+  - name: local/mxl-fabrics-gateway
+    newName: ${IMAGE_REPO}/gateway
+    newTag: ${BUILD}
+  - name: local/mxl-shim
+    newName: ${IMAGE_REPO}/shim
+    newTag: ${BUILD}
+  - name: local/mxl-demo-tools
+    newName: ${IMAGE_REPO}/demo-tools
+    newTag: ${BUILD}
+EOF
+  APPLY_DIR="$DEMO_OVERLAY"
+  log "Using BUILD overlay at ${DEMO_OVERLAY}"
+fi
+"${KUBECTL[@]}" apply -k "$APPLY_DIR"
 
 # On re-runs the kubelet caches images by tag, so re-loading a :dev
 # image doesn't get picked up by existing pods. Force a rollout
@@ -140,7 +239,12 @@ if [[ "$CLUSTER_REUSED" == "true" ]]; then
   # still Terminating leaves the new pod in limbo (apply observes
   # the live object and treats it as a no-op).
   "${KUBECTL[@]}" -n mxl-system delete pod mxl-tcp-demo-writer mxl-tcp-demo-reader --ignore-not-found --force --grace-period=0
-  "${KUBECTL[@]}" apply -k "${REPO_ROOT}/examples/tcp-demo/"
+  "${KUBECTL[@]}" apply -k "$APPLY_DIR"
+fi
+
+# Clean up the BUILD overlay temp dir if we created one.
+if [[ -n "$DEMO_OVERLAY" ]]; then
+  rm -rf "$DEMO_OVERLAY"
 fi
 
 log "Waiting for control-plane workloads (timeout ${ROLLOUT_TIMEOUT_SECS}s)"


### PR DESCRIPTION
A new kind-integration job in images.yml brings up a KIND cluster on
the runner, loads the docker-save tarballs the build job produced for
the amd64 leg, and exercises \`make kind BUILD=sha-<short>\` against
them.

## Trigger gate

kind-integration runs only when one of:

- PR diff touches \`docker/\`, \`hack/kind-*\`, \`examples/\`, \`config/crd/\`,
  \`config/rbac/\`, \`charts/mxl-k8s/\`, \`Makefile\`, or \`.github/workflows/images.yml\`
- PR carries the \`run-kind\` label
- push to \`main\` matching the same path filter
- manual \`workflow_dispatch\` on HEAD (empty \`release_tag\`)

Tag-event / release publish runs skip the job; the kind path is a
pre-release smoke test, not a release gate.

## Image transport

The build job grows a tarball-emit step (single-arch amd64, gated on
\`kind_wanted\`) that runs alongside the digest push and uploads
\`kind-image-<name>.tar\` via \`actions/upload-artifact\`. The
kind-integration job downloads the bundle and \`kind load
image-archive\` loads each tarball — no GHCR round-trip, works for
fork PRs (\`push=false\`).

\`images-summary\` gains \`kind-integration\` in its \`needs:\` so branch
protection covers it; a skipped run still counts as success.

## Makefile and kind-up.sh

A new Makefile target \`kind\` accepts \`BUILD\` / \`IMAGE_REPO\` /
\`IMAGE_TARS\`. \`hack/kind-up.sh\` routes on \`BUILD\`:

- \`BUILD=\` (default) → existing local-developer loop that builds
  \`local/mxl-*:dev\` from the working tree.
- \`BUILD=<tag>\` → loads each image from
  \`\${IMAGE_TARS}/kind-image-<name>.tar\` (or pulls from
  \`\${IMAGE_REPO}/<name>:<tag>\` when \`IMAGE_TARS\` is unset), then
  applies the demo through an ephemeral kustomize overlay that
  rewrites every \`local/mxl-*\` reference to the \`BUILD\`-tagged ref,
  and tears the overlay down on completion.

The existing \`kind-up\` target is preserved for the no-BUILD developer
path.

Refs https://github.com/qvest-digital/mxl-k8s — kanban task t_f0832303 (KIND CI design).