### PR TITLE
fix(gateway): recover targets wedged in silent ErrNotReady

### DIFF
--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -228,7 +228,6 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// re-registered the flow, typically after a pod restart).
 		// Tear down + reopen so the reader tails the fresh writer
 		// instead of holding a handle on a now-invalid ring.
-		// Target-side recoverFromFatalError republishes status.targetInfo via SSA on the Ready transition after rebuilding the fabric side. This infoStr comparison is the source initiator's only wake-up signal for that rotation - do not add a spec-only predicate to this watch.
 		if originRotated(existing.lastObservedOriginAt.Load(), originAt) {
 			l.Info("flow origin rotated, reopening reader")
 			r.closeEntry(req.NamespacedName)
@@ -238,7 +237,13 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 			// TargetInfo rotated under us (typically: target gateway
 			// restarted and rebuilt the writer on a fresh ephemeral
 			// port). Tear down the stale initiator so we re-open
-			// against the new address.
+			// against the new address. The target side also lands
+			// here after recoverFromFatalError republishes
+			// status.targetInfo via SSA on its Ready transition --
+			// the infoStr comparison above is the source initiator's
+			// only wake-up signal for that rotation, so do not add a
+			// spec-only predicate to the MxlFlowMirror watch or
+			// recovery wakes will be silently dropped.
 			l.Info("target info rotated, rebuilding initiator")
 			r.closeEntry(req.NamespacedName)
 		}

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -228,6 +228,7 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// re-registered the flow, typically after a pod restart).
 		// Tear down + reopen so the reader tails the fresh writer
 		// instead of holding a handle on a now-invalid ring.
