### PR TITLE
test(kind): add integration suite asserting flow mirroring works

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -71,6 +71,7 @@ jobs:
       shim:       ${{ steps.f.outputs.shim }}
       demo_tools: ${{ steps.f.outputs.demo_tools }}
       workflow:   ${{ steps.f.outputs.workflow }}
+      kind:       ${{ steps.f.outputs.kind }}
     steps:
       - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v4
@@ -83,6 +84,16 @@ jobs:
             shim:       ['docker/shim.Dockerfile', 'shim/**']
             demo_tools: ['docker/demo-tools.Dockerfile']
             workflow:   ['.github/workflows/images.yml']
+            kind:
+              - 'hack/kind-*'
+              - 'docker/**'
+              - 'examples/tcp-demo/**'
+              - 'config/crd/**'
+              - 'config/rbac/**'
+              - 'charts/mxl-k8s/**'
+              - 'Makefile'
+              - 'test/integration/kind/**'
+              - '.github/workflows/images.yml'
 
   # Compute the list of images to build and the registry references /
   # tag lists each image should be published under. Centralised here
@@ -104,8 +115,20 @@ jobs:
       images: ${{ steps.m.outputs.images }}
       push: ${{ steps.m.outputs.push }}
       has_images: ${{ steps.m.outputs.has_images }}
+      kind_wanted: ${{ steps.m.outputs.kind_wanted }}
+      sha_short: ${{ steps.m.outputs.sha_short }}
     env:
       INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+      # kind-integration eligibility (kind_wanted below):
+      # - pull_request: changes.kind == true on a same-repo PR, OR a
+      #   `run-kind` label is attached (opt-in escape hatch).
+      # - push to main (branch): changes.kind == true and push == true
+      #   (release-please merges already toggled push=false above).
+      # - workflow_dispatch with empty release_tag: always true.
+      # - tag push / workflow_call with release_tag: false. Release
+      #   publishes are not gated on a smoke test.
+      CHANGED_KIND:   ${{ needs.changes.outputs.kind   || 'false' }}
+      PR_LABELS_JSON: ${{ toJSON(github.event.pull_request.labels.*.name) }}
       # head_commit is present on push events; empty otherwise. Used
       # to detect release-please's own merge commits and defer their
       # image publish to the workflow_call run that release-please.yml
@@ -264,10 +287,48 @@ jobs:
             has_images=true
           fi
 
+          # kind-integration eligibility. The kind path is a pre-
+          # release smoke test, not a release gate, so tag pushes and
+          # workflow_call-with-release_tag invocations always skip.
+          # has_images=false short-circuits to false too: with no
+          # images to build, there is nothing for kind to load.
+          kind_wanted=false
+          case "$GITHUB_EVENT_NAME" in
+            pull_request)
+              # Fork PRs are excluded -- the per-PR image tag is not
+              # pushed to GHCR, so there is no manifest to kind-load.
+              if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+                if [ "$CHANGED_KIND" = "true" ]; then
+                  kind_wanted=true
+                elif echo "${PR_LABELS_JSON:-[]}" | grep -q '"run-kind"'; then
+                  kind_wanted=true
+                fi
+              fi
+              ;;
+            push)
+              if [ "$GITHUB_REF_TYPE" = "branch" ] \
+                  && [ "$GITHUB_REF" = "refs/heads/main" ] \
+                  && [ "$CHANGED_KIND" = "true" ] \
+                  && [ "$push" = "true" ]; then
+                kind_wanted=true
+              fi
+              ;;
+            workflow_dispatch)
+              if [ -z "${INPUT_RELEASE_TAG:-}" ]; then
+                kind_wanted=true
+              fi
+              ;;
+          esac
+          if [ "$has_images" != "true" ]; then
+            kind_wanted=false
+          fi
+
           {
             echo "push=${push}"
             echo "images=${images}"
             echo "has_images=${has_images}"
+            echo "kind_wanted=${kind_wanted}"
+            echo "sha_short=${short_sha}"
           } >> "$GITHUB_OUTPUT"
 
   # Per-image, per-arch build. Each cell builds on the matching native
@@ -408,13 +469,78 @@ jobs:
           first=$(echo '${{ matrix.image.tags }}' | cut -d, -f1)
           docker buildx imagetools inspect "$first"
 
