### PR TITLE
chore: ignore .claude/worktrees/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ kind-diagnostics/
 # Editor/IDE
 # .idea/
 # .vscode/
+
+# Per-session git worktrees managed by the Claude Code harness
+.claude/worktrees/


### PR DESCRIPTION
The Claude Code harness creates per-session worktrees under
.claude/worktrees/agent-<id>/ for parallel agents to mutate the
repository without colliding. Those trees are scratch space tied
to a single session and must never be tracked.