### PR TITLE
ci(renovate): deps type, track CI tool versions, fix dashboard warning

### DIFF
--- a/.github/workflows/chart-autofix.yml
+++ b/.github/workflows/chart-autofix.yml
@@ -38,7 +38,10 @@ concurrency:
 env:
   # Keep in lock-step with the generator pins in chart.yml so the
   # regenerated output matches what the lint drift check expects.
+  # Same depNames as chart.yml, so Renovate bumps both copies together.
+  # renovate: datasource=github-releases depName=dadav/helm-schema versioning=semver
   HELM_SCHEMA_VERSION: "0.23.2"
+  # renovate: datasource=go depName=github.com/norwoodj/helm-docs versioning=semver
   HELM_DOCS_VERSION: v1.14.2
 
 jobs:

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -45,15 +45,24 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 env:
-  # helm-schema and helm-unittest tags upstream are bare semver (no v
-  # prefix); go install and helm plugin install accept that form.
+  # Renovate tracks each of these via the inline `# renovate:` marker
+  # on the line directly above the value (see the CI-tool-versions
+  # custom manager in renovate.json). helm-schema tags are bare semver;
+  # helm-unittest tags are v-prefixed, so extractVersion strips the v
+  # to keep the bare value `helm plugin install --version` expects.
+  # renovate: datasource=github-releases depName=helm/helm versioning=semver
   HELM_VERSION: v3.18.4
+  # renovate: datasource=github-releases depName=helm-unittest/helm-unittest versioning=semver extractVersion=^v(?<version>.+)$
   HELM_UNITTEST_VERSION: "1.1.0"
+  # renovate: datasource=github-releases depName=dadav/helm-schema versioning=semver
   HELM_SCHEMA_VERSION: "0.23.2"
+  # renovate: datasource=go depName=github.com/norwoodj/helm-docs versioning=semver
   HELM_DOCS_VERSION: v1.14.2
+  # renovate: datasource=github-releases depName=yannh/kubeconform versioning=semver
   KUBECONFORM_VERSION: v0.6.7
   # mikefarah/yq for in-place yaml editing of values.yaml at
   # package-time. Pinned because we rely on `yq -i` semantics.
+  # renovate: datasource=github-releases depName=mikefarah/yq versioning=semver
   YQ_VERSION: v4.44.6
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,12 @@ permissions:
   pull-requests: write
 
 env:
+  # renovate: datasource=go depName=gotest.tools/gotestsum versioning=semver
   GOTESTSUM_VERSION: v1.13.0
+  # SETUP_ENVTEST_VERSION (a controller-runtime release branch) and
+  # ENVTEST_K8S_VERSION (an envtest asset version that trails upstream
+  # Kubernetes) have no clean Renovate datasource and are bumped by
+  # hand. Keep them in step with the Makefile copies.
   SETUP_ENVTEST_VERSION: release-0.22
   ENVTEST_K8S_VERSION: "1.31.0"
 

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -523,9 +523,11 @@ jobs:
 
       # hack/kind-up.sh installs the chart via `helm upgrade --install`.
       # Pin the helm version to the value chart.yml uses so the chart
-      # path is exercised against a single tested release.
+      # path is exercised against a single tested release. Same depName
+      # as chart.yml's HELM_VERSION, so Renovate bumps both together.
       - uses: azure/setup-helm@v5
         with:
+          # renovate: datasource=github-releases depName=helm/helm versioning=semver
           version: v3.18.4
 
       # `make kind-up BUILD=<tag>` pulls images from GHCR. GHCR

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,17 @@
+# renovate: datasource=go depName=sigs.k8s.io/controller-tools versioning=semver
 CONTROLLER_TOOLS_VERSION ?= v0.18.0
 CONTROLLER_GEN ?= go run sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION)
 
+# renovate: datasource=go depName=gotest.tools/gotestsum versioning=semver
 GOTESTSUM_VERSION ?= v1.13.0
 GOTESTSUM ?= go run gotest.tools/gotestsum@$(GOTESTSUM_VERSION)
+# renovate: datasource=go depName=github.com/vektra/mockery/v3 versioning=semver
 MOCKERY_VERSION ?= v3.5.4
 MOCKERY ?= go run github.com/vektra/mockery/v3@$(MOCKERY_VERSION)
+# SETUP_ENVTEST_VERSION (a controller-runtime release branch) and
+# ENVTEST_K8S_VERSION (an envtest asset version that trails upstream
+# Kubernetes) have no clean Renovate datasource and are bumped by hand.
+# Keep them in step with the .github/workflows/ci.yml copies.
 SETUP_ENVTEST_VERSION ?= release-0.22
 SETUP_ENVTEST ?= go run sigs.k8s.io/controller-runtime/tools/setup-envtest@$(SETUP_ENVTEST_VERSION)
 ENVTEST_K8S_VERSION ?= 1.31.0

--- a/renovate.json
+++ b/renovate.json
@@ -24,22 +24,47 @@
       "matchStrings": [
         "tag: \"(?<currentValue>[^\"]+)\"\\s+#\\s*renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?"
       ]
