### PR TITLE
feat(examples): add audio sample transfer to the TCP demo

### DIFF
--- a/docker/demo-tools.Dockerfile
+++ b/docker/demo-tools.Dockerfile
@@ -1,5 +1,6 @@
-# demo-tools: minimal image carrying go-mxl's write-grain and
-# read-grain example binaries, on top of go-mxl-runtime.
+# demo-tools: minimal image carrying go-mxl's write-grain, read-grain,
+# write-samples, and read-samples example binaries, on top of
+# go-mxl-runtime.
 #
 # These pure-Go (cgo-to-libmxl) tools sidestep the GStreamer-plugin
 # rabbit hole `mxl-gst-testsrc` runs into on Debian trixie (where
@@ -18,8 +19,12 @@ ARG GO_MXL_TAG
 ENV GOBIN=/out
 RUN go install \
         github.com/qvest-digital/go-mxl/examples/write-grain@v${GO_MXL_TAG} \
-        github.com/qvest-digital/go-mxl/examples/read-grain@v${GO_MXL_TAG}
+        github.com/qvest-digital/go-mxl/examples/read-grain@v${GO_MXL_TAG} \
+        github.com/qvest-digital/go-mxl/examples/write-samples@v${GO_MXL_TAG} \
+        github.com/qvest-digital/go-mxl/examples/read-samples@v${GO_MXL_TAG}
 
 FROM ghcr.io/qvest-digital/go-mxl-runtime:${GO_MXL_TAG}
-COPY --from=builder /out/write-grain /usr/local/bin/write-grain
-COPY --from=builder /out/read-grain  /usr/local/bin/read-grain
+COPY --from=builder /out/write-grain   /usr/local/bin/write-grain
+COPY --from=builder /out/read-grain    /usr/local/bin/read-grain
+COPY --from=builder /out/write-samples /usr/local/bin/write-samples
+COPY --from=builder /out/read-samples  /usr/local/bin/read-samples

--- a/examples/kind/demo/kustomization.yaml
+++ b/examples/kind/demo/kustomization.yaml
@@ -13,10 +13,14 @@ resources:
   - ../../tcp-demo/10-writer.yaml
   - ../../tcp-demo/20-receiver.yaml
   - ../../tcp-demo/21-reader.yaml
+  - ../../tcp-demo/11-writer-audio.yaml
+  - ../../tcp-demo/22-receiver-audio.yaml
+  - ../../tcp-demo/23-reader-audio.yaml
 
 configMapGenerator:
   - name: mxl-demo-flow-config
     files:
       - ../../tcp-demo/flow-video-v210.json
+      - ../../tcp-demo/flow-audio-f32.json
 generatorOptions:
   disableNameSuffixHash: true

--- a/examples/tcp-demo/11-writer-audio.yaml
+++ b/examples/tcp-demo/11-writer-audio.yaml
@@ -1,0 +1,45 @@
+# Audio producer pod for the demo. Writes a deterministic sample ramp
+# into a continuous (audio) flow on the local MXL domain using the
+# `write-samples` example binary from go-mxl. Mirrors 10-writer.yaml
+# but for the sample (audio) data path. Its own producer role label
+# lets the audio reader target a different node via anti-affinity,
+# independent of the video pair.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mxl-tcp-demo-audio-writer
+  namespace: mxl-system
+  labels:
+    app.kubernetes.io/name: mxl-tcp-demo-audio-writer
+    mxl-k8s-demo.qvest-digital.com/role: audio-producer
+spec:
+  containers:
+    - name: writer
+      image: ghcr.io/qvest-digital/mxl-k8s/demo-tools:dev
+      command: ["/usr/local/bin/write-samples"]
+      args:
+        - "-domain"
+        - "/run/mxl/domain"
+        - "-flow-def"
+        - "/etc/mxl-demo/flow-audio-f32.json"
+      # IPC_LOCK + SYS_RESOURCE: libmxl pins flow pages into RAM via
+      # mlock; tmpfs-backed shared memory needs the same to be
+      # RDMA-pinnable from the gateway sharing this domain.
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK", "SYS_RESOURCE"]
+      volumeMounts:
+        - name: mxl-domain
+          mountPath: /run/mxl/domain
+        - name: flow-config
+          mountPath: /etc/mxl-demo
+          readOnly: true
+  volumes:
+    - name: mxl-domain
+      hostPath:
+        path: /run/mxl/domain
+        type: DirectoryOrCreate
+    - name: flow-config
+      configMap:
+        name: mxl-demo-flow-config