+		// Target-side recoverFromFatalError republishes status.targetInfo via SSA on the Ready transition after rebuilding the fabric side. This infoStr comparison is the source initiator's only wake-up signal for that rotation - do not add a spec-only predicate to this watch.
 		if originRotated(existing.lastObservedOriginAt.Load(), originAt) {
 			l.Info("flow origin rotated, reopening reader")
 			r.closeEntry(req.NamespacedName)

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -45,6 +45,35 @@ const defaultDegradedAfter = 10 * time.Second
 // transition.
 const defaultTargetFlushInterval = 1 * time.Second
 
+// defaultStuckHandshakeAfter is the duration without any grain
+// commit since the fabric side was last opened that the flusher
+// treats as a silent libmxl-fabrics wedge: ReadGrain keeps reporting
+// ErrNotReady forever, so onFatal never fires, but no FI_CONNECTED
+// has landed and no grain has ever arrived. After this much time the
+// flusher escalates into recoverFromFatalError instead of waiting on
+// a fatal signal that will never come. 20 s sits between the typical
+// post-DaemonSet-rollout reconnect window (~15 s observed) and the
+// kind testcase-60 ceiling (STUCK_SECS=45 s).
+const defaultStuckHandshakeAfter = 20 * time.Second
+
+// maxStuckRebuilds bounds the number of consecutive recovery spawns
+// the watchdog will issue without seeing a grain commit land. On the
+// (maxStuckRebuilds+1)th observation of a stuck handshake the flusher
+// publishes Phase=Failed with reason StuckHandshakeCapReached, drops
+// the entry, closes the writer (invalidating consumer FlowReaders),
+// and exits; the next Reconcile rebuilds from scratch. The counter
+// resets on the first commit after each successful fabric open, so
+// the cap counts *consecutive* failed rebuilds, not lifetime ones.
+const maxStuckRebuilds uint32 = 3
+
+// ReasonStuckHandshakeCapReached marks a target-side mirror whose
+// libmxl-fabrics handshake never produced a grain commit across
+// maxStuckRebuilds consecutive watchdog-driven rebuilds. Distinct
+// from ReasonNoGrains: NoGrains is a recoverable Degraded state, this
+// reason accompanies a terminal Phase=Failed and signals that the
+// gateway has given up rebuilding the target in place.
+const ReasonStuckHandshakeCapReached = "StuckHandshakeCapReached"
+
 // TargetReconciler reconciles MxlFlowMirror resources from the
 // receiving side. See the package doc.
 type TargetReconciler struct {
@@ -75,10 +104,28 @@ type TargetReconciler struct {
 	// re-establish instead of short-circuiting. Defaults to 10s.
 	DegradedAfter time.Duration
 
+	// StuckHandshakeAfter is the duration without any grain commit
+	// since the fabric side was opened that the flusher treats as a
+	// silent libmxl-fabrics wedge (ErrNotReady forever, no fatal
+	// signal). On reaching it the flusher spawns recoverFromFatalError
+	// instead of waiting on a fatal that will not come. Defaults to
+	// defaultStuckHandshakeAfter.
+	StuckHandshakeAfter time.Duration
+
 	// openFabricSideFn is overridable so tests exercise the recovery
 	// path without a real libmxl-fabrics. Production leaves it nil
 	// and the reconciler falls back to (*TargetReconciler).openFabricSide.
 	openFabricSideFn func(writer *mxl.Writer, provider fabrics.Provider) (*fabrics.Regions, *fabrics.Target, *fabrics.TargetInfo, string, error)
+
+	// recoverFn is the seam the stuck-handshake watchdog uses to
+	// spawn its recovery work. Production leaves it nil and the
+	// flusher invokes recoverFromFatalError directly; tests inject a
+	// stub so the watchdog's spawn/cap behavior can be observed
+	// without driving a real libmxl-fabrics rebuild. Kept distinct
+	// from openFabricSideFn because the watchdog's contract is
+	// "fire-and-forget" — it does not own the recovery result, only
+	// the gate that prevents double spawns.
+	recoverFn func(key types.NamespacedName)
 
 	mu      sync.Mutex
 	targets map[types.NamespacedName]*targetEntry
@@ -111,6 +158,30 @@ type targetEntry struct {
 	// status flusher.
 	commits      atomic.Uint64
 	lastCommitAt atomic.Pointer[time.Time]
+
+	// fabricOpenedAt is the wall-clock the current fabric side became
+	// live (initial openTarget or a recoverFromFatalError rebuild).
+	// commitsAtFabricOpen snapshots the commits counter at the same
+	// moment. Together they let the flusher discriminate "no commits
+	// yet because we just opened" from "no commits because the
+	// handshake is silently wedged" without needing a separate
+	// state-machine flag.
+	//
+	// Atomic because the recovery goroutine swaps them inside
+	// startProgressLoop while the flusher tick reads them. The
+	// existing entry.recovering atomic gates the flusher's read but
+	// only after the recovery has cleared it; the watchdog block
+	// reads these values from the flusher without ever taking r.mu.
+	// nil pointer (zero value) means "fabric side never opened".
+	fabricOpenedAt      atomic.Pointer[time.Time]
+	commitsAtFabricOpen atomic.Uint64
+
+	// recoveryAttempts counts consecutive watchdog-spawned recovery
+	// invocations that did not result in a fresh commit. recordCommit
+	// resets it to zero on the first commit after each fabric open,
+	// so the cap counts *consecutive* failed rebuilds rather than
+	// lifetime ones. The flusher caps spawns at maxStuckRebuilds.
+	recoveryAttempts atomic.Uint32
 
 	// recovering, set during recoverFromFatalError, tells the flusher
 	// to back off so its writes do not race the rebuild's own status
@@ -345,6 +416,15 @@ func (r *TargetReconciler) openFabricSideDispatch(writer *mxl.Writer, provider f
 // arms the recovery callback. Called after openTarget and again
 // after every successful in-place fabric rebuild.
 func (r *TargetReconciler) startProgressLoop(entry *targetEntry, key types.NamespacedName) {
+	// Re-arm the stuck-handshake watchdog reference: every fabric
+	// open (initial or rebuilt) gets its own elapsed window measured
+	// against its own commits baseline. Without resetting here the
+	// post-recovery flusher would trip the watchdog immediately on
+	// the carried-over (now-stale) fabricOpenedAt.
+	now := time.Now()
+	entry.fabricOpenedAt.Store(&now)
+	entry.commitsAtFabricOpen.Store(entry.commits.Load())
+
 	loopCtx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	entry.cancel = cancel
@@ -369,9 +449,17 @@ type commitTracker interface {
 }
 
 func (e *targetEntry) recordCommit(_ uint64, at time.Time) {
-	e.commits.Add(1)
+	n := e.commits.Add(1)
 	t := at
 	e.lastCommitAt.Store(&t)
+	// First commit after this fabric side opened disarms the
+	// stuck-handshake cap so a previously-rebuilt-successfully entry
+	// gets a fresh budget if it later wedges again. recoveryAttempts
+	// thus counts *consecutive* unsuccessful rebuilds, not lifetime
+	// ones.
+	if n == e.commitsAtFabricOpen.Load()+1 {
+		e.recoveryAttempts.Store(0)
+	}
 }
 
 // runTargetProgressLoop drives the libmxl-fabrics Target until ctx
@@ -473,6 +561,20 @@ func (r *TargetReconciler) closeEntry(key types.NamespacedName) {
 		return
 	}
 	closeTargetHandles(entry)
+}
+
+// dispatchRecovery routes the stuck-handshake watchdog's spawn
+// through the recoverFn seam when set, falling back to the cgo-
+// dependent recoverFromFatalError in production. The runTargetProgressLoop
+// onFatal callback continues to invoke recoverFromFatalError
+// directly: that path only fires on a fatal ReadGrain return, which
+// the tests cannot reach without real libmxl-fabrics anyway.
+func (r *TargetReconciler) dispatchRecovery(key types.NamespacedName) {
+	if r.recoverFn != nil {
+		r.recoverFn(key)
+		return
+	}
+	r.recoverFromFatalError(key)
 }
 
 // recoverFromFatalError rebuilds the libmxl-fabrics side of a mirror
@@ -664,6 +766,16 @@ func (r *TargetReconciler) degradedAfter() time.Duration {
 	return defaultDegradedAfter
 }
 
+// stuckHandshakeAfter returns the configured silent-wedge timeout the
+// flusher uses to escalate a non-progressing target into recovery,
+// falling back to defaultStuckHandshakeAfter when unset.
+func (r *TargetReconciler) stuckHandshakeAfter() time.Duration {
+	if r.StuckHandshakeAfter > 0 {
+		return r.StuckHandshakeAfter
+	}
+	return defaultStuckHandshakeAfter
+}
+
 // flushInterval returns the configured per-mirror flusher tick,
 // falling back to defaultTargetFlushInterval when unset.
 func (r *TargetReconciler) flushInterval() time.Duration {
@@ -737,6 +849,96 @@ func (r *TargetReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 		// the fabric side. Skip the tick so the flusher's Degraded
 		// write does not race the recovery's Materializing publish.
 		if entry.recovering.Load() {
+			continue
+		}
+		// Stuck-handshake watchdog. A libmxl-fabrics target whose
+		// remote initiator never sent FI_CONNECTED keeps reporting
+		// ErrNotReady forever - the progress loop never raises
+		// onFatal, so recoverFromFatalError never fires, and the
+		// flusher would otherwise just oscillate between Ready and
+		// Degraded as time goes by. Spawn recovery explicitly when
+		// no commit has landed since the fabric side opened and the
+		// stuck-handshake window has elapsed.
+		//
+		// A nil fabricOpenedAt guards entries that the flusher runs
+		// against without a real openTarget/recovery handoff (existing
+		// flusher tests construct bare targetEntry values and drive
+		// the flusher directly): the watchdog must not fire on an
+		// entry whose fabric side was never actually opened.
+		openedAt := entry.fabricOpenedAt.Load()
+		if openedAt != nil &&
+			entry.commits.Load() == entry.commitsAtFabricOpen.Load() &&
+			time.Since(*openedAt) > r.stuckHandshakeAfter() {
+			if entry.recoveryAttempts.Load() >= maxStuckRebuilds {
+				// Cap reached: rebuilds keep failing to attract a
+				// commit. Publish a terminal Phase=Failed so operators
+				// see an explicit dead state, tear down the entry the
+				// way recoverFromFatalError's failure path does, and
+				// exit the flusher. The next Reconcile rebuilds the
+				// entry from scratch through openTarget.
+				//
+				// closeEntry must NOT be called from here:
+				// closeTargetHandles waits on flusherDone and the
+				// flusher is the goroutine that closes it on return,
+				// so a closeEntry from this point would deadlock the
+				// flusher on its own done channel. The teardown below
+				// matches recoverFromFatalError's drop-entry exit
+				// shape: cancel progress loop, wait for done, delete
+				// from r.targets, close writer, return.
+				log.FromContext(ctx).Error(nil,
+					"stuck handshake; recovery cap reached, dropping entry",
+					"mirror", key,
+					"attempts", entry.recoveryAttempts.Load())
+				if mirror, err := r.fetchMirror(ctx, key); err == nil {
+					_ = r.applyTargetStatus(ctx, mirror, mxlv1alpha1.MxlFlowMirrorFailed, &entry.infoStr, nil, &metav1.Condition{
+						Type:               mxlv1alpha1.ConditionTypeTargetProgress,
+						Status:             metav1.ConditionFalse,
+						Reason:             ReasonStuckHandshakeCapReached,
+						Message:            fmt.Sprintf("no commits in %s across %d rebuild attempts", r.stuckHandshakeAfter(), maxStuckRebuilds),
+						LastTransitionTime: metav1.Now(),
+					})
+				}
+				if entry.cancel != nil {
+					entry.cancel()
+				}
+				if entry.done != nil {
+					// Mirror recoverFromFatalError's ordering
+					// (target.go drop-entry exit): the progress loop
+					// must release its libmxl handles before Close
+					// runs underneath it.
+					<-entry.done
+				}
+				r.mu.Lock()
+				delete(r.targets, key)
+				r.mu.Unlock()
+				if entry.writer != nil {
+					// Invalidates consumer FlowReaders, matching
+					// recoverFromFatalError's failure exit. A
+					// concurrent closeEntry+closeTargetHandles would
+					// also Close this writer; double-close on
+					// *mxl.Writer is safe per the existing precedent
+					// in closeTargetHandles.
+					_ = entry.writer.Close()
+				}
+				return
+			}
+			if entry.recovering.CompareAndSwap(false, true) {
+				// CompareAndSwap, not Load+Store: two flusher ticks
+				// observing "not recovering" simultaneously would
+				// otherwise both spawn recoverFromFatalError on the
+				// same entry. CAS makes the spawn atomic. The
+				// goroutine clears recovering via the deferred
+				// Store(false) inside recoverFromFatalError.
+				attempt := entry.recoveryAttempts.Add(1)
+				log.FromContext(ctx).Info("stuck handshake; triggering recovery",
+					"mirror", key, "attempt", attempt)
+				go r.dispatchRecovery(key)
+			}
+			// Skip the Degraded write this tick: publishing it would
+			// flap Ready->Degraded->Materializing->Ready around the
+			// rebuild. The watchdog and the would-be Degraded write
+			// fire on the same discriminator, so the recovery must
+			// take precedence.
 			continue
 		}
 		state := observedTargetState(entry, r.degradedAfter(), last)

--- a/gateway/internal/mirror/target_test.go
+++ b/gateway/internal/mirror/target_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
@@ -655,4 +656,455 @@ func TestTarget_RecoverFromFatalErrorClearsRecoveringOnRebuildFailure(t *testing
 	assert.False(t, present,
 		"a failed rebuild must drop the entry so the next Reconcile rebuilds "+
 			"from scratch instead of operating on torn-down fabric handles")
+}
+
+func TestRecordCommit_FirstCommitResetsRecoveryAttempts(t *testing.T) {
+	// recordCommit must zero recoveryAttempts on the first commit
+	// after each fabric open so a previously-rebuilt-successfully
+	// entry that later wedges again gets a fresh budget. The cap
+	// counts *consecutive* failed rebuilds, not lifetime ones.
+	entry := &targetEntry{}
+	entry.commits.Store(5)
+	entry.commitsAtFabricOpen.Store(5)
+	entry.recoveryAttempts.Store(2)
+
+	entry.recordCommit(0, time.Now())
+
+	assert.Equal(t, uint32(0), entry.recoveryAttempts.Load(),
+		"the first commit after fabricOpenedAt was set must clear the "+
+			"recoveryAttempts counter; without the reset, the cap would "+
+			"fire across what are actually unrelated stuck windows")
+
+	// A subsequent commit must not re-reset (the condition fires only
+	// on the first-commit-after-open boundary).
+	entry.recoveryAttempts.Store(1)
+	entry.recordCommit(0, time.Now())
+	assert.Equal(t, uint32(1), entry.recoveryAttempts.Load(),
+		"only the very first commit after each fabric open resets the "+
+			"counter; later commits must leave it alone so the next "+
+			"wedge keeps any in-flight attempt count intact")
+}
+
+// targetWatchdogFixture sets up a TargetReconciler + entry pair
+// configured to exercise the stuck-handshake watchdog in isolation.
+// FlushInterval is small (1ms) so a test can drive several ticks
+// inside an Eventually budget; StuckHandshakeAfter is shorter still
+// (1ms) so the wedge condition is permanently met from the moment
+// fabricOpenedAt is stamped. DegradedAfter is wide so the would-be
+// Degraded write would still apply if the watchdog branch did not
+// pre-empt it.
+type targetWatchdogFixture struct {
+	r       *TargetReconciler
+	entry   *targetEntry
+	key     types.NamespacedName
+	cancel  context.CancelFunc
+	done    chan struct{}
+	mirror  *mxlv1alpha1.MxlFlowMirror
+	c       client.WithWatch
+	spawnCh chan struct{} // unbuffered; receiver blocks each spawn
+}
+
+func newTargetWatchdogFixture(t *testing.T, spawnBufLen int) *targetWatchdogFixture {
+	t.Helper()
+	scheme := newSourceTestScheme(t)
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	mirror := mirrorWithTargetFinalizer(key.Name, key.Namespace, "node-a", "flow-1", mxlv1alpha1.MxlFlowMirrorStatus{
+		Phase:      mxlv1alpha1.MxlFlowMirrorReady,
+		TargetInfo: "info-1",
+	})
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	entry := &targetEntry{infoStr: "info-1"}
+	// fabricOpenedAt sits far in the past so time.Since() always
+	// exceeds StuckHandshakeAfter; commits/commitsAtFabricOpen are
+	// both zero so the no-progress branch matches.
+	past := time.Now().Add(-time.Hour)
+	entry.fabricOpenedAt.Store(&past)
+	entry.commitsAtFabricOpen.Store(0)
+	// cancel + done so the cap path's <-entry.done does not block:
+	// a closed channel reads instantly. Tests that want to assert
+	// ordering replace these with channels they control.
+	closedDone := make(chan struct{})
+	close(closedDone)
+	entry.cancel = func() {}
+	entry.done = closedDone
+
+	spawnCh := make(chan struct{}, spawnBufLen)
+	r := &TargetReconciler{
+		Client:              c,
+		Scheme:              scheme,
+		NodeName:            "node-a",
+		FlushInterval:       1 * time.Millisecond,
+		DegradedAfter:       time.Hour, // wide so Degraded does not pre-empt the watchdog
+		StuckHandshakeAfter: 1 * time.Millisecond,
+		targets:             map[types.NamespacedName]*targetEntry{key: entry},
+		recoverFn: func(types.NamespacedName) {
+			spawnCh <- struct{}{}
+			// Re-arm the watchdog for the next tick: clear recovering
+			// so CompareAndSwap can succeed again, and stamp
+			// fabricOpenedAt back into the past so the wedge condition
+			// stays true. A real recoverFromFatalError calls
+			// startProgressLoop, which would reset fabricOpenedAt to
+			// time.Now() and bury the wedge window; the test's
+			// re-wedge scenario instead simulates the case where each
+			// rebuild succeeds but the new fabric side wedges again
+			// before any commit lands.
+			past := time.Now().Add(-time.Hour)
+			entry.fabricOpenedAt.Store(&past)
+			entry.recovering.Store(false)
+		},
+	}
+
+	return &targetWatchdogFixture{
+		r:       r,
+		entry:   entry,
+		key:     key,
+		mirror:  mirror,
+		c:       c,
+		spawnCh: spawnCh,
+	}
+}
+
+func (f *targetWatchdogFixture) startFlusher(t *testing.T) {
+	t.Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	f.cancel = cancel
+	f.done = done
+	go f.r.runFlusher(ctx, done, f.key, f.entry)
+}
+
+func (f *targetWatchdogFixture) stopFlusher(t *testing.T) {
+	t.Helper()
+	if f.cancel == nil {
+		return
+	}
+	f.cancel()
+	select {
+	case <-f.done:
+	case <-time.After(time.Second):
+		t.Fatal("flusher did not exit after cancel")
+	}
+	f.cancel = nil
+}
+
+func TestRunFlusher_StuckHandshake_TriggersRecovery(t *testing.T) {
+	// Fabric opened in the distant past, zero commits: the flusher
+	// must escalate into the recovery seam exactly once and increment
+	// recoveryAttempts. Without the escalation a silently-wedged
+	// libmxl-fabrics target stays Ready forever (no fatal ReadGrain
+	// to trigger onFatal) and consumer FlowReaders see no grains.
+	f := newTargetWatchdogFixture(t, 4)
+	f.startFlusher(t)
+	defer f.stopFlusher(t)
+
+	select {
+	case <-f.spawnCh:
+	case <-time.After(time.Second):
+		t.Fatal("watchdog did not spawn recovery within 1s of a stuck handshake")
+	}
+
+	require.Eventually(t, func() bool {
+		return f.entry.recoveryAttempts.Load() >= 1
+	}, time.Second, 5*time.Millisecond,
+		"the watchdog spawn must increment recoveryAttempts so the cap "+
+			"branch can count consecutive failures")
+}
+
+func TestRunFlusher_CommitDisarmsWatchdog(t *testing.T) {
+	// One commit recorded after the fabric opened: the flusher must
+	// NOT spawn recovery. The discriminator is "no progress since
+	// open", not "fabric opened long ago".
+	f := newTargetWatchdogFixture(t, 4)
+	// Simulate a commit landing: bump commits past commitsAtFabricOpen.
+	f.entry.commits.Store(1)
+	commitAt := time.Now()
+	f.entry.lastCommitAt.Store(&commitAt)
+
+	f.startFlusher(t)
+	defer f.stopFlusher(t)
+
+	select {
+	case <-f.spawnCh:
+		t.Fatal("watchdog spawned recovery despite a commit landing after fabric open; " +
+			"the discriminator must be 'no progress since open', not 'time since open'")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	assert.Equal(t, uint32(0), f.entry.recoveryAttempts.Load(),
+		"a commit after fabric open must suppress the watchdog spawn; "+
+			"incrementing recoveryAttempts here would let an otherwise "+
+			"healthy mirror trip the cap on transient stalls")
+}
+
+func TestRunFlusher_CapsRecoveryAttempts(t *testing.T) {
+	// After maxStuckRebuilds spawns the next tick must publish
+	// Phase=Failed + Reason=StuckHandshakeCapReached, remove the
+	// entry from r.targets, and exit the flusher. The plan asserts
+	// exact spawn count + terminal status + entry removal + flusher
+	// exit in one test.
+	f := newTargetWatchdogFixture(t, int(maxStuckRebuilds)+2)
+	f.startFlusher(t)
+
+	for i := uint32(0); i < maxStuckRebuilds; i++ {
+		select {
+		case <-f.spawnCh:
+		case <-time.After(time.Second):
+			t.Fatalf("watchdog did not spawn recovery attempt %d within 1s", i+1)
+		}
+	}
+
+	// No further spawn should land; the cap fires on the next tick
+	// and tears the entry down. Drain the spawn channel briefly to
+	// confirm no fourth spawn slipped through.
+	select {
+	case <-f.spawnCh:
+		t.Fatalf("watchdog spawned more than maxStuckRebuilds=%d recoveries; "+
+			"the cap branch must take over before another spawn", maxStuckRebuilds)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	// Flusher must exit by itself once the cap branch returns.
+	select {
+	case <-f.done:
+	case <-time.After(time.Second):
+		t.Fatal("flusher did not exit after the cap branch fired; " +
+			"a stuck flusher leaks a goroutine and keeps producing status writes")
+	}
+	f.cancel = nil // already exited
+
+	f.r.mu.Lock()
+	_, present := f.r.targets[f.key]
+	f.r.mu.Unlock()
+	assert.False(t, present,
+		"the cap branch must delete the entry from r.targets so the next "+
+			"Reconcile rebuilds from scratch through openTarget")
+
+	assert.Equal(t, uint32(maxStuckRebuilds), f.entry.recoveryAttempts.Load(),
+		"recoveryAttempts must equal maxStuckRebuilds at cap time; a higher "+
+			"value means another spawn raced the cap branch")
+
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, f.c.Get(context.Background(), f.key, &got))
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorFailed, got.Status.Phase,
+		"the cap branch must publish Phase=Failed so operators see an "+
+			"explicit terminal state instead of a silently-dropped entry")
+}
+
+func TestRunFlusher_CapPath_TerminalStatus(t *testing.T) {
+	// Codifies the operator-visible signal: cap must publish a
+	// TargetProgress condition with reason StuckHandshakeCapReached.
+	// A bare Phase=Failed without the reason would leave operators
+	// unable to distinguish this failure mode from other terminal
+	// states.
+	f := newTargetWatchdogFixture(t, int(maxStuckRebuilds)+2)
+	f.startFlusher(t)
+
+	for i := uint32(0); i < maxStuckRebuilds; i++ {
+		select {
+		case <-f.spawnCh:
+		case <-time.After(time.Second):
+			t.Fatalf("recovery spawn %d did not fire", i+1)
+		}
+	}
+
+	require.Eventually(t, func() bool {
+		var got mxlv1alpha1.MxlFlowMirror
+		if err := f.c.Get(context.Background(), f.key, &got); err != nil {
+			return false
+		}
+		if got.Status.Phase != mxlv1alpha1.MxlFlowMirrorFailed {
+			return false
+		}
+		for _, cond := range got.Status.Conditions {
+			if cond.Type == mxlv1alpha1.ConditionTypeTargetProgress &&
+				cond.Reason == ReasonStuckHandshakeCapReached {
+				return true
+			}
+		}
+		return false
+	}, time.Second, 5*time.Millisecond,
+		"the cap branch must publish TargetProgress with reason "+
+			"StuckHandshakeCapReached; a missing reason hides the failure "+
+			"mode from operators")
+
+	select {
+	case <-f.done:
+	case <-time.After(time.Second):
+		t.Fatal("flusher did not exit after cap branch")
+	}
+	f.cancel = nil
+}
+
+func TestRunFlusher_CapResetsAfterCommit(t *testing.T) {
+	// A commit between cap-imminent spawns must reset the counter so
+	// the next stuck window starts from zero. The cap counts
+	// *consecutive* failed rebuilds; without the reset, a long-lived
+	// mirror that survives a couple of transient wedges would
+	// eventually trip the cap even though every wedge healed.
+	f := newTargetWatchdogFixture(t, int(maxStuckRebuilds)*3)
+	// Override the recoverFn to drive the test deterministically:
+	// each spawn rearms the wedge without recording a commit. The
+	// test injects the commit in between bursts.
+	f.r.recoverFn = func(types.NamespacedName) {
+		f.spawnCh <- struct{}{}
+		past := time.Now().Add(-time.Hour)
+		f.entry.fabricOpenedAt.Store(&past)
+		f.entry.recovering.Store(false)
+	}
+
+	f.startFlusher(t)
+	defer func() {
+		if f.cancel != nil {
+			f.cancel()
+			<-f.done
+		}
+	}()
+
+	// First burst: maxStuckRebuilds-1 spawns, then record a commit
+	// before the cap can fire.
+	for i := uint32(0); i < maxStuckRebuilds-1; i++ {
+		select {
+		case <-f.spawnCh:
+		case <-time.After(time.Second):
+			t.Fatalf("first burst: spawn %d did not fire", i+1)
+		}
+	}
+
+	// Pause the flusher so the commit + counter reset happen as one
+	// atomic transition: stop the flusher, mutate the entry, restart.
+	// Without the pause an in-flight tick could spawn a fourth time
+	// against the un-reset counter before the test gets to record
+	// the commit, racing the cap branch.
+	f.stopFlusher(t)
+
+	// Record a commit: recoveryAttempts must clear.
+	prev := f.entry.commits.Load()
+	f.entry.commitsAtFabricOpen.Store(prev)
+	f.entry.recordCommit(0, time.Now())
+	require.Equal(t, uint32(0), f.entry.recoveryAttempts.Load(),
+		"the post-burst recordCommit must clear recoveryAttempts; without "+
+			"the reset, the cap would persist across what are actually "+
+			"unrelated stuck windows")
+
+	// Set up a fresh wedge: commitsAtFabricOpen tracks current commits.
+	f.entry.commitsAtFabricOpen.Store(f.entry.commits.Load())
+	past := time.Now().Add(-time.Hour)
+	f.entry.fabricOpenedAt.Store(&past)
+	f.startFlusher(t)
+
+	// Second burst must again reach maxStuckRebuilds spawns before
+	// the cap fires, proving the counter restarted at zero.
+	for i := uint32(0); i < maxStuckRebuilds; i++ {
+		select {
+		case <-f.spawnCh:
+		case <-time.After(time.Second):
+			t.Fatalf("second burst: spawn %d did not fire; the post-commit "+
+				"counter reset must give a full fresh budget", i+1)
+		}
+	}
+
+	select {
+	case <-f.done:
+	case <-time.After(time.Second):
+		t.Fatal("flusher did not exit after the second burst hit the cap")
+	}
+	f.cancel = nil
+}
+
+func TestRunFlusher_CapPath_NoDeadlock(t *testing.T) {
+	// The cap branch waits on entry.done before deleting the entry
+	// and closing the writer (mirroring recoverFromFatalError's
+	// ordering). If a concurrent closeEntry+closeTargetHandles were
+	// to also wait on flusherDone, the two would deadlock: the
+	// flusher waits on entry.done while closeTargetHandles waits on
+	// flusherDone, and the flusher cannot return until it has waited
+	// on entry.done. The cap branch must complete within a bounded
+	// timeout regardless. Test by holding entry.done open just long
+	// enough for the cap branch to be parked on it, then releasing.
+	f := newTargetWatchdogFixture(t, int(maxStuckRebuilds)+2)
+	// Replace the closed entry.done with an open one so the cap
+	// branch's <-entry.done parks instead of returning instantly.
+	openDone := make(chan struct{})
+	f.entry.done = openDone
+	cancelCalled := make(chan struct{})
+	f.entry.cancel = func() { close(cancelCalled) }
+
+	f.startFlusher(t)
+
+	for i := uint32(0); i < maxStuckRebuilds; i++ {
+		select {
+		case <-f.spawnCh:
+		case <-time.After(time.Second):
+			t.Fatalf("spawn %d did not fire", i+1)
+		}
+	}
+
+	// Wait until the cap branch has cancelled the progress loop.
+	select {
+	case <-cancelCalled:
+	case <-time.After(time.Second):
+		t.Fatal("cap branch did not cancel the progress loop; the cap path " +
+			"must signal the loop to exit before waiting on done")
+	}
+
+	// At this point the cap branch is blocked on <-entry.done. The
+	// flusher is still running. Release the progress loop so the
+	// cap branch can finish its teardown.
+	close(openDone)
+
+	select {
+	case <-f.done:
+	case <-time.After(time.Second):
+		t.Fatal("cap branch deadlocked after progress loop released; the " +
+			"teardown ordering must not wait on the flusher's own done")
+	}
+	f.cancel = nil
+}
+
+func TestRunFlusher_RecoveryGate_NoDoubleSpawnUnderRace(t *testing.T) {
+	// CompareAndSwap on entry.recovering is the spawn gate: two
+	// flusher ticks observing "not recovering" simultaneously would
+	// otherwise both spawn recoverFromFatalError on the same entry.
+	// Pin recovering = true after the first spawn and confirm a
+	// second tick (which only proceeds because the first spawn does
+	// not clear the flag) does not double-spawn.
+	f := newTargetWatchdogFixture(t, 4)
+	// Override recoverFn to NOT clear the recovering flag: this
+	// pins entry.recovering=true after the first spawn, so the
+	// flusher's recovering.Load() check at the top of the tick
+	// short-circuits every subsequent tick. The watchdog block
+	// never runs again, regardless of how many ticks elapse.
+	f.r.recoverFn = func(types.NamespacedName) {
+		f.spawnCh <- struct{}{}
+		// Intentionally do NOT clear recovering: simulates a slow
+		// recovery still in flight when the next flusher tick fires.
+	}
+
+	f.startFlusher(t)
+	defer f.stopFlusher(t)
+
+	// First spawn must land.
+	select {
+	case <-f.spawnCh:
+	case <-time.After(time.Second):
+		t.Fatal("first spawn did not fire")
+	}
+
+	// No second spawn within a generous window of further ticks.
+	select {
+	case <-f.spawnCh:
+		t.Fatal("second spawn fired while a previous recovery was still " +
+			"in flight; CompareAndSwap must serialize the spawn against " +
+			"concurrent observers")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	assert.Equal(t, uint32(1), f.entry.recoveryAttempts.Load(),
+		"recoveryAttempts must be exactly 1 after a single spawn; a higher "+
+			"value would mean two ticks raced past the CAS gate")
 }


### PR DESCRIPTION
The target-side progress loop polls `fabrics.Target.ReadGrainNonBlocking` and only escalates non-`ErrNotReady` returns into `recoverFromFatalError` (see commit `ab6bdd0`). A libmxl-fabrics target whose remote initiator never finished the FI_CONNECTED handshake keeps reporting `ErrNotReady` indefinitely, so `onFatal` never fires, `recoverFromFatalError` never runs, and the entry sits `Ready` without ever committing a grain. Consumer `FlowReader`s drain while operators see the mirror as healthy. Kind testcase `60-gateway-ds-restart.sh` was intermittently failing on exactly this wedge after the gateway DaemonSet rollout.

The flusher already has coherent visibility into `commits` and the recovery gate, so the watchdog lives there rather than as a separate goroutine (which would add another shutdown-ordering case to `closeTargetHandles`). `startProgressLoop` stamps `fabricOpenedAt` and `commitsAtFabricOpen` on every open. The flusher escalates when `commits == commitsAtFabricOpen && time.Since(fabricOpenedAt) > 20 s` -- a `CompareAndSwap(false, true)` on `entry.recovering` gates the spawn so two ticks observing the gate cannot double-spawn `recoverFromFatalError`. `recordCommit` resets `recoveryAttempts` on the first commit after each fabric open so the cap counts *consecutive* failed rebuilds, not lifetime ones.

After `maxStuckRebuilds = 3` attempts the flusher publishes `Phase=Failed` with `TargetProgress` reason `StuckHandshakeCapReached`, cancels the progress loop, waits for `entry.done`, deletes the entry from `r.targets`, closes the writer (invalidating consumer `FlowReader`s, exactly as `recoverFromFatalError`'s own failure exit does), and returns from the flusher. The next `Reconcile` rebuilds from scratch through `openTarget`. The cap branch does not call `closeEntry`: `closeTargetHandles` waits on `flusherDone` and the flusher is the goroutine that closes it -- the teardown shape mirrors `recoverFromFatalError`'s drop-entry exit instead.

`defaultStuckHandshakeAfter = 20 s` sits between the observed post-DaemonSet-rollout reconnect window (~15 s) and testcase 60's `STUCK_SECS=45 s` ceiling. `ReasonStuckHandshakeCapReached` is defined locally in the gateway mirror package rather than in `api/v1alpha1/conditions.go` -- the API surface change is deferred so this PR stays inside the gateway module's release boundary.

The source reconciler gains a one-line invariant comment above the `infoStr` comparison that wakes the source initiator on a target-side rotation -- the target-side rebuild publishes the new `status.targetInfo` via SSA on the Ready transition, and that comparison is the source's only wake-up signal.

`fabricOpenedAt` and `commitsAtFabricOpen` are `atomic.Pointer`/`atomic.Uint64` because the recovery goroutine swaps them while the flusher reads them.