### PR TITLE
feat(gateway): mirror continuous audio flows via sample transfer

### DIFF
--- a/gateway/internal/mirror/iface.go
+++ b/gateway/internal/mirror/iface.go
@@ -38,8 +38,8 @@ type RuntimeProbe func() (head uint64, err error)
 
 // TransferFunc transfers one grain from the source flow to the
 // target. The bool return signals "grain was skipped" - production
-// returns it true when grain.TotalSlices == 0 (continuous flows have
-// no slice subdivision and v0 does not transfer them).
+// returns it true when grain.TotalSlices == 0. Continuous (audio)
+// flows take the sample-transfer path and never reach this loop.
 //
 // A non-nil error breaks the per-tick loop; the next tick re-reads
 // head and re-tries from lastSent+1.
@@ -60,3 +60,22 @@ type ReadGrainFunc func() (idx uint64, err error)
 // (OpenGrain + Commit) so consumer FlowReaders see it. Production
 // passes a closure over the per-mirror *mxl.Writer.
 type CommitFunc func(idx uint64) error
+
+// SampleTransferFunc transfers a contiguous run of `count` samples
+// ending at headIndex from a continuous source flow to the target.
+// Production calls Initiator.TransferSamples; tests record the
+// (headIndex, count) pairs. A non-nil error breaks the per-tick loop;
+// the next tick re-reads head and re-tries from lastSent+1.
+type SampleTransferFunc func(headIndex uint64, count int) error
+
+// ReadSamplesFunc polls the target side for an arrived run of samples,
+// returning the ending head index and the sample count. Returns
+// fabrics.ErrNotReady when nothing landed since the previous call so
+// the loop can sleep. Any other error is fatal: it tells the loop to
+// exit and the recovery callback to fire.
+type ReadSamplesFunc func() (headIndex uint64, count int, err error)
+
+// CommitSamplesFunc finishes one arrived run of samples on the local
+// writer (OpenSamples + Commit) so consumer FlowReaders see it.
+// Production passes a closure over the per-mirror *mxl.Writer.
+type CommitSamplesFunc func(headIndex uint64, count int) error