--- a/examples/tcp-demo/22-receiver-audio.yaml
+++ b/examples/tcp-demo/22-receiver-audio.yaml
@@ -1,0 +1,17 @@
+# MxlReceiver for the audio reader: it wants the continuous (audio)
+# flow materialized locally. The operator translates this into an
+# MxlFlowMirror; the gateway pair then sets up the TCP sample transfer.
+#
+# flowID matches the id embedded in flow-audio-f32.json.
+
+apiVersion: mxl.qvest-digital.com/v1alpha1
+kind: MxlReceiver
+metadata:
+  name: tcp-demo-audio
+  namespace: mxl-system
+spec:
+  flowID: "b3bb5be7-9fe9-4324-a5bb-4c70e1084449"
+  provider: tcp
+  podRef:
+    name: mxl-tcp-demo-audio-reader
+    namespace: mxl-system

--- a/examples/tcp-demo/23-reader-audio.yaml
+++ b/examples/tcp-demo/23-reader-audio.yaml
@@ -1,0 +1,71 @@
+# Audio consumer pod for the demo. Opens the continuous (audio) flow
+# on its local MXL domain with the `read-samples` example binary from
+# go-mxl, which prints a one-line summary of each sample batch it
+# observes. The libmxl-intent.so LD_PRELOAD shim turns libmxl's first
+# ENOENT probe into a synchronous wait on the agent's UDS, so the
+# reader's first mxlCreateFlowReader already sees the mirrored flow.
+#
+# Unlike read-grain, read-samples anchors to the flow's current head
+# and exits if the flow has no committed samples yet (no head). While
+# the mirrored flow warms up that is expected, so read-samples runs in
+# an `until` retry loop: the container stays up (no CrashLoopBackOff)
+# and starts printing once the gateway has committed the first batch.
+#
+# Anti-affinity forces the pod onto a different node than the audio
+# writer so the mirror plumbing is exercised across the fabric.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mxl-tcp-demo-audio-reader
+  namespace: mxl-system
+  labels:
+    app.kubernetes.io/name: mxl-tcp-demo-audio-reader
+    mxl-k8s-demo.qvest-digital.com/role: audio-consumer
+spec:
+  affinity:
+    podAntiAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+              mxl-k8s-demo.qvest-digital.com/role: audio-producer
+          topologyKey: kubernetes.io/hostname
+  initContainers:
+    - name: install-intent-shim
+      image: ghcr.io/qvest-digital/mxl-k8s/shim:dev
+      imagePullPolicy: IfNotPresent
+      volumeMounts:
+        - name: intent-shim
+          mountPath: /shared
+  containers:
+    - name: reader
+      image: ghcr.io/qvest-digital/mxl-k8s/demo-tools:dev
+      command: ["/bin/sh", "-c"]
+      args:
+        - |
+          until /usr/local/bin/read-samples -domain /run/mxl/domain -flow b3bb5be7-9fe9-4324-a5bb-4c70e1084449; do
+            echo "read-samples exited (flow not ready yet); retrying in 1s"
+            sleep 1
+          done
+      env:
+        - name: LD_PRELOAD
+          value: /opt/mxl-intent/libmxl-intent.so
+      securityContext:
+        capabilities:
+          add: ["IPC_LOCK", "SYS_RESOURCE"]
+      volumeMounts:
+        # Mount /run/mxl as a whole so both the domain subdir and the
+        # agent's intent socket land inside the pod even if the
+        # socket hasn't been created yet at scheduling time.
+        - name: mxl-run
+          mountPath: /run/mxl
+        - name: intent-shim
+          mountPath: /opt/mxl-intent
+          readOnly: true
+  volumes:
+    - name: mxl-run
+      hostPath:
+        path: /run/mxl
+        type: DirectoryOrCreate
+    - name: intent-shim
+      emptyDir: {}

--- a/examples/tcp-demo/README.md
+++ b/examples/tcp-demo/README.md
@@ -38,6 +38,20 @@ then skip the shim and just open the flow directly. The shim turns
 that into "the application doesn't need to declare anything; the
 first open is the declaration".
 
