### PR TITLE
chore: ignore .omc/ except .omc/skills/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,7 +37,7 @@ kind-diagnostics/
 # Per-session git worktrees managed by the Claude Code harness
 .claude/worktrees/
 
-# Local OMC scratch state; keep only user-authored skills under .omc/skills/
+# Local OMC scratch state; keep skills under .omc/skills/
 !.omc/
 .omc/*
 !.omc/skills/

--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,12 @@ kind-diagnostics/
 # Per-session git worktrees managed by the Claude Code harness
 .claude/worktrees/
 
+# Local OMC scratch state; keep only user-authored skills under .omc/skills/
+!.omc/
+.omc/*
+!.omc/skills/
+!.omc/skills/**
+
 # Graphify local-only outputs (the rest of graphify-out/ is committed)
 graphify-out/manifest.json
 graphify-out/cost.json


### PR DESCRIPTION
The harness writes session-scoped scratch into `.omc/` (state, notepad, plans, research, logs) that must not enter the index. `.omc/skills/` holds skills meant to persist across sessions and be available in team scope -- both user-authored and ones OMC learned and generated itself -- so it stays tracked.

Verified:
- `.omc/state/*`, `.omc/notepad.md` -> ignored
- `.omc/skills/<name>/SKILL.md` -> staged by `git add .omc/`