### PR TITLE
test(operator): drain status echo before baseline

### DIFF
--- a/operator/internal/receiver/lease_watch_envtest_test.go
+++ b/operator/internal/receiver/lease_watch_envtest_test.go
@@ -250,6 +250,15 @@ func TestReceiver_LeaseWatchIgnoresOtherNamespaces(t *testing.T) {
 	baseline := rec.waitForAtLeast(key, 1, 5*time.Second)
 	require.GreaterOrEqual(t, baseline, 1)
 
+	// Quiesce so the post-action assertion observes only the
+	// cross-namespace Lease event. markPending on the initial
+	// reconcile writes status, which echoes through the For()
+	// watch as a fresh reconcile; without this wait the baseline
+	// can be sampled before those echoes land and inflate the
+	// post-action count.
+	time.Sleep(750 * time.Millisecond)
+	baseline = rec.countFor(key)
+
 	// Lease in default namespace with a name that would otherwise
 	// match this receiver's flow ID. The predicate must reject it
 	// before the mapper runs.


### PR DESCRIPTION
`TestReceiver_LeaseWatchIgnoresOtherNamespaces` is flaky on CI
(seen on the operator test job for PR #83) with
`baseline=1 got=3`.

The receiver controller's `markPending` writes status on the
first reconcile, that write echoes through the
`For(MxlReceiver)` watch as another reconcile, and the echo
lands inside the 750ms window the test sleeps after creating
the cross-namespace Lease. The namespace predicate is doing its
job; the inflated count is the receiver's own status feedback.

`TestReceiver_LeaseWatchTriggersReconcile` already does the
quiescence dance: wait for the first reconcile, sleep 750ms,
re-sample the baseline. Apply the same pattern to the ignore
test.

Reproduced locally with a per-iteration `go test` loop: 1 fail
in 10 before the fix, 0 fails in 30 after.