+## Audio (sample) variant
+
+Alongside the video/grain pair, the demo includes an audio pair that
+exercises the continuous (sample) data path. `11-writer-audio.yaml`
+runs `write-samples` into the 48 kHz stereo flow defined by
+`flow-audio-f32.json`; `22-receiver-audio.yaml` and
+`23-reader-audio.yaml` mirror it onto a second node where
+`read-samples` prints one line per arrived sample batch. The gateway
+selects the sample-transfer path from the flow's data format, so the
+audio and video pairs run side by side over the same control plane.
+`23-reader-audio.yaml` runs `read-samples` in an `until` loop because
+that tool exits until the mirrored flow has a committed head; the loop
+keeps the pod up while the flow warms up.
+
 ## Prerequisites
 
 - A two-node Linux cluster, kernel >= 5.17 on the worker nodes

--- a/examples/tcp-demo/flow-audio-f32.json
+++ b/examples/tcp-demo/flow-audio-f32.json
@@ -1,0 +1,19 @@
+{
+  "description": "MXL Test Flow, 48kHz stereo float32",
+  "id": "b3bb5be7-9fe9-4324-a5bb-4c70e1084449",
+  "tags": {
+    "urn:x-nmos:tag:grouphint/v1.0": [
+      "Media Function XYZ:Audio"
+    ]
+  },
+  "format": "urn:x-nmos:format:audio",
+  "label": "MXL Test Flow, 48kHz stereo",
+  "parents": [],
+  "media_type": "audio/float32",
+  "sample_rate": {
+    "numerator": 48000,
+    "denominator": 1
+  },
+  "channel_count": 2,
+  "bit_depth": 32
+}

--- a/examples/tcp-demo/kustomization.yaml
+++ b/examples/tcp-demo/kustomization.yaml
@@ -16,6 +16,9 @@ resources:
   - 10-writer.yaml
   - 20-receiver.yaml
   - 21-reader.yaml
+  - 11-writer-audio.yaml
+  - 22-receiver-audio.yaml
+  - 23-reader-audio.yaml
 
 # The demo writer (mxl-gst-testsrc) needs an NMOS flow definition
 # pointed at via --video-config-file. We ship it verbatim from
@@ -25,5 +28,6 @@ configMapGenerator:
   - name: mxl-demo-flow-config
     files:
       - flow-video-v210.json
+      - flow-audio-f32.json
 generatorOptions:
   disableNameSuffixHash: true

--- a/gateway/internal/mirror/sample_test.go
+++ b/gateway/internal/mirror/sample_test.go
@@ -56,7 +56,7 @@ func TestRunSampleTransferLoop_TransfersDeltaSinceLastTick(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, makeProgress, 480, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, makeProgress, 480, 480, time.Millisecond, tracker)
 
 	require.Eventually(t, func() bool { return len(xfersSnap()) == 1 },
 		time.Second, time.Millisecond, "expected exactly one sample-run transfer")
