### PR TITLE
fix(operator): reap stale mirror owner refs and tighten cross-ns labels

### DIFF
--- a/operator/internal/receiver/controller.go
+++ b/operator/internal/receiver/controller.go
@@ -409,18 +409,12 @@ func isFieldIndexUnsupported(err error) bool {
 // listOwnedCrossNsMirrors returns every MxlFlowMirror in a namespace
 // other than the receiver's own that this receiver owns.
 //
-// Cross-namespace mirrors carry LabelCreatedByReceiver=<recv.Name>
-// and LabelCreatedByReceiverNamespace=<recv.Namespace> (since PR #86).
-// Pre-PR-86 mirrors only carry LabelCreatedByReceiver; the namespace
-// label is absent. The lookup keeps the receiver-name label as the
-// cluster-wide selector (the only key that fits a single
-// MatchingLabels list call without 63-char overflow) and then in-Go
-// rejects any cross-namespace match whose namespace label disagrees
-// with this receiver's namespace, so two receivers sharing a name
-// across namespaces no longer collide. Mirrors with no namespace
-// label are accepted as legacy entries belonging to this receiver
-// for one upgrade cycle; on the next ensureMirror Create they will
-// be stamped with the namespace label.
+// Cross-namespace ownership requires both
+// LabelCreatedByReceiver=<recv.Name> and
+// LabelCreatedByReceiverNamespace=<recv.Namespace>. ensureMirror
+// stamps both on every cross-ns Create, so any mirror missing the
+// namespace label was not produced by this controller for this
+// receiver and is rejected.
 //
 // controller-runtime's field index extractor cannot return entries
 // reaching across the receiver's namespace boundary, so this stays
@@ -444,8 +438,7 @@ func (r *Reconciler) listOwnedCrossNsMirrorsFrom(ctx context.Context, reader cli
 		if mirrors.Items[i].Namespace == recv.Namespace {
 			continue
 		}
-		ns, hasNS := mirrors.Items[i].Labels[mxlv1alpha1.LabelCreatedByReceiverNamespace]
-		if hasNS && ns != recv.Namespace {
+		if mirrors.Items[i].Labels[mxlv1alpha1.LabelCreatedByReceiverNamespace] != recv.Namespace {
 			continue
 		}
 		out = append(out, mirrors.Items[i])
@@ -454,12 +447,18 @@ func (r *Reconciler) listOwnedCrossNsMirrorsFrom(ctx context.Context, reader cli
 }
 
 // gcOrphanMirrors releases this receiver's ownership of any mirror
-// not in the desired set. Called on every successful reconcile so a
-// pod move, a pod deletion, or a flow origin rotation all converge
-// to one mirror per live target node. Same-namespace mirrors lose
-// only this receiver's OwnerReference; apiserver GC handles the
-// eventual deletion once the owner list is empty. Cross-namespace
-// mirrors are unique per-receiver and get Deleted directly.
+// not in the desired set, and scrubs any owner reference whose UID
+// does not resolve to a live MxlReceiver in the mirror's namespace.
+// Called on every successful reconcile so a pod move, a pod deletion,
+// a flow origin rotation, or a stray foreign owner ref all converge
+// to the steady state. Same-namespace mirrors lose this receiver's
+// OwnerReference via removeOwnerRef, which itself issues a
+// resourceVersion-preconditioned Delete when the owner list goes
+// empty -- apiserver garbage collection does not fire on
+// ownerReferences becoming empty via Update, only when one of the
+// listed owners is itself deleted. Cross-namespace mirrors carry no
+// OwnerReferences (the apiserver rejects them) and get Deleted
+// directly.
 func (r *Reconciler) gcOrphanMirrors(ctx context.Context, recv *mxlv1alpha1.MxlReceiver, desired map[mirrorKey]nodeTarget) error {
 	sameNs, err := r.listOwnedSameNsMirrors(ctx, recv)
 	if err != nil {
@@ -469,6 +468,9 @@ func (r *Reconciler) gcOrphanMirrors(ctx context.Context, recv *mxlv1alpha1.MxlR
 		m := &sameNs[i]
 		if !m.DeletionTimestamp.IsZero() {
 			continue
+		}
+		if err := r.pruneForeignOwnerRefs(ctx, m); err != nil {
+			return fmt.Errorf("scrub foreign owner refs from %s/%s: %w", m.Namespace, m.Name, err)
 		}
 		key := mirrorKey{namespace: m.Namespace, name: m.Name}
 		if _, keep := desired[key]; keep {
@@ -835,36 +837,134 @@ func (r *Reconciler) removeOwnerRef(ctx context.Context, recv *mxlv1alpha1.MxlRe
 		return err
 	}
 	if deleteRV != "" {
-		// Guard the Delete with a resourceVersion precondition so a
-		// concurrent ensureOwnerRef from a sibling receiver, racing
-		// between this loop's Update and the Delete here, cannot lose
-		// its newly added owner ref. If the precondition fails the
-		// mirror was mutated after the empty-owners observation, which
-		// means it correctly has owners again; bail and let the next
-		// reconcile re-evaluate. Bare-empty owner-ref deletion is
-		// required because apiserver GC only fires when an owner is
-		// deleted, not when ownerReferences becomes empty via Update.
-		mirrorRef := &mxlv1alpha1.MxlFlowMirror{
-			ObjectMeta: metav1.ObjectMeta{
-				Namespace:       key.Namespace,
-				Name:            key.Name,
-				ResourceVersion: deleteRV,
-			},
-		}
-		err := r.Delete(ctx, mirrorRef, &client.DeleteOptions{
-			Preconditions: &metav1.Preconditions{ResourceVersion: &deleteRV},
-		})
-		switch {
-		case err == nil, apierrors.IsNotFound(err):
-		case apierrors.IsConflict(err):
-			log.FromContext(ctx).V(1).Info("skipping mirror delete after concurrent owner add",
-				"mirror", key.String())
-		default:
-			return fmt.Errorf("delete orphaned mirror: %w", err)
+		if err := r.deleteIfStillEmpty(ctx, key, deleteRV); err != nil {
+			return err
 		}
 	}
 	log.FromContext(ctx).V(1).Info("released mirror owner ref",
 		"mirror", key.String(), "owners", remaining)
+	return nil
+}
+
+// deleteIfStillEmpty deletes mirror at key only when its
+// resourceVersion still matches rv. A concurrent ensureOwnerRef from
+// any receiver that observed the empty owner list and re-added itself
+// wins; we leave the mirror alone. Conflict is logged at V(1) and
+// swallowed; IsNotFound is also swallowed. Bare-empty owner-ref
+// deletion is required because apiserver GC only fires when an owner
+// is deleted, not when ownerReferences becomes empty via Update.
+func (r *Reconciler) deleteIfStillEmpty(ctx context.Context, key types.NamespacedName, rv string) error {
+	mirrorRef := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:       key.Namespace,
+			Name:            key.Name,
+			ResourceVersion: rv,
+		},
+	}
+	err := r.Delete(ctx, mirrorRef, &client.DeleteOptions{
+		Preconditions: &metav1.Preconditions{ResourceVersion: &rv},
+	})
+	switch {
+	case err == nil, apierrors.IsNotFound(err):
+		return nil
+	case apierrors.IsConflict(err):
+		log.FromContext(ctx).V(1).Info("skipping mirror delete after concurrent owner add",
+			"mirror", key.String())
+		return nil
+	default:
+		return fmt.Errorf("delete orphaned mirror: %w", err)
+	}
+}
+
+// listLiveReceiverUIDs returns the set of UIDs of every MxlReceiver
+// currently present in ns. Reads through liveReader so a sibling
+// receiver whose cache entry has not yet propagated is not invisible
+// to the foreign-ref scrub -- a cache miss would let the scrub reap
+// the sibling's just-added UID.
+func (r *Reconciler) listLiveReceiverUIDs(ctx context.Context, ns string) (map[types.UID]struct{}, error) {
+	var recvs mxlv1alpha1.MxlReceiverList
+	if err := r.liveReader().List(ctx, &recvs, client.InNamespace(ns)); err != nil {
+		return nil, err
+	}
+	out := make(map[types.UID]struct{}, len(recvs.Items))
+	for i := range recvs.Items {
+		out[recvs.Items[i].UID] = struct{}{}
+	}
+	return out, nil
+}
+
+// pruneForeignOwnerRefs drops any OwnerReference that points at an
+// MxlReceiver from this API group whose UID does not resolve to a
+// receiver currently present in the mirror's namespace. Refs to any
+// other Kind, or to a same-Kind/different-group resource, are kept
+// verbatim -- we only police our own ownership domain. When the prune
+// empties the owner list, the shared deleteIfStillEmpty tail fires
+// against the post-Update resourceVersion.
+func (r *Reconciler) pruneForeignOwnerRefs(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror) error {
+	key := types.NamespacedName{Namespace: mirror.Namespace, Name: mirror.Name}
+	var pruned int
+	var deleteRV string
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		pruned = 0
+		deleteRV = ""
+		// Both the mirror Get and the live-UID List run through
+		// liveReader and on every retry attempt, so they observe the
+		// same apiserver state: a sibling receiver Created between
+		// the two calls is either visible to both (its ref is kept,
+		// its UID is in the set) or to neither (its ref is not yet
+		// on the mirror). A cached read would risk reaping a
+		// sibling's just-added UID that the cache had not yet
+		// ingested.
+		var live mxlv1alpha1.MxlFlowMirror
+		if err := r.liveReader().Get(ctx, key, &live); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+		liveUIDs, err := r.listLiveReceiverUIDs(ctx, mirror.Namespace)
+		if err != nil {
+			return err
+		}
+		kept := live.OwnerReferences[:0]
+		removed := false
+		for _, or := range live.OwnerReferences {
+			isOurs := or.Kind == "MxlReceiver" && or.APIVersion == mxlv1alpha1.GroupVersion.String()
+			if !isOurs {
+				kept = append(kept, or)
+				continue
+			}
+			if _, alive := liveUIDs[or.UID]; alive {
+				kept = append(kept, or)
+				continue
+			}
+			removed = true
+		}
+		if !removed {
+			return nil
+		}
+		pruned = len(live.OwnerReferences) - len(kept)
+		live.OwnerReferences = kept
+		if err := r.Update(ctx, &live); err != nil {
+			return err
+		}
+		if len(kept) == 0 {
+			deleteRV = live.ResourceVersion
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	if pruned > 0 {
+		log.FromContext(ctx).V(1).Info("scrubbed foreign owner refs",
+			"mirror", key.String(), "pruned", pruned)
+	}
+	if deleteRV != "" {
+		if err := r.deleteIfStillEmpty(ctx, key, deleteRV); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 

--- a/operator/internal/receiver/controller_envtest_test.go
+++ b/operator/internal/receiver/controller_envtest_test.go
@@ -893,19 +893,97 @@ func TestReconcile_StaleOwnerRef_DroppedOnReconcile(t *testing.T) {
 		"the legitimate rb owner must survive: ra's reconcile must not touch "+
 			"a sibling receiver's claim on the shared mirror")
 
-	// MEDIUM-6 finding: the reconciler does NOT prune owner refs to
-	// unknown receivers. ensureMirror only appends via ensureOwnerRef
-	// and gcOrphanMirrors only walks mirrors this receiver already
-	// owns, so a grafted ghost UID survives every reconcile. The
-	// assertion is left as a soft observation rather than a failing
-	// require so the rest of the coverage stays green; tightening
-	// this would need a separate production change to re-state the
-	// owner-ref set against the desired receivers per reconcile.
-	if hasOwnerUID(&live, ghostUID) {
-		t.Logf("known limitation: ghost owner ref %s survived reconcile; "+
-			"production code does not currently prune unknown owners "+
-			"(see MEDIUM-6 follow-up)", ghostUID)
-	}
+	// gcOrphanMirrors now scrubs OwnerReferences whose UID does not
+	// resolve to a live MxlReceiver in the mirror's namespace. A
+	// leftover ghost would keep the mirror alive forever -- the last
+	// legitimate owner could leave and the precondition-Delete in
+	// removeOwnerRef would still see len(owners) == 1 and never fire.
+	require.False(t, hasOwnerUID(&live, ghostUID),
+		"foreign owner ref must be reaped on the next reconcile; a "+
+			"leftover ghost UID keeps the mirror alive forever")
+}
+
+func TestReconcile_GhostOwnerRef_AllowsDeletionWhenLastLegitimateLeaves(t *testing.T) {
+	ctx := context.Background()
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	require.NoError(t, env.Client.Create(ctx, testutil.NewPod(ns, "consumer-a", "node-target",
+		testutil.WithPodLabels(map[string]string{"app": "consumer-a"}))))
+	require.NoError(t, env.Client.Create(ctx, testutil.NewPod(ns, "consumer-b", "node-target",
+		testutil.WithPodLabels(map[string]string{"app": "consumer-b"}))))
+
+	flow := newFlow(t, "node-source")
+	require.NoError(t, env.Client.Create(ctx, testutil.NewReceiver(ns, "ra",
+		testutil.WithReceiverFlowID(flow.Spec.ID),
+		testutil.WithReceiverSelector(map[string]string{"app": "consumer-a"}))))
+	require.NoError(t, env.Client.Create(ctx, testutil.NewReceiver(ns, "rb",
+		testutil.WithReceiverFlowID(flow.Spec.ID),
+		testutil.WithReceiverSelector(map[string]string{"app": "consumer-b"}))))
+
+	reconcile(t, r, ns, "ra")
+	reconcile(t, r, ns, "rb")
+
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(ctx, &mirrors, client.InNamespace(ns)))
+	require.Len(t, mirrors.Items, 1,
+		"setup precondition: ra and rb must converge on a single shared mirror")
+	mirror := mirrors.Items[0]
+	require.Len(t, mirror.OwnerReferences, 2,
+		"setup precondition: both receivers must own the shared mirror before the ghost is grafted in")
+
+	// Graft a ghost OwnerReference pointing at a non-existent
+	// receiver. Without the scrub, the precondition-Delete tail in
+	// removeOwnerRef would never fire: owners would walk 3 -> 2 -> 1
+	// as ra and rb left, never reaching the empty list that triggers
+	// the Delete.
+	const ghostUID = "00000000-0000-0000-0000-000000000000"
+	mirror.OwnerReferences = append(mirror.OwnerReferences, metav1.OwnerReference{
+		APIVersion:         mxlv1alpha1.GroupVersion.String(),
+		Kind:               "MxlReceiver",
+		Name:               "ghost",
+		UID:                ghostUID,
+		Controller:         utilptr.To(false),
+		BlockOwnerDeletion: utilptr.To(false),
+	})
+	require.NoError(t, env.Client.Update(ctx, &mirror))
+
+	// Live-path reconcile runs gcOrphanMirrors, which scrubs the
+	// ghost UID out of the OwnerReferences slice.
+	reconcile(t, r, ns, "ra")
+
+	var live mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, env.Client.Get(ctx,
+		types.NamespacedName{Namespace: mirror.Namespace, Name: mirror.Name}, &live))
+	require.False(t, hasOwnerUID(&live, ghostUID),
+		"the scrub in gcOrphanMirrors must drop the ghost UID on the "+
+			"first live reconcile after it is grafted in")
+	require.Len(t, live.OwnerReferences, 2,
+		"the scrub must drop only the ghost; both legitimate owner refs survive")
+
+	// Drop rb first: owners walk 2 -> 1, mirror persists.
+	rb := mustGetReceiver(t, env.Client, ns, "rb")
+	require.NoError(t, env.Client.Delete(ctx, rb))
+	reconcile(t, r, ns, "rb")
+
+	require.NoError(t, env.Client.Get(ctx,
+		types.NamespacedName{Namespace: mirror.Namespace, Name: mirror.Name}, &live))
+	require.Len(t, live.OwnerReferences, 1,
+		"rb's handleDeletion must drop only its own ref; ra still co-owns the mirror")
+
+	// Drop ra: owners walk 1 -> 0, the precondition-Delete tail in
+	// removeOwnerRef fires because the ghost is no longer there to
+	// keep the slice non-empty.
+	ra := mustGetReceiver(t, env.Client, ns, "ra")
+	require.NoError(t, env.Client.Delete(ctx, ra))
+	reconcile(t, r, ns, "ra")
+
+	err := env.Client.Get(ctx,
+		types.NamespacedName{Namespace: mirror.Namespace, Name: mirror.Name}, &live)
+	assert.True(t, apierrors.IsNotFound(err),
+		"once the last legitimate owner leaves and the scrub has already "+
+			"reaped the ghost, removeOwnerRef must issue the bare-empty "+
+			"Delete and the apiserver must surface NotFound; got %v", err)
 }
 
 func TestReconcile_LegacyLabelOnlyMirror_AdoptsOwnerRef(t *testing.T) {


### PR DESCRIPTION
PR #86 left three loose ends in the MxlFlowMirror OwnerReferences
refcount.

The receiver controller now reconciles a mirror's OwnerReferences
against the live MxlReceiver set in the mirror's namespace. A
hand-typed ref, a leftover from a phased operator migration, or one
left behind by a misdirected dry-run operator would otherwise pin
the mirror alive after every legitimate owner has gone, because the
precondition-Delete in removeOwnerRef only fires when the slice goes
empty. The receiver List and the per-mirror Get both go through
liveReader on the same RetryOnConflict iteration; a sibling Created
between the two is visible to both or neither, never reaped in
error. A Kind+APIVersion pair guards the prune so refs from outside
this ownership domain stay untouched.

The cross-namespace mirror lookup now requires both
LabelCreatedByReceiver and LabelCreatedByReceiverNamespace to match.
The earlier tolerance for mirrors missing the namespace label was a
planned upgrade migration that never had a release to migrate from;
without it, two receivers sharing a name in different namespaces can
no longer claim each other's mirrors.

The gcOrphanMirrors doc comment is rewritten. Apiserver garbage
collection does not fire when OwnerReferences becomes empty via
Update; the resourceVersion-preconditioned Delete in removeOwnerRef
is the actual deletion mechanism, now factored into a shared
deleteIfStillEmpty helper used by both removeOwnerRef and the new
prune path.

fix(operator): scrub mirror owner refs to dead receivers
fix(operator): require LabelCreatedByReceiverNamespace on cross-ns adopt
docs(operator): correct gcOrphanMirrors apiserver-GC claim