+    },
+    {
+      "customType": "regex",
+      "description": "Track CI/build tool versions pinned in workflow env blocks and the Makefile via inline `# renovate:` markers (helm, helm-unittest, helm-schema, helm-docs, kubeconform, yq, gotestsum, controller-tools, mockery). The marker sits on the line directly above the value; the value line may be a workflow `KEY: value` or a Makefile `KEY ?= value`.",
+      "fileMatch": [
+        "^\\.github/workflows/chart\\.yml$",
+        "^\\.github/workflows/ci\\.yml$",
+        "^\\.github/workflows/images\\.yml$",
+        "^\\.github/workflows/chart-autofix\\.yml$",
+        "^Makefile$"
+      ],
+      "matchStrings": [
+        "# renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)(?: versioning=(?<versioning>\\S+))?(?: extractVersion=(?<extractVersion>\\S+))?[ \\t]*\\n[ \\t]*[\\w.-]+[ \\t]*(?::|\\?=|=)[ \\t]*[\"']?(?<currentValue>[^\"'\\s#]+)"
+      ]
     }
   ],
   "packageRules": [
     {
-      "description": "Group Go module bumps into one PR per module",
+      "description": "Group third-party Go module bumps into one PR; deps(gomod) so release-please folds a dependency move into each affected module's next release",
       "matchManagers": ["gomod"],
       "groupName": "Go modules",
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps"
+      "semanticCommitType": "deps",
+      "semanticCommitScope": "gomod"
     },
     {
       "description": "Group GitHub Actions bumps into one PR",
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",
-      "semanticCommitType": "ci",
-      "semanticCommitScope": "deps"
+      "semanticCommitType": "deps",
+      "semanticCommitScope": "actions"
+    },
+    {
+      "description": "CI/build tool versions tracked via inline markers in workflows and the Makefile. Third-party, so the default stability delay applies; these files are not under a release-please package path, so the bump does not cut a release.",
+      "matchManagers": ["custom.regex"],
+      "matchFileNames": [
+        ".github/workflows/*.yml",
+        "Makefile"
+      ],
+      "groupName": "CI tool versions",
+      "semanticCommitType": "deps",
+      "semanticCommitScope": "tools"
     },
     {
       "description": "libmxl is intentionally not delayed so upstream-breaking releases surface immediately via a CI-red PR",
@@ -48,7 +73,7 @@
       "minimumReleaseAge": "0 days",
       "schedule": ["at any time"],
       "commitMessageTopic": "libmxl",
-      "semanticCommitType": "build",
+      "semanticCommitType": "deps",
       "semanticCommitScope": "libmxl",
       "labels": ["dependencies", "libmxl"]
     },
@@ -74,8 +99,8 @@
       "groupName": "mxl-k8s api module",
       "minimumReleaseAge": "0 days",
       "schedule": ["at any time"],
-      "semanticCommitType": "chore",
-      "semanticCommitScope": "deps"
+      "semanticCommitType": "deps",
+      "semanticCommitScope": "api"
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -78,6 +78,12 @@
       "labels": ["dependencies", "libmxl"]
     },
     {
+      "description": "operator/agent/gateway are tracked by the custom regex manager below with their full ghcr path. Renovate's built-in helm-values manager also detects them from values.yaml, but only as the bare repository (operator/agent/gateway) because the registry lives under global.image.registry; that docker lookup returns no-result and warns on the dependency dashboard. Disable the helm-values copies; busybox and bitnami/kubectl keep their working helm-values detection.",
+      "matchManagers": ["helm-values"],
+      "matchPackageNames": ["operator", "agent", "gateway"],
+      "enabled": false
+    },
+    {
       "description": "Chart-bundled module images are intra-repo and not stability-gated, so a new module (pre)release re-pins the chart immediately via a deps(chart) PR that release-please turns into a chart release",
       "matchManagers": ["custom.regex"],
       "matchDatasources": ["docker"],


### PR DESCRIPTION
Follow-up to #115. Renovate-side changes only; a companion PR covers the chart-pin doc/script cleanup.

## deps commit type everywhere

Every Renovate package rule now emits `deps`-typed commits, so a dependency move is a releasable unit. Third-party Go modules and the intra-repo `api` require move from `chore(deps)`; under the prerelease manifest config each affected module (api/operator/agent/gateway/shim) gets a fresh rc on the next release-please run. GitHub Actions and libmxl move from `ci`/`build` to `deps`; their files are outside any release-please package path, so the type change does not by itself cut a release.

## Track CI/build tool versions

Only the pins Renovate does not already detect (verified against the dependency dashboard, #25) get an inline `# renovate:` marker, read by a new custom manager: helm, helm-unittest, helm-schema, helm-docs, kubeconform, yq (chart.yml / images.yml), gotestsum (ci.yml / Makefile), controller-tools and mockery (Makefile). Shared pins carry the same depName so one PR bumps every copy. helm-unittest tags are v-prefixed, so its marker strips the v via `extractVersion` to keep the bare value the helm plugin install expects. `SETUP_ENVTEST_VERSION` (a controller-runtime release branch) and `ENVTEST_K8S_VERSION` (an envtest asset version that trails upstream Kubernetes) have no clean datasource and stay hand-managed.

## Fix the dashboard warning

The built-in helm-values manager detected operator/agent/gateway as the bare repository (the registry lives under `global.image.registry`), and its docker lookup returned no-result, warning on the dashboard. The custom regex manager already tracks those three by their full ghcr path, so the helm-values copies are disabled; busybox and bitnami/kubectl keep their working helm-values detection.

Validated: `renovate-config-validator` passes; a regex self-test confirms all 13 markers extract the right depName/currentValue/datasource; `actionlint` clean.

Note: the dashboard also shows a separate "Config Migration Needed" checkbox. That is Renovate's own optional migration offer, best taken as the Renovate-authored PR it generates, so it is left untouched here.