@@ -72,6 +72,55 @@ func TestRunSampleTransferLoop_TransfersDeltaSinceLastTick(t *testing.T) {
 	assert.Zero(t, agedOuts, "a within-window catch-up is not an aged-out skip")
 	assert.GreaterOrEqual(t, progressCalls.Load(), int32(1),
 		"makeProgress must drive the fabric event queues every tick")
+}
+
+func TestRunSampleTransferLoop_ChunksLargeDeltaByXferBatch(t *testing.T) {
+	// A within-window delta larger than xferBatch must be transferred
+	// as several runs of at most xferBatch each, not one oversized
+	// TransferSamples (the fabric rejects an over-large count). The
+	// delta is below maxBatch, so this is a normal catch-up with no
+	// aged-out skip.
+	const xferBatch = 480
+	var probeCalls atomic.Int32
+	probe := func() (uint64, error) {
+		if probeCalls.Add(1) == 1 {
+			return 0, nil
+		}
+		return 1200, nil
+	}
+
+	var mu sync.Mutex
+	var xfers []sampleXfer
+	transfer := func(head uint64, count int) error {
+		mu.Lock()
+		xfers = append(xfers, sampleXfer{head, count})
+		mu.Unlock()
+		return nil
+	}
+	xfersSnap := func() []sampleXfer {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]sampleXfer, len(xfers))
+		copy(out, xfers)
+		return out
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	tracker := &recordingTracker{}
+	// maxBatch large so no aged-out clamp fires; xferBatch caps each run.
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, 100000, xferBatch, time.Millisecond, tracker)
+
+	require.Eventually(t, func() bool { return len(xfersSnap()) == 3 },
+		time.Second, time.Millisecond, "expected the 1200-sample delta to split into 480+480+240")
+
+	cancel()
+	<-done
+
+	assert.Equal(t, []sampleXfer{{480, 480}, {960, 480}, {1200, 240}}, xfersSnap(),
+		"the loop must chunk the delta into runs of at most xferBatch, each ending at the chunk's last index")
+	_, agedOuts := tracker.snapshot()
+	assert.Zero(t, agedOuts, "a within-maxBatch delta is a normal catch-up, not an aged-out skip")
 }
 
 func TestRunSampleTransferLoop_FellBehindSkipsToWindowAndSignals(t *testing.T) {
@@ -109,7 +158,7 @@ func TestRunSampleTransferLoop_FellBehindSkipsToWindowAndSignals(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, maxBatch, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, maxBatch, maxBatch, time.Millisecond, tracker)
 
 	require.Eventually(t, func() bool { return len(xfersSnap()) == 1 },
 		time.Second, time.Millisecond, "expected the clamped final run to transfer")
@@ -159,7 +208,7 @@ func TestRunSampleTransferLoop_TransferErrorBreaksTickAndRetries(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, 480, time.Millisecond, &recordingTracker{})
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, 480, 480, time.Millisecond, &recordingTracker{})
 
 	require.Eventually(t, func() bool { return xfersLen() >= 1 },
 		time.Second, time.Millisecond, "a transfer error must not wedge the loop; the next tick must retry")
@@ -183,7 +232,7 @@ func TestRunSampleTransferLoop_CtxCancelExitsDuringIdle(t *testing.T) {
 	done := make(chan struct{})
 	go runSampleTransferLoop(ctx, done, "flow-audio", probe,
 		func(uint64, int) error { t.Error("no transfer expected on an idle flow"); return nil },
-		func() error { return nil }, 480, time.Millisecond, &recordingTracker{})
+		func() error { return nil }, 480, 480, time.Millisecond, &recordingTracker{})
 
 	cancel()
 	select {

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -430,9 +430,10 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 	}
 
 	// A continuous (audio) flow moves samples, not grains; pick the
-	// transfer path from the flow's data format. maxBatch bounds both a
-	// single TransferSamples call and the catch-up window: the reader's
-	// max readable sample run.
+	// transfer path from the flow's data format. maxBatch is the
+	// reader's max readable sample run, used as the catch-up window;
+	// xferBatch caps a single TransferSamples call, which the fabric
+	// rejects when the count is over-large.
 	cfg, err := reader.Config()
 	if err != nil {
 		_ = info.Close()
@@ -441,7 +442,7 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 		return nil, fmt.Errorf("Reader.Config: %w", err)
 	}
 	audio := cfg.Common.Format == mxl.FormatAudio
-	var maxBatch uint64
+	var maxBatch, xferBatch uint64
 	if audio {
 		maxBatch, err = reader.GetMaxReadLengthSamples()
 		if err != nil {
@@ -449,6 +450,19 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 			_ = initiator.Close()
 			_ = reader.Close()
 			return nil, fmt.Errorf("GetMaxReadLengthSamples: %w", err)
+		}
+		// Cap each transfer at ~10 ms of audio: that is the producer's
+		// natural commit batch and stays well under the fabric's
+		// per-call limit. Transferring the whole readable window in one
+		// TransferSamples is rejected as invalid argument.
+		xferBatch = 1
+		if rate := cfg.Common.GrainRate; rate.Den > 0 && rate.Num > 0 {
+			if b := uint64(rate.Num / (100 * rate.Den)); b > 0 {
+				xferBatch = b
+			}
+		}
+		if maxBatch > 0 && xferBatch > maxBatch {
+			xferBatch = maxBatch
 		}
 	}
 
@@ -480,7 +494,7 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 		transferSamplesFn := func(headIndex uint64, count int) error {
 			return initiator.TransferSamples(headIndex, count)
 		}
