### PR TITLE
fix(gateway): close entry on sourceNode mismatch

### DIFF
--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -171,6 +171,11 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 
 	if mirror.Spec.SourceNode != r.NodeName {
+		// spec.sourceNode used to name this node and was mutated to
+		// another; the in-memory sources map keeps an RCInitiator open
+		// against a producer-less .mxl-flow until the pod is bounced.
+		// closeEntry is a no-op when key absent (def at line 592).
+		r.closeEntry(req.NamespacedName)
 		return ctrl.Result{}, nil
 	}
 

--- a/gateway/internal/mirror/source_test.go
+++ b/gateway/internal/mirror/source_test.go
@@ -568,6 +568,62 @@ func TestReconcile_FlowOriginRotationReopensReader(t *testing.T) {
 			"gateway tails the rebound writer instead of the stale handle")
 }
 
+func TestReconcile_SourceNodeMutatedAwayClosesEntry(t *testing.T) {
+	// The operator mutates spec.sourceNode away from this node (e.g.
+	// the source agent moves to a different host). The MxlFlowMirror
+	// watch is unfiltered, so the spec change wakes Reconcile here.
+	// Without the closeEntry call ahead of the early return, the
+	// in-memory sourceEntry stays installed with an RCInitiator open
+	// against a producer-less .mxl-flow until the pod is bounced.
+	scheme := newSourceTestScheme(t)
+	const selfNode = "node-a"
+	const otherNode = "node-b"
+	mirror := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "m1",
+			Namespace:  "ns1",
+			Finalizers: []string{SourceFinalizerName},
+		},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     "flow-1",
+			SourceNode: otherNode,
+			TargetNode: "node-c",
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	r := &SourceReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: selfNode,
+		sources:  map[types.NamespacedName]*sourceEntry{},
+		attempts: map[types.NamespacedName]uint32{},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+
+	// Pre-seed: a previous reconcile (when spec.sourceNode == selfNode)
+	// installed an entry on this node. closeSourceHandles is nil-safe
+	// for every field, so a zero-value entry is enough to detect the
+	// removal without spinning up real fabrics handles.
+	r.sources[key] = &sourceEntry{}
+
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	r.mu.Lock()
+	_, present := r.sources[key]
+	r.mu.Unlock()
+	require.False(t, present,
+		"entry must be removed when spec.sourceNode is mutated away; "+
+			"otherwise the RCInitiator keeps ticking against a producer-less "+
+			"flow until the pod restarts")
+}
+
 func TestSource_SeedAttemptsFromStatus(t *testing.T) {
 	// A gateway pod restart drops every in-memory counter. Without a
 	// seed from status, a mirror whose target has been unreachable


### PR DESCRIPTION
When the operator mutates MxlFlowMirror.spec.sourceNode away from
this node, the source-side reconciler returned early without
tearing down the in-memory sourceEntry. The RCInitiator stayed
open against a producer-less .mxl-flow file and ticked the
transfer loop at progressInterval until the pod was bounced.

The MxlFlowMirror watch is unfiltered (source.go:244-246 forbids a
spec-only predicate because it would silently drop recovery
wakes), so the spec-mutation event already reaches Reconcile.
Move the closeEntry call ahead of the SourceNode != NodeName
early return; closeEntry is a no-op when the key is absent.

## Revert-rerun-fails proof

With the production hunk in place, the new regression test passes:

```
=== RUN   TestReconcile_SourceNodeMutatedAwayClosesEntry
--- PASS: TestReconcile_SourceNodeMutatedAwayClosesEntry (0.49s)
PASS
ok  	github.com/qvest-digital/mxl-k8s/gateway/internal/mirror	1.635s
```

With the production hunk stashed (only the test added), the same
test fails on the post-Reconcile presence assertion:

```
=== RUN   TestReconcile_SourceNodeMutatedAwayClosesEntry
    source_test.go:621:
        	Error Trace:	/work/gateway/internal/mirror/source_test.go:621
        	Error:      	Should be false
        	Test:       	TestReconcile_SourceNodeMutatedAwayClosesEntry
        	Messages:   	entry must be removed when spec.sourceNode is mutated away; otherwise the RCInitiator keeps ticking against a producer-less flow until the pod restarts
--- FAIL: TestReconcile_SourceNodeMutatedAwayClosesEntry (0.48s)
FAIL
FAIL	github.com/qvest-digital/mxl-k8s/gateway/internal/mirror	0.621s
```

Restoring the hunk and re-running the targeted tests with -race
-count=2 alongside the existing rotation regression test:

```
=== RUN   TestReconcile_FlowOriginRotationReopensReader
--- PASS: TestReconcile_FlowOriginRotationReopensReader (0.47s)
=== RUN   TestReconcile_SourceNodeMutatedAwayClosesEntry
--- PASS: TestReconcile_SourceNodeMutatedAwayClosesEntry (0.01s)
=== RUN   TestReconcile_FlowOriginRotationReopensReader
--- PASS: TestReconcile_FlowOriginRotationReopensReader (0.02s)
=== RUN   TestReconcile_SourceNodeMutatedAwayClosesEntry
--- PASS: TestReconcile_SourceNodeMutatedAwayClosesEntry (0.01s)
PASS
ok  	github.com/qvest-digital/mxl-k8s/gateway/internal/mirror	1.661s
```

`go test ./internal/mirror/... -race -count=2` (full package) and
`go vet ./...` both pass inside the `go-mxl-builder:1.0.0-rc.5`
image.