### PR TITLE
build(gateway): migrate to go-mxl v1.0.0-rc.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,7 +116,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.8
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.9
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -242,7 +242,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.8
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.9
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,7 +68,7 @@ This repo is a Go workspace with four modules:
 | --- | --- | --- |
 | `api/` | `github.com/qvest-digital/mxl-k8s/api` | no |
 | `operator/` | `github.com/qvest-digital/mxl-k8s/operator` | no |
-| `agent/` | `github.com/qvest-digital/mxl-k8s/agent` | libmxl (via `go-mxl`) |
+| `agent/` | `github.com/qvest-digital/mxl-k8s/agent` | no |
 | `gateway/` | `github.com/qvest-digital/mxl-k8s/gateway` | libmxl + libmxl-fabrics (via `go-mxl/fabrics`) |
 
 `go.work` at the repo root enumerates all four `use` paths. Don't add

--- a/docker/demo-tools.Dockerfile
+++ b/docker/demo-tools.Dockerfile
@@ -11,7 +11,7 @@
 #   docker build -f docker/demo-tools.Dockerfile -t local/mxl-demo-tools:dev .
 
 # renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
-ARG GO_MXL_TAG=1.0.0-rc.8
+ARG GO_MXL_TAG=1.0.0-rc.9
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 ARG GO_MXL_TAG

--- a/docker/gateway.Dockerfile
+++ b/docker/gateway.Dockerfile
@@ -5,7 +5,7 @@
 # Build context: repo root.
 
 # renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