-		go runSampleTransferLoop(loopCtx, done, flowID, runtimeFn, transferSamplesFn, progressFn, maxBatch, progressInterval, entry)
+		go runSampleTransferLoop(loopCtx, done, flowID, runtimeFn, transferSamplesFn, progressFn, maxBatch, xferBatch, progressInterval, entry)
 	} else {
 		transferFn := func(idx uint64) (bool, error) {
 			grain, err := reader.GetGrainNonBlocking(idx)
@@ -612,12 +626,12 @@ func runTransferLoop(
 // canceled. Closes done on exit. It mirrors runTransferLoop but moves
 // ranges of samples per tick rather than one grain per index: a
 // continuous flow's head advances by many samples between ticks, so
-// the loop transfers the (lastSent, head] delta in chunks bounded by
-// maxBatch (the reader's max readable sample run). If the source falls
-// more than maxBatch behind the writer the oldest samples have left
-// the readable window; the loop skips ahead to head-maxBatch and
-// signals the tracker so the reconciler can publish
-// SourceProgress=ReaderAgedOut.
+// the loop transfers the (lastSent, head] delta in chunks of at most
+// xferBatch samples (the fabric rejects an over-large single transfer).
+// If the source falls more than maxBatch (the reader's max readable
+// sample run) behind the writer the oldest samples have left the
+// readable window; the loop skips ahead to head-maxBatch and signals
+// the tracker so the reconciler can publish SourceProgress=ReaderAgedOut.
 //
 // The cgo-dependent calls are injected as functions so the state
 // machine stays testable without libmxl-fabrics. Production binds
@@ -632,6 +646,7 @@ func runSampleTransferLoop(
 	transferSamples SampleTransferFunc,
 	makeProgress ProgressFunc,
 	maxBatch uint64,
+	xferBatch uint64,
 	interval time.Duration,
 	tracker progressTracker,
 ) {
@@ -678,12 +693,12 @@ func runSampleTransferLoop(
 				lastSent = head - maxBatch
 			}
 			// Transfer the remaining (lastSent, head] delta in chunks
-			// of at most maxBatch samples, each ending at the chunk's
+			// of at most xferBatch samples, each ending at the chunk's
 			// last index.
 			for lastSent < head {
 				count := head - lastSent
-				if maxBatch > 0 && count > maxBatch {
-					count = maxBatch
+				if xferBatch > 0 && count > xferBatch {
+					count = xferBatch
 				}
 				end := lastSent + count
 				if err := transferSamples(end, int(count)); err != nil {

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -232,7 +232,10 @@ if [[ "$CLUSTER_REUSED" == "true" ]]; then
   # Wait for the deletes to complete -- re-applying while a pod is
   # still Terminating leaves the new pod in limbo (apply observes
   # the live object and treats it as a no-op).
-  "${KUBECTL[@]}" -n mxl-system delete pod mxl-tcp-demo-writer mxl-tcp-demo-reader --ignore-not-found --force --grace-period=0
+  "${KUBECTL[@]}" -n mxl-system delete pod \
+    mxl-tcp-demo-writer mxl-tcp-demo-reader \
+    mxl-tcp-demo-audio-writer mxl-tcp-demo-audio-reader \
+    --ignore-not-found --force --grace-period=0
   apply_demo
 fi
 

--- a/test/integration/kind/cases/45-samples-flowing.sh
+++ b/test/integration/kind/cases/45-samples-flowing.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# Assert audio samples are actually flowing across the fabric to the
+# reader, not just that the MxlFlowMirror status says Ready. The reader
+# pod runs go-mxl's read-samples example which prints one line per
+# sample batch observed (e.g. "idx=480 ch=2 frags=[1920,1920]").
+# Sample the batch index, wait, sample again, and require it to advance.
+# This is the audio (sample-transfer) analogue of 40-frames-flowing.sh.
+
+set -euo pipefail
+# shellcheck source=../lib.sh
+. "$KIND_TEST_LIB"
+
+READER_POD="${READER_POD:-mxl-tcp-demo-audio-reader}"
+SAMPLE_WINDOW_SECS="${SAMPLES_WINDOW_SECS:-5}"
+
+# The reader must be Running before the index can advance. read-samples
+# runs in an until-loop, so the container stays up while the mirrored
+# flow warms up; Ready means it is at least retrying.
+"${KUBECTL[@]}" -n "$NAMESPACE" wait --for=condition=Ready \
+    "pod/${READER_POD}" --timeout="${MIRROR_TIMEOUT_SECS}s" \
+  || fail "${READER_POD} did not become Ready"
+
+# Tail the reader's logs and extract the most recent batch index. Only
+# the per-batch output lines carry "frags="; anchoring on it avoids the
+# "fell behind (idx=... head=...)" resync log lines.
+sample_idx() {
+  "${KUBECTL[@]}" -n "$NAMESPACE" logs "pod/${READER_POD}" --tail=20 2>/dev/null \
+    | awk '
+        /frags=/ && match($0, /idx=[0-9]+/) {
+          last = substr($0, RSTART + 4, RLENGTH - 4)
+        }
+        END { if (last != "") print last }
+      '
+}
+
+# Allow a warm-up for the first batch to land: the gateway target must
+# commit at least one arrived sample run before read-samples gets a head.
+deadline=$(( $(date +%s) + 60 ))
+first=""
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  first=$(sample_idx || true)
+  [ -n "$first" ] && break
+  sleep 1
+done
+[ -n "$first" ] || fail "${READER_POD} produced no idx= batch lines within 60s"
+
+sleep "$SAMPLE_WINDOW_SECS"
+
+last=$(sample_idx || true)
+[ -n "$last" ] || fail "${READER_POD} stopped producing idx= batch lines mid-window"
+
+if [ "$last" -le "$first" ]; then
+  fail "reader sample index did not advance: first=${first} last=${last} window=${SAMPLE_WINDOW_SECS}s"
+fi
+
+echo "  idx advanced ${first} -> ${last} over ${SAMPLE_WINDOW_SECS}s ($(( last - first )) samples)"

--- a/test/integration/kind/cases/70-consumer-eviction.sh
+++ b/test/integration/kind/cases/70-consumer-eviction.sh
@@ -15,12 +15,25 @@ READER_POD="${READER_POD:-mxl-tcp-demo-reader}"
 READER_MANIFEST="${READER_MANIFEST:-${PWD}/examples/tcp-demo/21-reader.yaml}"
 GC_TIMEOUT_SECS="${GC_TIMEOUT_SECS:-30}"
 
-# Establish baseline: at least one mirror exists so the assertion
-# is not trivially satisfied.
-pre=$("${KUBECTL[@]}" -n "$NAMESPACE" get mxlfm \
-      -o jsonpath='{range .items[*]}{.metadata.name} {end}')
-[ -n "$pre" ] || fail "no MxlFlowMirror in namespace ${NAMESPACE} before deletion"
+# The deleted reader consumes the video flow, so only that flow's
+# mirror must be GC'd. The audio reader is untouched, so the audio
+# flow's mirror must persist -- GC is per-consumer, not global.
+VIDEO_FLOW_ID="${VIDEO_FLOW_ID:-5fbec3b1-1b0f-417d-9059-8b94a47197ed}"
+AUDIO_FLOW_ID="${AUDIO_FLOW_ID:-b3bb5be7-9fe9-4324-a5bb-4c70e1084449}"
+
+mirror_names() {
+  "${KUBECTL[@]}" -n "$NAMESPACE" get mxlfm \
+      -o jsonpath='{range .items[*]}{.metadata.name} {end}' 2>/dev/null || true
+}
+
+# Establish baseline: the video consumer's mirror exists so the
+# assertion is not trivially satisfied.
+pre=$(mirror_names)
 echo "  pre-deletion mirrors: ${pre}"
+case "$pre" in
+  *"${VIDEO_FLOW_ID}--"*) : ;;
+  *) fail "no video MxlFlowMirror (${VIDEO_FLOW_ID}) in ${NAMESPACE} before deletion" ;;
+esac
 
 "${KUBECTL[@]}" -n "$NAMESPACE" delete "pod/${READER_POD}" \
     --grace-period=0 --force --ignore-not-found \
@@ -32,19 +45,25 @@ echo "  pre-deletion mirrors: ${pre}"
     "pod/${READER_POD}" --timeout=30s >/dev/null 2>&1 || true
 
 deadline=$(( $(date +%s) + GC_TIMEOUT_SECS ))
-remaining=""
+video_gone=0
 while [ "$(date +%s)" -lt "$deadline" ]; do
-  remaining=$("${KUBECTL[@]}" -n "$NAMESPACE" get mxlfm \
-              -o jsonpath='{range .items[*]}{.metadata.name} {end}' 2>/dev/null || true)
-  # Trim trailing whitespace so an empty list compares equal to "".
-  remaining="$(echo "$remaining" | sed 's/[[:space:]]*$//')"
-  [ -z "$remaining" ] && break
+  case "$(mirror_names)" in
+    *"${VIDEO_FLOW_ID}--"*) ;;        # video mirror still present
+    *) video_gone=1; break ;;
+  esac
   sleep 2
 done
-if [ -n "$remaining" ]; then
-  fail "MxlFlowMirror(s) not GC'd within ${GC_TIMEOUT_SECS}s after reader deletion: ${remaining}"
-fi
-echo "  mirrors GC'd within budget"
+[ "$video_gone" -eq 1 ] \
+  || fail "video MxlFlowMirror (${VIDEO_FLOW_ID}) not GC'd within ${GC_TIMEOUT_SECS}s after reader deletion"
+echo "  video mirror GC'd within budget"
+
+# The audio consumer was not touched, so its mirror must survive the
+# video reader's deletion: GC keys on the evicted consumer, not on the
+# presence of any consumer.
+case "$(mirror_names)" in
+  *"${AUDIO_FLOW_ID}--"*) echo "  audio mirror retained (per-consumer GC)" ;;
+  *) fail "audio MxlFlowMirror (${AUDIO_FLOW_ID}) GC'd by deleting the video reader; GC must be per-consumer" ;;
+esac
 
 # Restore the reader so subsequent cases see a converged demo. A
 # per-pod apply (not the all-in-one tcp-demo kustomization) leaves

--- a/test/integration/kind/lib.sh
+++ b/test/integration/kind/lib.sh
@@ -119,7 +119,8 @@ collect_diagnostics() {
         --all-containers --prefix --tail=400 \
         > "$KIND_DIAG_DIR/${app}.log"       2>&1 || true
   done
-  for pod in mxl-tcp-demo-writer mxl-tcp-demo-reader; do
+  for pod in mxl-tcp-demo-writer mxl-tcp-demo-reader \
+             mxl-tcp-demo-audio-writer mxl-tcp-demo-audio-reader; do
     "${KUBECTL[@]}" -n "$NAMESPACE" logs "pod/${pod}" \
         --all-containers --prefix --tail=400 \
         > "$KIND_DIAG_DIR/${pod}.log"       2>&1 || true


### PR DESCRIPTION
The tcp-demo only exercised the discrete (video/grain) data path. With
the gateway now mirroring continuous flows via sample transfer (#111),
add an audio pair that drives and asserts that path end to end on KIND.

A new continuous flow (`flow-audio-f32.json`, 48 kHz stereo float32) is
produced by `write-samples` (`11-writer-audio.yaml`) and consumed on a
second node by `read-samples` (`23-reader-audio.yaml`) through its
`MxlReceiver` (`22-receiver-audio.yaml`). Both the standalone demo
kustomization and the KIND overlay that `kind-up` applies gain the
three manifests and the audio flow definition.

`read-samples` anchors to the flow's current head and exits until the
mirrored flow has a committed head, so the reader runs it in an `until`
loop: the pod stays up (no CrashLoopBackOff) while the target flow
warms up. `demo-tools` gains the `write-samples`/`read-samples`
binaries, and `kind-up` recreates the audio pods on cluster reuse. The
kind-integration case `45-samples-flowing.sh` asserts the reader's
sample-batch index advances over a window, the sample analogue of the
video case `40-frames-flowing.sh`.

That case surfaced a gateway bug: `runSampleTransferLoop` transferred
the whole readable window in one `TransferSamples` call, which
libmxl-fabrics rejects as invalid argument once the count is large, so
the target head never advanced past the initial commit. Transfers are
now chunked to ~10 ms of audio (the producer's commit batch), with
`GetMaxReadLengthSamples` kept as the aged-out window.
`70-consumer-eviction` is scoped to the video flow's mirror and now
also asserts the untouched audio mirror survives, proving mirror GC is
per-consumer; failure diagnostics capture the audio pods.

Verified in ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.9: gofmt,
go vet, go build, and go test -race ./... pass; both kustomizations
render and the scripts parse (incl. bash 3.2). The end-to-end audio
transfer runs in CI's kind-integration lane.

fix(gateway): transfer mirrored audio samples in rate-sized batches