--- a/gateway/internal/mirror/sample_test.go
+++ b/gateway/internal/mirror/sample_test.go
@@ -1,0 +1,379 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+)
+
+// sampleXfer records one transferSamples(headIndex, count) call so the
+// source-loop tests can assert the exact runs that were sent.
+type sampleXfer struct {
+	head  uint64
+	count int
+}
+
+func TestRunSampleTransferLoop_TransfersDeltaSinceLastTick(t *testing.T) {
+	// Initial probe head=1000 means lastSent starts at 1000; tailing
+	// the live flow rather than replaying history. The first tick sees
+	// head=1096, so the loop transfers the 96-sample run ending at 1096
+	// exactly once. Steady ticks at the same head transfer nothing.
+	var probeCalls atomic.Int32
+	probe := func() (uint64, error) {
+		if probeCalls.Add(1) == 1 {
+			return 1000, nil
+		}
+		return 1096, nil
+	}
+
+	var mu sync.Mutex
+	var xfers []sampleXfer
+	transfer := func(head uint64, count int) error {
+		mu.Lock()
+		xfers = append(xfers, sampleXfer{head, count})
+		mu.Unlock()
+		return nil
+	}
+	xfersSnap := func() []sampleXfer {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]sampleXfer, len(xfers))
+		copy(out, xfers)
+		return out
+	}
+
+	var progressCalls atomic.Int32
+	makeProgress := func() error { progressCalls.Add(1); return nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	tracker := &recordingTracker{}
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, makeProgress, 480, time.Millisecond, tracker)
+
+	require.Eventually(t, func() bool { return len(xfersSnap()) == 1 },
+		time.Second, time.Millisecond, "expected exactly one sample-run transfer")
+
+	cancel()
+	<-done
+
+	assert.Equal(t, []sampleXfer{{head: 1096, count: 96}}, xfersSnap(),
+		"the loop must transfer the (lastSent, head] delta as one run ending at head")
+	transfers, agedOuts := tracker.snapshot()
+	assert.Equal(t, []uint64{1096}, transfers,
+		"recordTransfer must observe the ending index of each sent run")
+	assert.Zero(t, agedOuts, "a within-window catch-up is not an aged-out skip")
+	assert.GreaterOrEqual(t, progressCalls.Load(), int32(1),
+		"makeProgress must drive the fabric event queues every tick")
+}
+
+func TestRunSampleTransferLoop_FellBehindSkipsToWindowAndSignals(t *testing.T) {
+	// The producer has lapped the reader by more than maxBatch. The
+	// loop must skip to head-maxBatch (the oldest still-readable
+	// sample), signal the tracker once, and transfer only the final
+	// maxBatch run. The dropped samples are unrecoverable: re-reading
+	// them would fail because they have left the ring's readable
+	// window.
+	const maxBatch = 480
+	var probeCalls atomic.Int32
+	probe := func() (uint64, error) {
+		if probeCalls.Add(1) == 1 {
+			return 0, nil
+		}
+		return 2000, nil
+	}
+
+	var mu sync.Mutex
+	var xfers []sampleXfer
+	transfer := func(head uint64, count int) error {
+		mu.Lock()
+		xfers = append(xfers, sampleXfer{head, count})
+		mu.Unlock()
+		return nil
+	}
+	xfersSnap := func() []sampleXfer {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]sampleXfer, len(xfers))
+		copy(out, xfers)
+		return out
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	tracker := &recordingTracker{}
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, maxBatch, time.Millisecond, tracker)
+
+	require.Eventually(t, func() bool { return len(xfersSnap()) == 1 },
+		time.Second, time.Millisecond, "expected the clamped final run to transfer")
+
+	cancel()
+	<-done
+
+	assert.Equal(t, []sampleXfer{{head: 2000, count: maxBatch}}, xfersSnap(),
+		"after falling behind, the loop must transfer only the final maxBatch run ending at head")
+	transfers, agedOuts := tracker.snapshot()
+	assert.Equal(t, []uint64{2000}, transfers)
+	assert.Equal(t, 1, agedOuts,
+		"falling more than maxBatch behind must record exactly one aged-out skip so the "+
+			"reconciler can publish SourceProgress=ReaderAgedOut")
+}
+
+func TestRunSampleTransferLoop_TransferErrorBreaksTickAndRetries(t *testing.T) {
+	// A transferSamples error (e.g. the fabric briefly not ready) must
+	// not exit the loop or advance lastSent past the failed run: the
+	// next tick re-reads head and re-attempts the same delta. The first
+	// call fails, the second succeeds against the unchanged head.
+	var probeCalls atomic.Int32
+	probe := func() (uint64, error) {
+		if probeCalls.Add(1) == 1 {
+			return 0, nil
+		}
+		return 240, nil
+	}
+
+	var calls atomic.Int32
+	var mu sync.Mutex
+	var xfers []sampleXfer
+	transfer := func(head uint64, count int) error {
+		if calls.Add(1) == 1 {
+			return errors.New("transient fabric error")
+		}
+		mu.Lock()
+		xfers = append(xfers, sampleXfer{head, count})
+		mu.Unlock()
+		return nil
+	}
+	xfersLen := func() int {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(xfers)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, 480, time.Millisecond, &recordingTracker{})
+
+	require.Eventually(t, func() bool { return xfersLen() >= 1 },
+		time.Second, time.Millisecond, "a transfer error must not wedge the loop; the next tick must retry")
+
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	require.NotEmpty(t, xfers)
+	assert.Equal(t, sampleXfer{head: 240, count: 240}, xfers[0],
+		"the retry must re-send the same run; a failed transfer must not advance lastSent")
+}
+
+func TestRunSampleTransferLoop_CtxCancelExitsDuringIdle(t *testing.T) {
+	// A steady flow with no new samples must still honour ctx cancel
+	// promptly (the loop blocks on the ticker, not on a read).
+	probe := func() (uint64, error) { return 500, nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe,
+		func(uint64, int) error { t.Error("no transfer expected on an idle flow"); return nil },
+		func() error { return nil }, 480, time.Millisecond, &recordingTracker{})
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not honour ctx cancel on an idle flow")
+	}
+}
+
+// sampleCommit records one commit(headIndex, count) call so the
+// target-loop tests can assert the runs handed to the writer.
+type sampleCommit struct {
+	head  uint64
+	count int
+}
+
+func TestRunTargetSampleProgressLoop_CommitsArrivedSampleRuns(t *testing.T) {
+	// Two sample runs arrive in order, then ErrNotReady, then cancel.
+	// The loop must commit both runs with their exact (head, count) and
+	// the idle sleep must not swallow the cancel.
+	var seq atomic.Int32
+	read := func() (uint64, int, error) {
+		switch seq.Add(1) {
+		case 1:
+			return 100, 480, nil
+		case 2:
+			return 580, 480, nil
+		default:
+			return 0, 0, fabrics.ErrNotReady
+		}
+	}
+
+	var mu sync.Mutex
+	var commits []sampleCommit
+	commit := func(head uint64, count int) error {
+		mu.Lock()
+		commits = append(commits, sampleCommit{head, count})
+		mu.Unlock()
+		return nil
+	}
+	commitsSnap := func() []sampleCommit {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]sampleCommit, len(commits))
+		copy(out, commits)
+		return out
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	fatal := atomic.Int32{}
+	go runTargetSampleProgressLoop(ctx, done, read, commit, func() { fatal.Add(1) }, nil)
+
+	require.Eventually(t, func() bool { return len(commitsSnap()) == 2 },
+		time.Second, time.Millisecond, "expected both arrived sample runs to commit")
+
+	cancel()
+	<-done
+
+	assert.Equal(t, []sampleCommit{{100, 480}, {580, 480}}, commitsSnap())
+	assert.Zero(t, fatal.Load(),
+		"a clean ctx cancel must not look like a fatal target error")
+}
+
+func TestRunTargetSampleProgressLoop_FatalExitsAndCallsOnFatalOnce(t *testing.T) {
+	// ReadSamples returns a non-ErrNotReady error once. The loop must
+	// exit, close done, and invoke onFatal exactly once; a second call
+	// would race two fabric rebuilds against the same writer.
+	read := func() (uint64, int, error) {
+		return 0, 0, errors.New("EFI_RXMSG dropped, target dead")
+	}
+	commit := func(uint64, int) error {
+		t.Fatal("commit must not run on a fatal read error")
+		return nil
+	}
+	fatalCalls := atomic.Int32{}
+
+	done := make(chan struct{})
+	go runTargetSampleProgressLoop(context.Background(), done, read, commit, func() { fatalCalls.Add(1) }, nil)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not exit on fatal error")
+	}
+	assert.Equal(t, int32(1), fatalCalls.Load(), "onFatal must fire exactly once")
+}
+
+func TestRunTargetSampleProgressLoop_CommitErrorIsLoggedButLoopContinues(t *testing.T) {
+	// A commit-side error (e.g. OpenSamples busy under load) must not
+	// exit the loop nor look fatal; the next read may surface the next
+	// run.
+	var seq atomic.Int32
+	read := func() (uint64, int, error) {
+		switch seq.Add(1) {
+		case 1:
+			return 1, 64, nil
+		case 2:
+			return 65, 64, nil
+		default:
+			return 0, 0, fabrics.ErrNotReady
+		}
+	}
+	commitCalls := atomic.Int32{}
+	commit := func(uint64, int) error {
+		commitCalls.Add(1)
+		return errors.New("transient OpenSamples")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTargetSampleProgressLoop(ctx, done, read, commit,
+		func() { t.Error("commit failure must not be reported as fatal") }, nil)
+
+	require.Eventually(t, func() bool { return commitCalls.Load() >= 2 },
+		time.Second, time.Millisecond)
+	cancel()
+	<-done
+}
+
+func TestRunTargetSampleProgressLoop_CtxCancelExitsDuringIdle(t *testing.T) {
+	read := func() (uint64, int, error) { return 0, 0, fabrics.ErrNotReady }
+	commit := func(uint64, int) error { return nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTargetSampleProgressLoop(ctx, done, read, commit,
+		func() { t.Error("ctx cancel must not look fatal") }, nil)
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not honour ctx cancel during idle sleep")
+	}
+}
+
+func TestRunTargetSampleProgressLoop_NilOnFatalDoesNotPanic(t *testing.T) {
+	// A nil onFatal would be a caller bug, but a panic in the goroutine
+	// would crash the gateway; the loop must guard against it.
+	read := func() (uint64, int, error) { return 0, 0, errors.New("fatal") }
+	commit := func(uint64, int) error { return nil }
+
+	done := make(chan struct{})
+	go runTargetSampleProgressLoop(context.Background(), done, read, commit, nil, nil)
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("loop did not exit on fatal read with nil onFatal")
+	}
+}
+
+func TestRunTargetSampleProgressLoop_TracksOnlySuccessfulCommits(t *testing.T) {
+	// The flusher reads commits + lastCommitAt to decide Ready vs
+	// Degraded; the loop must hand only successful commits to the
+	// tracker. A run whose commit errored must not be recorded, or the
+	// flusher would report fresh progress while the consumer's flow is
+	// missing samples.
+	var seq atomic.Int32
+	read := func() (uint64, int, error) {
+		switch seq.Add(1) {
+		case 1:
+			return 100, 48, nil
+		case 2:
+			return 148, 48, nil
+		case 3:
+			return 196, 48, nil
+		default:
+			return 0, 0, fabrics.ErrNotReady
+		}
+	}
+	commit := func(head uint64, _ int) error {
+		if head == 148 {
+			return errors.New("transient OpenSamples")
+		}
+		return nil
+	}
+
+	tracker := &recordingCommitTracker{}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTargetSampleProgressLoop(ctx, done, read, commit, func() {}, tracker)
+
+	require.Eventually(t, func() bool { return len(tracker.snapshot()) >= 2 },
+		time.Second, time.Millisecond)
+
+	cancel()
+	<-done
+
+	assert.Equal(t, []uint64{100, 196}, tracker.snapshot(),
+		"the tracker must observe only commits that succeeded; recording the failed 148 "+
+			"would let the flusher report progress the consumer never received")
+}

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -429,6 +429,29 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 		return nil, fmt.Errorf("%w: %w", errAddTargetFailed, err)
 	}
 