-ARG GO_MXL_TAG=1.0.0-rc.8
+ARG GO_MXL_TAG=1.0.0-rc.9
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 WORKDIR /workspace

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/gateway
 go 1.26.0
 
 require (
-	github.com/qvest-digital/go-mxl v1.0.0-rc.8
+	github.com/qvest-digital/go-mxl v1.0.0-rc.9
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.1
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -86,8 +86,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/qvest-digital/go-mxl v1.0.0-rc.8 h1:Tvha6oYI8uYPup0HeHjVfIuHPLMBeGIKo3vuLEa1Qmk=
-github.com/qvest-digital/go-mxl v1.0.0-rc.8/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.0.0-rc.9 h1:p5eLT/XPEiu36FAtfn2bEyPXev1rEfI09F1YgQ7fKLg=
+github.com/qvest-digital/go-mxl v1.0.0-rc.9/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/gateway/internal/mirror/iface.go
+++ b/gateway/internal/mirror/iface.go
@@ -19,7 +19,7 @@ import "github.com/qvest-digital/go-mxl/fabrics"
 // initiatorOpener is the source reconciler's seam onto the
 // cgo-dependent libmxl-fabrics Initiator setup path. Production
 // binds it to libmxlOpener, which is a thin struct wrapping the
-// existing FlowReader + Regions + Initiator + AddTarget sequence.
+// existing FlowReader + Initiator + AddTarget sequence.
 // Tests bind it to an inline fake whose open method returns canned
 // sourceEntry values without touching libmxl or libmxl-fabrics.
 //

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -107,7 +107,6 @@ type SourceReconciler struct {
 // transfer-loop control plumbing for one source-side mirror.
 type sourceEntry struct {
 	reader    *mxl.Reader
-	regions   *fabrics.Regions
 	initiator *fabrics.Initiator
 	info      *fabrics.TargetInfo
 	// infoStr is the serialized TargetInfo the initiator was set up
@@ -376,9 +375,9 @@ func originRotated(baseline, observed *time.Time) bool {
 }
 
 // libmxlOpener is the production initiatorOpener implementation. It
-// opens a FlowReader on the local flow, registers its regions with
-// libmxl-fabrics, creates and sets up an Initiator, AddTarget()s the
-// remote info, and starts the per-flow transfer goroutine. The
+// opens a FlowReader on the local flow, creates and sets up an
+// Initiator that pins the reader, AddTarget()s the remote info, and
+// starts the per-flow transfer goroutine. The
 // fields are the subset of SourceReconciler state the open path
 // reads; the reconciler hands a fully populated value at
 // SetupWithManager time.
@@ -403,38 +402,29 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 	if err != nil {
 		return nil, fmt.Errorf("NewReader: %w", err)
 	}
-	regions, err := fabrics.RegionsForFlowReader(reader)
-	if err != nil {
-		_ = reader.Close()
-		return nil, fmt.Errorf("RegionsForFlowReader: %w", err)
-	}
 	initiator, err := fabInst.NewInitiator()
 	if err != nil {
-		_ = regions.Close()
 		_ = reader.Close()
 		return nil, fmt.Errorf("NewInitiator: %w", err)
 	}
 	if err := initiator.Setup(fabrics.InitiatorConfig{
 		Endpoint: fabrics.EndpointAddress{Node: o.BindAddress},
 		Provider: provider,
-		Regions:  regions,
+		Reader:   reader,
 	}); err != nil {
 		_ = initiator.Close()
-		_ = regions.Close()
 		_ = reader.Close()
 		return nil, fmt.Errorf("Initiator.Setup: %w", err)
 	}
 	info, err := fabrics.ParseTargetInfo(targetInfoStr)
 	if err != nil {
 		_ = initiator.Close()
-		_ = regions.Close()
 		_ = reader.Close()
 		return nil, fmt.Errorf("ParseTargetInfo: %w", err)
 	}
 	if err := initiator.AddTarget(info); err != nil {
 		_ = info.Close()
 		_ = initiator.Close()
-		_ = regions.Close()
 		_ = reader.Close()
 		return nil, fmt.Errorf("%w: %w", errAddTargetFailed, err)
 	}
@@ -443,7 +433,6 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 	done := make(chan struct{})
 	entry := &sourceEntry{
 		reader:    reader,
-		regions:   regions,
 		initiator: initiator,
 		info:      info,
 		infoStr:   targetInfoStr,
@@ -623,9 +612,6 @@ func closeSourceHandles(e *sourceEntry) {
 	}
 	if e.initiator != nil {
 		_ = e.initiator.Close()
-	}
-	if e.regions != nil {
-		_ = e.regions.Close()
 	}
 	if e.reader != nil {
 		_ = e.reader.Close()

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -115,7 +115,7 @@ type TargetReconciler struct {
 	// openFabricSideFn is overridable so tests exercise the recovery
 	// path without a real libmxl-fabrics. Production leaves it nil
 	// and the reconciler falls back to (*TargetReconciler).openFabricSide.
-	openFabricSideFn func(writer *mxl.Writer, provider fabrics.Provider) (*fabrics.Regions, *fabrics.Target, *fabrics.TargetInfo, string, error)
+	openFabricSideFn func(writer *mxl.Writer, provider fabrics.Provider) (*fabrics.Target, *fabrics.TargetInfo, string, error)
 
 	// recoverFn is the seam the stuck-handshake watchdog uses to
 	// spawn its recovery work. Production leaves it nil and the
@@ -143,7 +143,6 @@ type targetEntry struct {
 
 	// fabric-side handles, rebuilt by recoverFromFatalError when
 	// ReadGrain reports a non-recoverable error.
-	regions *fabrics.Regions
 	target  *fabrics.Target
 	info    *fabrics.TargetInfo
 	infoStr string
@@ -326,9 +325,9 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	return ctrl.Result{}, nil
 }
 
-// openTarget walks the libmxl handshake: open FlowWriter, register
-// memory regions, create + setup fabrics.Target, marshal TargetInfo,
-// and start the progress goroutine.
+// openTarget walks the libmxl handshake: open FlowWriter, create +
+// setup fabrics.Target against it, marshal TargetInfo, and start the
+// progress goroutine.
 //
 // key identifies the MxlFlowMirror whose target we're opening; the
 // progress goroutine uses it to invoke recovery if the libmxl-fabrics
@@ -344,7 +343,7 @@ func (r *TargetReconciler) openTarget(key types.NamespacedName, flowDef string, 
 	if err != nil {
 		return nil, fmt.Errorf("NewWriter: %w", err)
 	}
-	regions, target, info, s, err := r.openFabricSideDispatch(writer, provider)
+	target, info, s, err := r.openFabricSideDispatch(writer, provider)
 	if err != nil {
 		_ = writer.Close()
 		return nil, err
@@ -352,7 +351,6 @@ func (r *TargetReconciler) openTarget(key types.NamespacedName, flowDef string, 
 
 	entry := &targetEntry{
 		writer:   writer,
-		regions:  regions,
 		target:   target,
 		info:     info,
 		infoStr:  s,
@@ -362,42 +360,35 @@ func (r *TargetReconciler) openTarget(key types.NamespacedName, flowDef string, 
 	return entry, nil
 }
 
-// openFabricSide creates the regions + fabrics.Target + TargetInfo
-// on an already-open mxl.Writer. Used both by initial openTarget and
-// by recoverFromFatalError when the fabric side died but the writer
-// is still good.
-func (r *TargetReconciler) openFabricSide(writer *mxl.Writer, provider fabrics.Provider) (*fabrics.Regions, *fabrics.Target, *fabrics.TargetInfo, string, error) {
+// openFabricSide creates the fabrics.Target + TargetInfo on an
+// already-open mxl.Writer. Used both by initial openTarget and by
+// recoverFromFatalError when the fabric side died but the writer is
+// still good.
+func (r *TargetReconciler) openFabricSide(writer *mxl.Writer, provider fabrics.Provider) (*fabrics.Target, *fabrics.TargetInfo, string, error) {
 	fabInst := r.Handles.Fabrics()
 	if fabInst == nil {
-		return nil, nil, nil, "", fmt.Errorf("fabrics instance closed")
-	}
-	regions, err := fabrics.RegionsForFlowWriter(writer)
-	if err != nil {
-		return nil, nil, nil, "", fmt.Errorf("RegionsForFlowWriter: %w", err)
+		return nil, nil, "", fmt.Errorf("fabrics instance closed")
 	}
 	target, err := fabInst.NewTarget()
 	if err != nil {
-		_ = regions.Close()
-		return nil, nil, nil, "", fmt.Errorf("NewTarget: %w", err)
+		return nil, nil, "", fmt.Errorf("NewTarget: %w", err)
 	}
 	info, err := target.Setup(fabrics.TargetConfig{
 		Endpoint: fabrics.EndpointAddress{Node: r.BindAddress},
 		Provider: provider,
-		Regions:  regions,
+		Writer:   writer,
 	})
 	if err != nil {
 		_ = target.Close()
-		_ = regions.Close()
-		return nil, nil, nil, "", fmt.Errorf("Target.Setup: %w", err)
+		return nil, nil, "", fmt.Errorf("Target.Setup: %w", err)
 	}
 	s, err := info.MarshalString()
 	if err != nil {
 		_ = info.Close()
 		_ = target.Close()
-		_ = regions.Close()
-		return nil, nil, nil, "", fmt.Errorf("TargetInfo.MarshalString: %w", err)
+		return nil, nil, "", fmt.Errorf("TargetInfo.MarshalString: %w", err)
 	}
-	return regions, target, info, s, nil
+	return target, info, s, nil
 }
 
 // openFabricSideDispatch routes the fabric-side open through the
@@ -405,7 +396,7 @@ func (r *TargetReconciler) openFabricSide(writer *mxl.Writer, provider fabrics.P
 // production. The source reconciler routes the equivalent libmxl-
 // fabrics Initiator setup through the initiatorOpener interface
 // instead, but the seam serves the same purpose.
-func (r *TargetReconciler) openFabricSideDispatch(writer *mxl.Writer, provider fabrics.Provider) (*fabrics.Regions, *fabrics.Target, *fabrics.TargetInfo, string, error) {
+func (r *TargetReconciler) openFabricSideDispatch(writer *mxl.Writer, provider fabrics.Provider) (*fabrics.Target, *fabrics.TargetInfo, string, error) {
 	if r.openFabricSideFn != nil {
 		return r.openFabricSideFn(writer, provider)
 	}
@@ -615,7 +606,7 @@ func (r *TargetReconciler) recoverFromFatalError(key types.NamespacedName) {
 	}
 
 	// Wait for the previous progress loop to finish before swapping
-	// its target/regions/info pointers.
+	// its target/info pointers.
 	if entry.done != nil {
 		<-entry.done
 	}
@@ -628,10 +619,7 @@ func (r *TargetReconciler) recoverFromFatalError(key types.NamespacedName) {
 	if entry.target != nil {
 		_ = entry.target.Close()
 	}
-	if entry.regions != nil {
-		_ = entry.regions.Close()
-	}
-	entry.info, entry.target, entry.regions, entry.infoStr = nil, nil, nil, ""
+	entry.info, entry.target, entry.infoStr = nil, nil, ""
 
 	// Publish Materializing so observers see the in-flight rebuild.
 	// The flusher flips Phase back to Ready on the first commit the
@@ -648,7 +636,7 @@ func (r *TargetReconciler) recoverFromFatalError(key types.NamespacedName) {
 		}
 	}
 
-	regions, target, info, s, err := r.openFabricSideDispatch(entry.writer, entry.provider)
+	target, info, s, err := r.openFabricSideDispatch(entry.writer, entry.provider)
 	if err != nil {
 		l.Error(err, "rebuild fabric side")
 		// Drop the entry so the next Reconcile rebuilds from scratch
@@ -661,7 +649,6 @@ func (r *TargetReconciler) recoverFromFatalError(key types.NamespacedName) {
 		}
 		return
 	}
-	entry.regions = regions
 	entry.target = target
 	entry.info = info
 	entry.infoStr = s
@@ -711,9 +698,6 @@ func closeTargetHandles(e *targetEntry) {
 	}
 	if e.target != nil {
 		_ = e.target.Close()
-	}
-	if e.regions != nil {
-		_ = e.regions.Close()
 	}
 	if e.writer != nil {
 		_ = e.writer.Close()

--- a/gateway/internal/mirror/target_test.go
+++ b/gateway/internal/mirror/target_test.go
@@ -638,8 +638,8 @@ func TestTarget_RecoverFromFatalErrorClearsRecoveringOnRebuildFailure(t *testing
 		Scheme:   scheme,
 		NodeName: "node-a",
 		targets:  map[types.NamespacedName]*targetEntry{key: entry},
-		openFabricSideFn: func(*mxl.Writer, fabrics.Provider) (*fabrics.Regions, *fabrics.Target, *fabrics.TargetInfo, string, error) {
-			return nil, nil, nil, "", rebuildErr
+		openFabricSideFn: func(*mxl.Writer, fabrics.Provider) (*fabrics.Target, *fabrics.TargetInfo, string, error) {
+			return nil, nil, "", rebuildErr
 		},
 	}
 
@@ -695,8 +695,8 @@ func TestTarget_RecoverFromFatalErrorCancelsRunningProgressLoop(t *testing.T) {
 		Scheme:   scheme,
 		NodeName: "node-a",
 		targets:  map[types.NamespacedName]*targetEntry{key: entry},
-		openFabricSideFn: func(*mxl.Writer, fabrics.Provider) (*fabrics.Regions, *fabrics.Target, *fabrics.TargetInfo, string, error) {
-			return nil, nil, nil, "", rebuildErr
+		openFabricSideFn: func(*mxl.Writer, fabrics.Provider) (*fabrics.Target, *fabrics.TargetInfo, string, error) {
+			return nil, nil, "", rebuildErr
 		},
 	}
 


### PR DESCRIPTION
go-mxl v1.0.0-rc.9 removes the libmxl-fabrics Regions API. Initiator
and Target setup now pin the flow handle directly through
InitiatorConfig.Reader and TargetConfig.Writer, and the config structs
carry an Options passthrough left empty for default behaviour. The
explicit RegionsForFlowReader and RegionsForFlowWriter registration and
the *fabrics.Regions handle threaded through the source and target
reconcilers are gone in rc.9.

The source and target reconcilers drop the regions field from
sourceEntry and targetEntry, set the flow handle on the setup config,
and narrow the openFabricSide, openFabricSideDispatch, and
openFabricSideFn seam to return the Target without a Regions value.
Grain (video) mirroring, the transfer and progress loops, the
stuck-handshake watchdog, and the recovery path are unchanged apart
from the handle they pin.

The go-mxl-builder and go-mxl-runtime base images for the gateway and
demo-tools Dockerfiles, and the builder image the gateway CI lanes run
in, move to 1.0.0-rc.9 so the module and the toolchain that links it
stay aligned.

The workspace module table in CLAUDE.md no longer lists agent as a cgo
module; agent imports neither go-mxl nor any C and builds as pure Go.

Verified in ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.9: gofmt,
go vet, go build, and go test -race ./... all pass for the gateway
module.

go-mxl v1.0.0-rc.9 builds libmxl and libmxl-fabrics from the upstream
dmf-mxl/mxl track (cb7b1c7) rather than the qvest-digital/mxl-dmf-demo
fork, completing the upstream-track move tracked in #104.

Closes #104