+  # Bring up a 3-node KIND cluster on the runner, point `make kind-up`
+  # at the per-PR multi-arch manifest the `merge` job just published,
+  # and exercise the integration suite under test/integration/kind.
+  # Gated by meta.kind_wanted so unrelated diffs skip cleanly. Tag
+  # publishes and workflow_call-with-release_tag invocations skip by
+  # design -- the kind path is a pre-release smoke test, not a
+  # release gate.
+  kind-integration:
+    needs: [meta, build, merge]
+    if: ${{ !cancelled() && needs.meta.outputs.kind_wanted == 'true' && needs.merge.result == 'success' }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+
+      # install_only avoids creating a stub cluster here; hack/kind-up.sh
+      # creates the real one against hack/kind-config.yaml.
+      - uses: helm/kind-action@v1
+        with:
+          install_only: true
+
+      - uses: azure/setup-kubectl@v4
+
+      # `make kind-up BUILD=<tag>` pulls images from GHCR; the
+      # per-PR tag the merge job just produced is private to the
+      # repo, so the runner must log in first.
+      - uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Bring up KIND demo against PR-built images
+        env:
+          BUILD: pr-${{ github.event.number }}-${{ needs.meta.outputs.sha_short }}
+          IMAGE_REGISTRY_RAW: ghcr.io/${{ github.repository_owner }}/mxl-k8s
+          KIND_CLUSTER: mxl-k8s-ci
+          # Hosted runners are slower on first image pull than a
+          # developer laptop; raise the kind-up defaults (180 / 300)
+          # to absorb that without changing the script's defaults.
+          MIRROR_TIMEOUT_SECS: 240
+          ROLLOUT_TIMEOUT_SECS: 360
+        run: |
+          set -euo pipefail
+          IMAGE_REGISTRY=$(echo "$IMAGE_REGISTRY_RAW" | tr '[:upper:]' '[:lower:]')
+          make kind-up \
+            BUILD="$BUILD" \
+            IMAGE_REGISTRY="$IMAGE_REGISTRY" \
+            KIND_CLUSTER="$KIND_CLUSTER"
+
+      - name: Run integration suite
+        env:
+          KIND_CLUSTER: mxl-k8s-ci
+          KIND_DIAG_DIR: ${{ runner.temp }}/kind-diagnostics
+        run: make kind-test KIND_CLUSTER="$KIND_CLUSTER" KIND_DIAG_DIR="$KIND_DIAG_DIR"
+
+      - name: Upload diagnostics on failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: kind-diagnostics-${{ github.run_id }}
+          path: ${{ runner.temp }}/kind-diagnostics
+          if-no-files-found: ignore
+          retention-days: 7
+
   # Branch-protection target. Always runs, succeeds only when every
   # required upstream job is in `success` or `skipped` state. Without
   # this gate, branch protection would need to enumerate every
   # conditional job individually and would block PRs that legitimately
   # skipped one.
   images-summary:
-    needs: [changes, meta, build, merge]
+    needs: [changes, meta, build, merge, kind-integration]
     if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     timeout-minutes: 2

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,9 @@ profile.cov
 bin/
 testbin/
 
+# KIND integration suite failure diagnostics
+kind-diagnostics/
+
 # Editor/IDE
 # .idea/
 # .vscode/

--- a/Makefile
+++ b/Makefile
@@ -209,6 +209,11 @@ mocks-check: mocks
 #                    MxlFlowMirror to reach Ready.
 # `make kind-down`   deletes the cluster.
 # `make kind-status` prints a quick status summary.
+# `make kind-test`   runs the integration suite in
+#                    test/integration/kind against the cluster spun
+#                    up by `make kind-up`. Failure diagnostics land
+#                    under KIND_DIAG_DIR for the kind-integration
+#                    GitHub Actions job to upload as an artifact.
 #
 # Override the cluster name with KIND_CLUSTER=<name>.
 # Use Podman instead of Docker: CONTAINER_RUNTIME=podman
@@ -229,6 +234,8 @@ KIND_CLUSTER ?= mxl-k8s-demo
 CONTAINER_RUNTIME ?= docker
 # Image source: "local" (default) or a CI-produced image tag.
 BUILD ?= local
+# Where the integration suite writes failure diagnostics.
+KIND_DIAG_DIR ?= $(CURDIR)/kind-diagnostics
 
 .PHONY: kind-up
 kind-up:
@@ -241,3 +248,7 @@ kind-down:
 .PHONY: kind-status
 kind-status:
 	KIND_CLUSTER=$(KIND_CLUSTER) CONTAINER_RUNTIME=$(CONTAINER_RUNTIME) bash hack/kind-status.sh
+
+.PHONY: kind-test
+kind-test:
+	KIND_CLUSTER=$(KIND_CLUSTER) KIND_DIAG_DIR=$(KIND_DIAG_DIR) bash test/integration/kind/run.sh

--- a/docs/KIND.md
+++ b/docs/KIND.md
@@ -161,3 +161,30 @@ any side effects:
 ```
 ERROR: BUILD must be 'local' or a non-empty image tag
 ```
+
+## Integration suite
+
+`make kind-test` runs the bash suite under
+[`test/integration/kind/`](../test/integration/kind/) against an
+already-running cluster. Cases assert the five CRDs reach
+`Established`, the operator and the agent / gateway DaemonSets
+finish rolling out, `/healthz` and `/readyz` on each probe port
+answer `200`, every `MxlFlowMirror` reaches `phase=Ready` with a
+non-empty `status.targetInfo`, and the reader pod's `idx=` log
+lines actually advance over a sample window (catches the "Ready
+but no grains flowing" failure mode).
+
+```sh
+make kind-up
+make kind-test
+make kind-down
+```
+
+The same suite drives the `kind-integration` GitHub Actions job in
+`.github/workflows/images.yml`: on a same-repo PR that touches
+anything `make kind-up` consumes, the job pulls the PR's per-tag
+images from GHCR (`BUILD=pr-<num>-<sha>`), brings up a cluster on
+the runner, and runs `make kind-test`. New assertions land as
+`test/integration/kind/cases/<NN>-<name>.sh`; no runner changes
+required. See the suite's [`README.md`](../test/integration/kind/README.md)
+for the case-authoring conventions.

--- a/test/integration/kind/README.md
+++ b/test/integration/kind/README.md
@@ -1,0 +1,86 @@
+# KIND integration suite
+
+End-to-end smoke tests that run against a converged KIND cluster
+brought up by `make kind-up`. The suite verifies the control plane
+reaches a healthy state and that frames are actually flowing from
+the demo writer pod to the demo reader pod across the
+MxlFlowMirror.
+
+## Layout
+
+```
+test/integration/kind/
+  lib.sh           shared helpers (KUBECTL, wait_phase, port_forward_probe, collect_diagnostics, ...)
+  run.sh           orchestrator: iterates cases/*.sh, prints a pass/fail summary
+  cases/           one assertion per file, executed in lexicographic order
+    00-crds-established.sh
+    10-rollouts-ready.sh
+    20-probes-200.sh
+    30-mirror-ready.sh
+    40-frames-flowing.sh
+```
+
+## Usage
+
+```sh
+make kind-up      # build images, create cluster, apply examples/tcp-demo
+make kind-test    # run this suite against the cluster
+```
+
+Filter to a subset:
+
+```sh
+CASE_GLOB='test/integration/kind/cases/30-*.sh' make kind-test
+```
+
+Tunables (all optional, environment variables):
+
+| Name | Default | Purpose |
+| --- | --- | --- |
+| `KIND_CLUSTER` | `mxl-k8s-demo` | Cluster name; must match `make kind-up` |
+| `MXL_NAMESPACE` | `mxl-system` | Namespace the demo is applied to |
+| `ROLLOUT_TIMEOUT_SECS` | `180` | Per-rollout-status wait |
+| `MIRROR_TIMEOUT_SECS` | `180` | MxlFlowMirror Ready / reader Ready wait |
+| `PROBE_TIMEOUT_SECS` | `30` | Per-port-forward startup wait |
+| `FRAMES_WINDOW_SECS` | `5` | Case 40 sample window |
+| `KIND_DIAG_DIR` | `$PWD/kind-diagnostics` | Where failure diagnostics land |
+| `CASE_GLOB` | `cases/*.sh` | Case selection glob |
+
+## Diagnostics
+
+On any case failure, `run.sh` calls `collect_diagnostics` and writes
+into `$KIND_DIAG_DIR`:
+
+- `get-all.txt` -- `kubectl get all -A -o wide`
+- `describe-pods.txt` -- `kubectl describe pods` in the demo namespace
+- `events.txt` -- namespace events sorted by `lastTimestamp`
+- `mxl-resources.yaml` -- full `mxl.qvest-digital.com` resource dump
+- `<component>.log` -- last 400 lines per control-plane component
+- `cases/<case>.log` -- raw stdout/stderr of each case
+
+The `kind-integration` GitHub Actions job uploads the directory as
+an artifact named `kind-diagnostics-<run-id>` on failure.
+
+## Writing a new case
+
+Drop a new `<NN>-<name>.sh` into `cases/`. The runner discovers it
+automatically. A case is just a bash script that:
+
+1. Sources `lib.sh` via `. "$KIND_TEST_LIB"`.
+2. Calls `fail "<reason>"` on a failed assertion (exits non-zero).
+3. Exits 0 on success.
+
+Available helpers (see `lib.sh` for signatures):
+
+- `KUBECTL` -- array; expands to `kubectl --context kind-<cluster>`.
+- `NAMESPACE` -- demo namespace.
+- `log "msg"`, `fail "msg"`, `need "<cmd>"`.
+- `wait_phase <resource> <jsonpath> <regex> <timeout-secs>`.
+- `port_forward_probe <pod> <port> <path>` -- prints HTTP status,
+  returns 0 iff 200.
+- `resolve_pod <app.kubernetes.io/name label>`.
+
+Cases run in lexicographic order; the runner does **not** stop on
+the first failure, so a single broken case does not suppress the
+remaining diagnostics. Keep the `NN-` prefix in sync with the
+intended ordering (e.g. probe assertions after rollout assertions).

--- a/test/integration/kind/cases/00-crds-established.sh
+++ b/test/integration/kind/cases/00-crds-established.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Assert the five mxl.qvest-digital.com CRDs reach the Established
+# condition. The operator's reconcilers cannot bind to the API
+# objects they manage until each CRD's schema is registered.
+
+set -euo pipefail
+# shellcheck source=../lib.sh
+. "$KIND_TEST_LIB"
+
+CRDS=(
+  mxldomains.mxl.qvest-digital.com
+  mxlflows.mxl.qvest-digital.com
+  mxlflowmirrors.mxl.qvest-digital.com
+  mxlreceivers.mxl.qvest-digital.com
+  mxlnodecapabilities.mxl.qvest-digital.com
+)
+
+for crd in "${CRDS[@]}"; do
+  "${KUBECTL[@]}" wait --for=condition=Established --timeout=60s "crd/${crd}" \
+    || fail "CRD ${crd} not Established"
+  echo "  ${crd}: Established"
+done

--- a/test/integration/kind/cases/10-rollouts-ready.sh
+++ b/test/integration/kind/cases/10-rollouts-ready.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Assert the control-plane workloads finish rolling out and every
+# selected pod reaches the Ready condition. Covers the operator
+# Deployment and the agent + gateway DaemonSets.
+
+set -euo pipefail
+# shellcheck source=../lib.sh
+. "$KIND_TEST_LIB"
+
+WORKLOADS=(
+  deploy/mxl-operator
+  ds/mxl-domain-agent
+  ds/mxl-fabrics-gateway
+)
+
+for w in "${WORKLOADS[@]}"; do
+  "${KUBECTL[@]}" -n "$NAMESPACE" rollout status "$w" \
+      --timeout="${ROLLOUT_TIMEOUT_SECS}s" \
+    || fail "$w rollout did not complete in ${ROLLOUT_TIMEOUT_SECS}s"
+  echo "  ${w}: rolled out"
+done
+
+"${KUBECTL[@]}" -n "$NAMESPACE" wait --for=condition=Ready pod \
+    -l 'app.kubernetes.io/name in (mxl-operator,mxl-domain-agent,mxl-fabrics-gateway)' \
+    --timeout="${ROLLOUT_TIMEOUT_SECS}s" \
+  || fail "control-plane pods did not all become Ready"
+echo "  control-plane pods: Ready"

--- a/test/integration/kind/cases/20-probes-200.sh
+++ b/test/integration/kind/cases/20-probes-200.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Assert /healthz and /readyz on each control-plane component's probe
+# container port (8081) answer HTTP 200. Uses kubectl port-forward
+# so no curl-capable image needs to live inside the cluster.
+
+set -euo pipefail
+# shellcheck source=../lib.sh
+. "$KIND_TEST_LIB"
+
+# Parallel arrays: workload label / probe port. Kept index-aligned
+# so bash 3.2 (no associative arrays) can iterate them.
+WORKLOADS=(
+  mxl-operator
+  mxl-domain-agent
+  mxl-fabrics-gateway
+)
+PORTS=(
+  8081
+  8081
+  8081
+)
+
+probe_failed=0
+i=0
+while [ "$i" -lt "${#WORKLOADS[@]}" ]; do
+  label="${WORKLOADS[$i]}"
+  port="${PORTS[$i]}"
+  i=$(( i + 1 ))
+
+  pod=$(resolve_pod "$label") || fail "no Running pod found for app.kubernetes.io/name=${label}"
+  echo "-> ${label} (pod/${pod}) :${port}"
+
+  for endpoint in healthz readyz; do
+    code=$(port_forward_probe "$pod" "$port" "$endpoint" || true)
+    if [ "$code" = "200" ]; then
+      echo "   /${endpoint}: 200"
+    else
+      echo "   /${endpoint}: HTTP ${code} (expected 200)" >&2
+      probe_failed=1
+    fi
+  done
+done
+
+[ "$probe_failed" -eq 0 ] || fail "one or more probe endpoints did not return 200"

--- a/test/integration/kind/cases/30-mirror-ready.sh
+++ b/test/integration/kind/cases/30-mirror-ready.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Assert at least one MxlFlowMirror exists in the demo namespace and
+# every listed mirror reaches phase=Ready with a non-empty
+# status.targetInfo. status.targetInfo is set by the target-side
+# gateway reconciler after opening the libmxl Writer and the
+# fabrics Target; an empty value means the target plumbing never
+# materialised even if the phase string happens to read Ready.
+
+set -euo pipefail
+# shellcheck source=../lib.sh
+. "$KIND_TEST_LIB"
+
+JSONPATH='{range .items[*]}{.metadata.name}={.status.phase};{end}'
+
+phase=$(wait_phase mxlflowmirrors "$JSONPATH" \
+        '^([a-z0-9-]+=Ready;)+$' \
+        "$MIRROR_TIMEOUT_SECS") \
+  || {
+    echo "current phases: $("${KUBECTL[@]}" -n "$NAMESPACE" get mxlflowmirrors \
+            -o jsonpath="$JSONPATH" 2>/dev/null || true)" >&2
+    fail "not all MxlFlowMirrors reached Ready in ${MIRROR_TIMEOUT_SECS}s"
+  }
+
+# Walk every mirror; require status.targetInfo to be non-empty.
+names=$("${KUBECTL[@]}" -n "$NAMESPACE" get mxlflowmirrors \
+        -o jsonpath='{range .items[*]}{.metadata.name} {end}')
+[ -n "$names" ] || fail "no MxlFlowMirror resources found in namespace ${NAMESPACE}"
+
+for name in $names; do
+  ti=$("${KUBECTL[@]}" -n "$NAMESPACE" get "mxlflowmirror/${name}" \
+        -o jsonpath='{.status.targetInfo}')
+  if [ -z "$ti" ]; then
+    fail "MxlFlowMirror/${name} has empty status.targetInfo (target side never opened)"
+  fi
+  echo "  ${name}: Ready, targetInfo set"
+done
+
+echo "  phases: ${phase}"

--- a/test/integration/kind/cases/40-frames-flowing.sh
+++ b/test/integration/kind/cases/40-frames-flowing.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Assert grains are actually flowing across the fabric to the reader,
+# not just that the MxlFlowMirror status says Ready. The reader pod
+# runs go-mxl's read-grain example which prints one line per grain
+# observed (e.g. "idx=53318102095 size=5529600 ..."). Sample the
+# grain index, wait, sample again, and require the index to advance.
+
+set -euo pipefail
+# shellcheck source=../lib.sh
+. "$KIND_TEST_LIB"
+
+READER_POD="${READER_POD:-mxl-tcp-demo-reader}"
+SAMPLE_WINDOW_SECS="${FRAMES_WINDOW_SECS:-5}"
+
+# The reader must be Running before the index can advance. Wait up
+# to MIRROR_TIMEOUT_SECS, since the reader is the consumer of the
+# mirror and starts producing log lines only after the LD_PRELOAD
+# shim's intent wait completes.
+"${KUBECTL[@]}" -n "$NAMESPACE" wait --for=condition=Ready \
+    "pod/${READER_POD}" --timeout="${MIRROR_TIMEOUT_SECS}s" \
+  || fail "${READER_POD} did not become Ready"
+
+# Tail the reader's logs and extract the most recent grain index.
+# read-grain prints lines like "idx=<digits> size=... ...".
+sample_idx() {
+  "${KUBECTL[@]}" -n "$NAMESPACE" logs "pod/${READER_POD}" --tail=20 2>/dev/null \
+    | awk '
+        match($0, /idx=[0-9]+/) {
+          v = substr($0, RSTART + 4, RLENGTH - 4)
+          last = v
+        }
+        END { if (last != "") print last }
+      '
+}
+
+# Allow a brief warm-up for the first grain to land if we got here
+# the instant the mirror flipped Ready.
+deadline=$(( $(date +%s) + 30 ))
+first=""
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  first=$(sample_idx || true)
+  [ -n "$first" ] && break
+  sleep 1
+done
+[ -n "$first" ] || fail "${READER_POD} produced no idx= lines within 30s"
+
+sleep "$SAMPLE_WINDOW_SECS"
+
+last=$(sample_idx || true)
+[ -n "$last" ] || fail "${READER_POD} stopped producing idx= lines mid-window"
+
+if [ "$last" -le "$first" ]; then
+  fail "reader grain index did not advance: first=${first} last=${last} window=${SAMPLE_WINDOW_SECS}s"
+fi
+
+echo "  idx advanced ${first} -> ${last} over ${SAMPLE_WINDOW_SECS}s ($(( last - first )) grains)"

--- a/test/integration/kind/lib.sh
+++ b/test/integration/kind/lib.sh
@@ -1,0 +1,127 @@
+# lib.sh -- shared helpers for the KIND integration suite. Sourced by
+# run.sh and by each case under cases/.
+#
+# Exported state:
+#   KIND_CLUSTER          name of the running KIND cluster
+#   NAMESPACE             namespace the demo is applied to
+#   KUBECTL               array; expands to `kubectl --context kind-...`
+#   KIND_DIAG_DIR         directory where collect_diagnostics writes
+#   ROLLOUT_TIMEOUT_SECS  per-rollout-status wait
+#   MIRROR_TIMEOUT_SECS   per-MxlFlowMirror Ready wait
+#   PROBE_TIMEOUT_SECS    per-port-forward startup wait
+
+KIND_CLUSTER="${KIND_CLUSTER:-mxl-k8s-demo}"
+NAMESPACE="${MXL_NAMESPACE:-mxl-system}"
+KUBECTL=(kubectl --context "kind-${KIND_CLUSTER}")
+KIND_DIAG_DIR="${KIND_DIAG_DIR:-${PWD}/kind-diagnostics}"
+ROLLOUT_TIMEOUT_SECS="${ROLLOUT_TIMEOUT_SECS:-180}"
+MIRROR_TIMEOUT_SECS="${MIRROR_TIMEOUT_SECS:-180}"
+PROBE_TIMEOUT_SECS="${PROBE_TIMEOUT_SECS:-30}"
+
+log()  { printf '\n=== %s ===\n' "$*" >&2; }
+fail() { echo "FAIL: $*" >&2; exit 1; }
+need() { command -v "$1" >/dev/null 2>&1 || fail "missing required tool: $1"; }
+
+# wait_phase <resource> <jsonpath> <regex> <timeout-secs>
+# Polls the resource until the jsonpath output matches the regex, or
+# the timeout elapses. On success prints the last observed value to
+# stdout; on timeout returns non-zero with the last value on stderr.
+wait_phase() {
+  local resource="$1" jsonpath="$2" regex="$3" timeout="$4"
+  local deadline value
+  deadline=$(( $(date +%s) + timeout ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    value=$("${KUBECTL[@]}" -n "$NAMESPACE" get "$resource" \
+              -o jsonpath="$jsonpath" 2>/dev/null || true)
+    if echo "$value" | grep -Eq "$regex"; then
+      echo "$value"
+      return 0
+    fi
+    sleep 2
+  done
+  echo "wait_phase: $resource $jsonpath did not match /$regex/ in ${timeout}s; last='$value'" >&2
+  return 1
+}
+
+# port_forward_probe <pod> <port> <path>
+# Opens a kubectl port-forward to pod:port, curls /<path>, and prints
+# the HTTP status code on stdout. Returns 0 iff the code is 200.
+# Random-binds locally (`0:port`) and learns the assigned port from
+# kubectl's stdout, avoiding clashes with parallel forwards.
+port_forward_probe() {
+  local pod="$1" port="$2" path="$3"
+  local pf_log local_port code rc deadline pf_pid
+  pf_log="$(mktemp)"
+  "${KUBECTL[@]}" -n "$NAMESPACE" port-forward "pod/${pod}" "0:${port}" \
+      > "$pf_log" 2>&1 &
+  pf_pid=$!
+
+  deadline=$(( $(date +%s) + PROBE_TIMEOUT_SECS ))
+  local_port=""
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    local_port=$(sed -n 's/.*Forwarding from 127\.0\.0\.1:\([0-9]*\) ->.*/\1/p' "$pf_log" | head -1)
+    [ -n "$local_port" ] && break
+    sleep 0.2
+  done
+  if [ -z "$local_port" ]; then
+    cat "$pf_log" >&2
+    kill "$pf_pid" 2>/dev/null || true
+    wait "$pf_pid" 2>/dev/null || true
+    rm -f "$pf_log"
+    echo "000"
+    return 1
+  fi
+
+  code=$(curl -sS -o /dev/null -w '%{http_code}' \
+              --max-time 5 "http://127.0.0.1:${local_port}/${path}" || echo "000")
+  rc=0
+  [ "$code" = "200" ] || rc=1
+
+  kill "$pf_pid" 2>/dev/null || true
+  wait "$pf_pid" 2>/dev/null || true
+  rm -f "$pf_log"
+  echo "$code"
+  return "$rc"
+}
+
+# resolve_pod <app.kubernetes.io/name label value>
+# Prints the name of one Running pod with the given label, or returns
+# non-zero. Used by cases that need to address a concrete pod.
+resolve_pod() {
+  local label="$1" pod
+  pod=$("${KUBECTL[@]}" -n "$NAMESPACE" get pods \
+          -l "app.kubernetes.io/name=${label}" \
+          --field-selector=status.phase=Running \
+          -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+  [ -n "$pod" ] || return 1
+  echo "$pod"
+}
+
+# collect_diagnostics
+# Dumps cluster state and component logs into $KIND_DIAG_DIR. Called
+# by run.sh once at the end of the suite if any case failed, so the
+# CI job can upload the directory as a workflow artifact.
+collect_diagnostics() {
+  mkdir -p "$KIND_DIAG_DIR"
+  "${KUBECTL[@]}" get all -A -o wide \
+      > "$KIND_DIAG_DIR/get-all.txt"        2>&1 || true
+  "${KUBECTL[@]}" -n "$NAMESPACE" describe pods \
+      > "$KIND_DIAG_DIR/describe-pods.txt"  2>&1 || true
+  "${KUBECTL[@]}" -n "$NAMESPACE" get events --sort-by=.lastTimestamp \
+      > "$KIND_DIAG_DIR/events.txt"         2>&1 || true
+  "${KUBECTL[@]}" -n "$NAMESPACE" get \
+      mxldomains,mxlflows,mxlflowmirrors,mxlreceivers,mxlnodecapabilities \
+      -o yaml \
+      > "$KIND_DIAG_DIR/mxl-resources.yaml" 2>&1 || true
+  for app in mxl-operator mxl-domain-agent mxl-fabrics-gateway; do
+    "${KUBECTL[@]}" -n "$NAMESPACE" logs \
+        -l "app.kubernetes.io/name=${app}" \
+        --all-containers --prefix --tail=400 \
+        > "$KIND_DIAG_DIR/${app}.log"       2>&1 || true
+  done
+  for pod in mxl-tcp-demo-writer mxl-tcp-demo-reader; do
+    "${KUBECTL[@]}" -n "$NAMESPACE" logs "pod/${pod}" \
+        --all-containers --prefix --tail=400 \
+        > "$KIND_DIAG_DIR/${pod}.log"       2>&1 || true
+  done
+}

--- a/test/integration/kind/run.sh
+++ b/test/integration/kind/run.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+# run.sh -- KIND integration suite runner. Sources lib.sh, iterates
+# cases/*.sh in lexicographic order, prints a pass/fail summary, and
+# exits non-zero if any case failed. Per-case stdout/stderr land
+# under $KIND_DIAG_DIR/cases/; cluster-level diagnostics under
+# $KIND_DIAG_DIR/ are collected once at the end on any failure.
+
+set -uo pipefail
+
+SUITE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+export KIND_TEST_LIB="${SUITE_DIR}/lib.sh"
+
+# shellcheck source=lib.sh
+. "$KIND_TEST_LIB"
+
+need kubectl
+need kind
+need curl
+
+if ! kind get clusters 2>/dev/null | grep -qx "$KIND_CLUSTER"; then
+  fail "KIND cluster ${KIND_CLUSTER} not present (run 'make kind-up' first)"
+fi
+
+mkdir -p "$KIND_DIAG_DIR/cases"
+
+# Resolve the case list. CASE_GLOB lets a developer filter; defaults
+# to every executable .sh file under cases/.
+CASE_GLOB="${CASE_GLOB:-${SUITE_DIR}/cases/*.sh}"
+cases=()
+for path in $CASE_GLOB; do
+  [ -f "$path" ] || continue
+  cases+=("$path")
+done
+
+if [ "${#cases[@]}" -eq 0 ]; then
+  fail "no cases matched ${CASE_GLOB}"
+fi
+
+# Parallel arrays (bash 3.2 has no associative arrays): case path /
+# result label / wall-clock duration. Index-aligned.
+results_path=()
+results_label=()
+results_secs=()
+any_failed=0
+
+for case_path in "${cases[@]}"; do
+  case_name="$(basename "$case_path" .sh)"
+  case_log="${KIND_DIAG_DIR}/cases/${case_name}.log"
+  log "case: ${case_name}"
+  start=$(date +%s)
+  if bash "$case_path" > "$case_log" 2>&1; then
+    label=PASS
+  else
+    label=FAIL
+    any_failed=1
+  fi
+  end=$(date +%s)
+  secs=$(( end - start ))
+
+  results_path+=("$case_path")
+  results_label+=("$label")
+  results_secs+=("$secs")
+
+  # Stream the case's output back to the runner's stdout so the CI
+  # log shows it inline; the file under cases/ keeps the raw copy.
+  sed 's/^/    /' "$case_log" >&2
+  printf '  [%s] %s (%ss)\n' "$label" "$case_name" "$secs" >&2
+done
+
+log "summary"
+i=0
+while [ "$i" -lt "${#results_path[@]}" ]; do
+  printf '  %-4s %-32s %ss\n' \
+      "${results_label[$i]}" \
+      "$(basename "${results_path[$i]}" .sh)" \
+      "${results_secs[$i]}" >&2
+  i=$(( i + 1 ))
+done
+
+if [ "$any_failed" -ne 0 ]; then
+  log "collecting diagnostics into ${KIND_DIAG_DIR}"
+  collect_diagnostics
+  exit 1
+fi
+
+log "PASS"


### PR DESCRIPTION
The KIND demo had no end-to-end test, so a regression in
`hack/kind-up.sh`, `examples/tcp-demo/`, or any of the five
component images could silently break the converged cluster. PR
#68's `BUILD=<tag>` mode is the missing piece -- it makes a CI
smoke against PR-built images possible without rebuilding inside
the job.

`test/integration/kind/` runs against an already-running cluster.
Five cases under `cases/` assert the CRDs reach `Established`,
the operator deploy plus the agent and gateway DaemonSets roll
out, `/healthz` and `/readyz` answer 200 via `kubectl
port-forward`, every `MxlFlowMirror` reaches `phase=Ready` with a
non-empty `status.targetInfo`, and the reader pod's `idx=` log
lines actually advance over a 5s sample window. The last case is
load-bearing: it distinguishes "phase=Ready" from "target
progress loop never read a grain".

`cases/` is the extension surface. `run.sh` discovers `NN-name.sh`
files in lexicographic order, executes each, and dumps per-case
logs plus cluster diagnostics into `KIND_DIAG_DIR` on any
failure. New assertions land as additional case files; no surgery
on the runner. The suite targets bash 3.2 per the repo-wide rule.

A new `kind-integration` job in `images.yml` runs after `merge`
has published the per-PR multi-arch manifest, then invokes `make
kind-up BUILD=pr-<num>-<sha>` followed by `make kind-test`. Gated
by the `kind` path filter and an opt-in `run-kind` PR label so
unrelated diffs skip cleanly; fork PRs skip because the per-PR
tag is not pushed to GHCR; tag pushes and `release_tag`
workflow_call invocations skip because the kind path is a
pre-release smoke test, not a release gate. The job is wired
into `images-summary` so branch protection picks up its result.

Verified locally against the existing `mxl-k8s-demo` cluster:
all five cases pass in ~9s (frames case observed the reader's
`idx=` advance by 153 grains over the 5s window).