+	// A continuous (audio) flow moves samples, not grains; pick the
+	// transfer path from the flow's data format. maxBatch bounds both a
+	// single TransferSamples call and the catch-up window: the reader's
+	// max readable sample run.
+	cfg, err := reader.Config()
+	if err != nil {
+		_ = info.Close()
+		_ = initiator.Close()
+		_ = reader.Close()
+		return nil, fmt.Errorf("Reader.Config: %w", err)
+	}
+	audio := cfg.Common.Format == mxl.FormatAudio
+	var maxBatch uint64
+	if audio {
+		maxBatch, err = reader.GetMaxReadLengthSamples()
+		if err != nil {
+			_ = info.Close()
+			_ = initiator.Close()
+			_ = reader.Close()
+			return nil, fmt.Errorf("GetMaxReadLengthSamples: %w", err)
+		}
+	}
+
 	loopCtx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	entry := &sourceEntry{
@@ -451,23 +474,31 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 		}
 		return rt.HeadIndex, nil
 	}
-	transferFn := func(idx uint64) (bool, error) {
-		grain, err := reader.GetGrainNonBlocking(idx)
-		if err != nil {
-			// Not yet committed or already aged out; signal the loop
-			// to break and re-try on the next tick.
-			return false, err
-		}
-		if grain.TotalSlices == 0 {
-			// Continuous flows or grains with no slice subdivision
-			// report TotalSlices==0; v0 sends only fully-discrete
-			// grains and skips these.
-			return true, nil
-		}
-		return false, initiator.TransferGrain(idx, 0, grain.TotalSlices)
-	}
 	progressFn := initiator.MakeProgressNonBlocking
