### PR TITLE
ci: authenticate release-please with PAT so release PR pushes trigger required checks

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -13,13 +13,15 @@ on:
       - 'config/crd/**'
       - '.github/workflows/chart.yml'
   # release-please.yml calls this workflow as a reusable workflow
-  # when a charts/mxl-k8s release tag has just been cut. Listening
-  # on release:published instead does not work: release-please-action
-  # creates the release with the default GITHUB_TOKEN, and events
-  # produced by GITHUB_TOKEN do not start downstream workflow runs.
-  # workflow_call (and workflow_dispatch, for manual recovery) are
-  # the documented exceptions, so we drive the release publish
-  # through them.
+  # when a charts/mxl-k8s release tag has just been cut, gated on
+  # the per-component release_created output. Pre-PAT a
+  # release:published listener was not an option either: release-
+  # please-action created the release with GITHUB_TOKEN and events
+  # produced by GITHUB_TOKEN do not start downstream runs. With
+  # release-please-action now authenticated through
+  # RELEASE_PLEASE_TOKEN that restriction no longer applies, but
+  # the explicit gating remains preferable to a tag-prefix filter
+  # on release:published. workflow_dispatch covers manual recovery.
   workflow_call:
     inputs:
       release_tag:

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -5,8 +5,12 @@ on:
     branches: [main]
     # Manual escape hatch: a developer pushing a tag from a shell.
     # release-please-driven publishes go through workflow_call from
-    # release-please.yml because tags created by GITHUB_TOKEN do not
-    # start downstream workflow runs.
+    # release-please.yml for explicit per-component gating; with
+    # release-please-action now authenticated through
+    # RELEASE_PLEASE_TOKEN its tag push also matches this filter,
+    # so each release tag currently publishes twice (once via
+    # workflow_call, once via this tag-push listener) until the
+    # overlap is collapsed.
     tags: ['*/v*.*.*']
   pull_request:
   # Invoked from release-please.yml once a per-component release

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -48,10 +48,13 @@ jobs:
 
   # Once a charts/mxl-k8s tag is cut (prerelease or stable),
   # package and push the chart with per-component image tags
-  # pinned. This is a reusable workflow call because GITHUB_TOKEN-
-  # created release events do not start downstream workflow runs,
-  # so chart.yml cannot listen on release:published.
-  # workflow_call is explicitly excepted from that restriction.
+  # pinned. Driven via workflow_call so the per-component
+  # release_created output gates the call explicitly. Pre-PAT
+  # this was also forced (release events created by GITHUB_TOKEN
+  # do not start downstream runs); release-please-action is now
+  # authenticated through RELEASE_PLEASE_TOKEN so that
+  # restriction no longer applies, but explicit gating is
+  # preferable to a tag-prefix filter on release:published.
   package-chart:
     needs: [release-please]
     if: needs.release-please.outputs.chart_released == 'true'
@@ -62,11 +65,10 @@ jobs:
     with:
       release_tag: ${{ needs.release-please.outputs.chart_tag }}
 
-  # Per-component image publishes. Same workflow_call-instead-of-
-  # tag-event reason as the chart above: tags pushed by GITHUB_TOKEN
-  # do not start downstream runs, so images.yml has to be invoked
-  # directly. Each job is gated on its component's release_created
-  # so an unrelated release cycle costs nothing.
+  # Per-component image publishes. Same workflow_call-driven
+  # path as the chart above, for the same explicit-gating
+  # reason. Each job is gated on its component's release_created
+  # output so an unrelated release cycle costs nothing.
   publish-operator-image:
     needs: [release-please]
     if: needs.release-please.outputs.operator_released == 'true'

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -42,6 +42,7 @@ jobs:
       - id: rp
         uses: googleapis/release-please-action@v5
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
           config-file: .github/release-please-config.json
           manifest-file: .github/release-please-manifest.json
 


### PR DESCRIPTION
Pushes made by GITHUB_TOKEN do not start downstream workflow runs.
release-please-action force-pushes its per-component release branches
with the default GITHUB_TOKEN, so the pull_request: synchronize event
on those branches never fires ci.yml or images.yml, and the
ruleset-required ci-summary / images-summary checks on main never
report on the new head SHA. Release PRs cannot merge until those
checks report (e.g. PR #82).

Routing release-please-action through a PAT via the token: input makes
the branch push come from a user identity rather than GITHUB_TOKEN,
which restores the synchronize trigger and lets the required summaries
report on the release PR's head SHA. This is the mitigation called out
in the release-please-action README for the same scenario.

The repo already documents the same root cause for the tag-driven
publish chain at release-please.yml:50-53, where chart and image
publishes are wired as workflow_call instead of release:published for
the same reason. The PR-check path now uses the same workaround at
the source.

The RELEASE_PLEASE_TOKEN secret is already configured in repository
Actions secrets.