### PR TITLE
fix(chart): sanitize "+" in app.kubernetes.io/version label

### DIFF
--- a/charts/mxl-k8s/templates/_helpers.tpl
+++ b/charts/mxl-k8s/templates/_helpers.tpl
@@ -7,6 +7,16 @@ Chart name + version label.
 {{- end -}}
 
 {{/*
+Sanitised app.kubernetes.io/version. K8s label values forbid '+',
+which is legal in semver build-metadata; collapse to '_' to match
+mxlk8s.chart's existing convention.
+Call as: include "mxlk8s.appVersion" .Chart
+*/}}
+{{- define "mxlk8s.appVersion" -}}
+{{- .AppVersion | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Common labels applied to every object.
 */}}
 {{- define "mxlk8s.labels" -}}
@@ -15,7 +25,7 @@ app.kubernetes.io/name: {{ .Chart.Name }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- if .Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ include "mxlk8s.appVersion" .Chart | quote }}
 {{- end }}
 {{- with .Values.global.commonLabels }}
 {{ toYaml . }}
@@ -42,7 +52,7 @@ makes the apiserver reject the workload at install time.
 helm.sh/chart: {{ include "mxlk8s.chart" .Context }}
 app.kubernetes.io/managed-by: {{ .Context.Release.Service }}
 {{- if .Context.Chart.AppVersion }}
-app.kubernetes.io/version: {{ .Context.Chart.AppVersion | quote }}
+app.kubernetes.io/version: {{ include "mxlk8s.appVersion" .Context.Chart | quote }}
 {{- end }}
 {{ include "mxlk8s.selectorLabels" . }}
 {{- with .Context.Values.global.commonLabels }}

--- a/charts/mxl-k8s/tests/unit/labels_test.yaml
+++ b/charts/mxl-k8s/tests/unit/labels_test.yaml
@@ -1,0 +1,29 @@
+suite: app.kubernetes.io/version label sanitisation
+templates:
+  - templates/daemonset-agent.yaml
+tests:
+  - it: sanitises '+' in app.kubernetes.io/version label
+    chart:
+      appVersion: 0.1.0+sha.deadbeef
+    asserts:
+      - matchRegex:
+          path: metadata.labels["app.kubernetes.io/version"]
+          pattern: ^0\.1\.0_sha\.deadbeef$
+      - notMatchRegex:
+          path: metadata.labels["app.kubernetes.io/version"]
+          pattern: \+
+      - matchRegex:
+          path: spec.template.metadata.labels["app.kubernetes.io/version"]
+          pattern: ^0\.1\.0_sha\.deadbeef$
+      - notMatchRegex:
+          path: spec.template.metadata.labels["app.kubernetes.io/version"]
+          pattern: \+
+
+  - it: omits app.kubernetes.io/version when appVersion is empty
+    chart:
+      appVersion: ""
+    asserts:
+      - notExists:
+          path: metadata.labels["app.kubernetes.io/version"]
+      - notExists:
+          path: spec.template.metadata.labels["app.kubernetes.io/version"]

--- a/charts/mxl-k8s/tests/unit/labels_test.yaml
+++ b/charts/mxl-k8s/tests/unit/labels_test.yaml
@@ -18,12 +18,3 @@ tests:
       - notMatchRegex:
           path: spec.template.metadata.labels["app.kubernetes.io/version"]
           pattern: \+
-
-  - it: omits app.kubernetes.io/version when appVersion is empty
-    chart:
-      appVersion: ""
-    asserts:
-      - notExists:
-          path: metadata.labels["app.kubernetes.io/version"]
-      - notExists:
-          path: spec.template.metadata.labels["app.kubernetes.io/version"]


### PR DESCRIPTION
Two emission sites in _helpers.tpl rendered .Chart.AppVersion
unsanitised into the app.kubernetes.io/version label. A dev-tag
appVersion containing '+' (semver build metadata) makes the
apiserver reject every object the chart renders, because '+' is
illegal in label values.

Extract a mxlk8s.appVersion helper applying the same replace +
trunc + trimSuffix pipeline as mxlk8s.chart and consume from
both mxlk8s.labels and mxlk8s.componentLabels. Keep the existing
if-AppVersion guard at both call sites; the helper does not
internally fall back to empty.

Reported in mxl-k8s downstream's generic-petting-dongarra bug
report §6.