-	go runTransferLoop(loopCtx, done, flowID, runtimeFn, transferFn, progressFn, progressInterval, entry)
+
+	if audio {
+		transferSamplesFn := func(headIndex uint64, count int) error {
+			return initiator.TransferSamples(headIndex, count)
+		}
+		go runSampleTransferLoop(loopCtx, done, flowID, runtimeFn, transferSamplesFn, progressFn, maxBatch, progressInterval, entry)
+	} else {
+		transferFn := func(idx uint64) (bool, error) {
+			grain, err := reader.GetGrainNonBlocking(idx)
+			if err != nil {
+				// Not yet committed or already aged out; signal the loop
+				// to break and re-try on the next tick.
+				return false, err
+			}
+			if grain.TotalSlices == 0 {
+				// A discrete grain with no slice subdivision; continuous
+				// (audio) flows take the sample path above and never
+				// reach here.
+				return true, nil
+			}
+			return false, initiator.TransferGrain(idx, 0, grain.TotalSlices)
+		}
+		go runTransferLoop(loopCtx, done, flowID, runtimeFn, transferFn, progressFn, progressInterval, entry)
+	}
 
 	return entry, nil
 }
@@ -568,6 +599,102 @@ func runTransferLoop(
 				tracker.recordTransfer(uint64(idx), time.Now())
 			}
 			lastSent = idx
