### PR TITLE
build(gateway): bump go-mxl to 1.0.0-rc.7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.6
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.7
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -242,7 +242,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.6
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.7
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/docker/demo-tools.Dockerfile
+++ b/docker/demo-tools.Dockerfile
@@ -10,7 +10,8 @@
 # Build:
 #   docker build -f docker/demo-tools.Dockerfile -t local/mxl-demo-tools:dev .
 
-ARG GO_MXL_TAG=1.0.0-rc.6
+# renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
+ARG GO_MXL_TAG=1.0.0-rc.7
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 ARG GO_MXL_TAG

--- a/docker/gateway.Dockerfile
+++ b/docker/gateway.Dockerfile
@@ -4,7 +4,8 @@
 # libmxl-fabrics, and libfabric are already in place.
 # Build context: repo root.
 
-ARG GO_MXL_TAG=1.0.0-rc.6
+# renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
+ARG GO_MXL_TAG=1.0.0-rc.7
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 WORKDIR /workspace

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/gateway
 go 1.26.0
 
 require (
-	github.com/qvest-digital/go-mxl v1.0.0-rc.6
+	github.com/qvest-digital/go-mxl v1.0.0-rc.7
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -86,8 +86,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/qvest-digital/go-mxl v1.0.0-rc.6 h1:zO6FSR1pmM6cRGkydp0bpIOOtjxW2/swbAE3H3giRJg=
-github.com/qvest-digital/go-mxl v1.0.0-rc.6/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.0.0-rc.7 h1:I1eBu+odoMdwCMqYXLAeAcVRijS2kI0/6dL001khDKY=
+github.com/qvest-digital/go-mxl v1.0.0-rc.7/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=


### PR DESCRIPTION
go-mxl 1.0.0-rc.7 publishes matching builder and runtime images
whose libmxl is compiled against libfabric with EFA support and verbs, so
the gateway runs on AWS RDMA NICs without an EFA-specific overlay
of either image. The demo-tools image carries the same GO_MXL_TAG
and refreshes alongside.

Annotate the GO_MXL_TAG ARG in both Dockerfiles with a renovate
comment naming the builder image as the docker datasource, so
Renovate proposes future bumps in lockstep with the ci.yml
container.image references it already tracks.