+		}
+
+		if err := makeProgress(); err != nil && !errors.Is(err, fabrics.ErrNotReady) {
+			l.Error(err, "MakeProgress")
+		}
+	}
+}
+
+// runSampleTransferLoop pumps newly committed samples that appear on a
+// continuous (audio) source flow into the initiator until ctx is
+// canceled. Closes done on exit. It mirrors runTransferLoop but moves
+// ranges of samples per tick rather than one grain per index: a
+// continuous flow's head advances by many samples between ticks, so
+// the loop transfers the (lastSent, head] delta in chunks bounded by
+// maxBatch (the reader's max readable sample run). If the source falls
+// more than maxBatch behind the writer the oldest samples have left
+// the readable window; the loop skips ahead to head-maxBatch and
+// signals the tracker so the reconciler can publish
+// SourceProgress=ReaderAgedOut.
+//
+// The cgo-dependent calls are injected as functions so the state
+// machine stays testable without libmxl-fabrics. Production binds
+// probeRuntime to mxl.Reader.Runtime().HeadIndex, transferSamples to
+// Initiator.TransferSamples, and makeProgress to
+// Initiator.MakeProgressNonBlocking.
+func runSampleTransferLoop(
+	ctx context.Context,
+	done chan struct{},
+	flowID string,
+	probeRuntime RuntimeProbe,
+	transferSamples SampleTransferFunc,
+	makeProgress ProgressFunc,
+	maxBatch uint64,
+	interval time.Duration,
+	tracker progressTracker,
+) {
+	defer close(done)
+
+	l := ctrl.Log.WithName("sample-transfer").WithValues("flowID", flowID)
+
+	// Discover the current head and tail the live flow from there,
+	// rather than replaying samples the producer may already have aged
+	// out of the ring.
+	head0, err := probeRuntime()
+	if err != nil {
+		l.Error(err, "initial Runtime")
+		return
+	}
+	lastSent := head0
+
+	t := time.NewTicker(interval)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+
+		head, err := probeRuntime()
+		if err != nil {
+			l.Error(err, "Runtime")
+			continue
+		}
+		if head > lastSent {
+			// Fell behind: the samples between lastSent+1 and
+			// head-maxBatch have left the readable window. Skip them
+			// and signal the tracker so the reconciler can publish the
+			// SourceProgress=ReaderAgedOut condition.
+			if maxBatch > 0 && head-lastSent > maxBatch {
+				l.Info("reader fell behind writer, skipping samples",
+					"fromIndex", lastSent+1, "toIndex", head)
+				if tracker != nil {
+					tracker.recordAgedOut(time.Now())
+				}
+				lastSent = head - maxBatch
+			}
+			// Transfer the remaining (lastSent, head] delta in chunks
+			// of at most maxBatch samples, each ending at the chunk's
+			// last index.
+			for lastSent < head {
+				count := head - lastSent
+				if maxBatch > 0 && count > maxBatch {
+					count = maxBatch
+				}
+				end := lastSent + count
+				if err := transferSamples(end, int(count)); err != nil {
+					l.Error(err, "TransferSamples", "headIndex", end, "count", count)
+					break
+				}
+				if tracker != nil {
+					tracker.recordTransfer(end, time.Now())
+				}
+				lastSent = end
+			}
 		}
 
 		if err := makeProgress(); err != nil && !errors.Is(err, fabrics.ErrNotReady) {

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -422,14 +422,26 @@ func (r *TargetReconciler) startProgressLoop(entry *targetEntry, key types.Names
 	entry.done = done
 	target := entry.target
 	writer := entry.writer
-	readFn := target.ReadGrainNonBlocking
-	commitFn := func(idx uint64) error { return commitArrivedGrain(writer, idx) }
-	go runTargetProgressLoop(loopCtx, done, readFn, commitFn, func() {
-		// Detach the recovery work from the goroutine that's
-		// exiting so the recovery's wait-for-done doesn't deadlock
-		// on its own done channel.
+	onFatal := func() {
+		// Detach the recovery work from the goroutine that's exiting
+		// so the recovery's wait-for-done doesn't deadlock on its own
+		// done channel.
 		go r.recoverFromFatalError(key)
-	}, entry)
+	}
+	// A continuous (audio) flow receives sample runs, not grains; pick
+	// the progress path from the flow's data format. The writer's
+	// cached config is the source of truth for which API is valid.
+	if writer.Config().Common.Format == mxl.FormatAudio {
+		readFn := target.ReadSamplesNonBlocking
+		commitFn := func(head uint64, count int) error {
+			return commitArrivedSamples(writer, head, count)
+		}
+		go runTargetSampleProgressLoop(loopCtx, done, readFn, commitFn, onFatal, entry)
+	} else {
+		readFn := target.ReadGrainNonBlocking
+		commitFn := func(idx uint64) error { return commitArrivedGrain(writer, idx) }
+		go runTargetProgressLoop(loopCtx, done, readFn, commitFn, onFatal, entry)
+	}
 }
 
 // commitTracker is the subset of targetEntry the progress loop
@@ -539,6 +551,75 @@ func commitArrivedGrain(writer *mxl.Writer, idx uint64) error {
 	}
 	if err := ga.Commit(ga.TotalSlices, 0); err != nil {
 		return fmt.Errorf("Commit(%d): %w", idx, err)
+	}
+	return nil
+}
+
+// runTargetSampleProgressLoop drives a libmxl-fabrics Target for a
+// continuous (audio) flow until ctx is canceled or ReadSamples reports
+// a non-recoverable error. It mirrors runTargetProgressLoop: the
+// non-blocking ReadSamples advances the libfabric event + completion
+// queues on every call, and the same Go-side idle sleep avoids the
+// blocking-variant SIGURG interaction documented there. For every run
+// of samples ReadSamples reports as arrived, commit does the
+// OpenSamples + Commit dance on the local FlowWriter so consumer
+// FlowReaders see them. Any non-ErrNotReady error is fatal and fires
+// onFatal so the reconciler rebuilds the fabric side.
+func runTargetSampleProgressLoop(
+	ctx context.Context,
+	done chan struct{},
+	readSamples ReadSamplesFunc,
+	commit CommitSamplesFunc,
+	onFatal func(),
+	tracker commitTracker,
+) {
+	defer close(done)
+	l := ctrl.Log.WithName("target-sample-progress")
+	const idleSleep = 1 * time.Millisecond
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+		head, count, err := readSamples()
+		switch {
+		case err == nil:
+			if err := commit(head, count); err != nil {
+				l.Error(err, "commit received samples", "headIndex", head, "count", count)
+				break
+			}
+			if tracker != nil {
+				tracker.recordCommit(head, time.Now())
+			}
+		case errors.Is(err, fabrics.ErrNotReady):
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(idleSleep):
+			}
+		default:
+			l.Error(err, "ReadSamples - target is no longer safe to poll, exiting loop")
+			if onFatal != nil {
+				onFatal()
+			}
+			return
+		}
+	}
+}
+
+// commitArrivedSamples advances the local flow's head for a run of
+// samples whose payload was already filled in by the remote
+// initiator's RDMA write. OpenSamples returns a writable view aliasing
+// the ring; we leave the bytes untouched and Commit so the flow
+// metadata catches up, mirroring commitArrivedGrain.
+func commitArrivedSamples(writer *mxl.Writer, head uint64, count int) error {
+	sa, err := writer.OpenSamples(head, count)
+	if err != nil {
+		return fmt.Errorf("OpenSamples(%d,%d): %w", head, count, err)
+	}
+	if err := sa.Commit(); err != nil {
+		return fmt.Errorf("CommitSamples(%d,%d): %w", head, count, err)
 	}
 	return nil
 }


### PR DESCRIPTION
The gateway mirrored only discrete (video) flows: the source transfer
loop skipped any flow whose grains reported TotalSlices == 0, which is
every continuous (audio) flow, so audio mirrors never moved data.

go-mxl v1.0.0-rc.9 exposes the libmxl-fabrics sample path
(Initiator.TransferSamples, Target.ReadSamples) alongside the grain
path. Both reconcilers pick their data path from the flow's data
format (FlowConfig.Common.Format): discrete flows keep the grain loop
unchanged, continuous flows take a new sample path.

runSampleTransferLoop transfers the (lastSent, head] sample delta per
tick in runs bounded by the reader's max readable sample run
(GetMaxReadLengthSamples). Falling more than that behind skips to the
newest readable run and signals ReaderAgedOut, mirroring the grain
loop's aged-out handling.

runTargetSampleProgressLoop polls Target.ReadSamples and hands each
arrived run to commitArrivedSamples (OpenSamples + Commit on the local
FlowWriter, payload left to the initiator's RDMA write), the sample
analogue of commitArrivedGrain. The idle-poll, fatal-rebuild,
stuck-handshake watchdog, and status flusher are format-agnostic and
are reused unchanged.

The new loops keep the injected-closure shape of the grain loops, so
their state machines are unit-tested without libmxl-fabrics: chunking,
the fell-behind skip, transfer-error retry, commit ordering,
fatal/onFatal, and ctx-cancel exits. End-to-end audio transfer over a
real libmxl-fabrics fabric is covered by the KIND demo in a follow-up.

Verified in ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.9: gofmt,
go vet, go build, and go test -race ./... all pass for the gateway
module.
