### PR TITLE
refactor(chart): package committed image pins, correct pin docs

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -227,14 +227,14 @@ jobs:
           chmod +x /usr/local/bin/yq
           yq --version
 
-      # hack/chart-resolve-tags.sh patches charts/mxl-k8s/values.yaml
-      # in place with the right image tag per component: dev for
-      # 0.0.0-dev* chart builds (track main HEAD), otherwise the
-      # per-component version from .github/release-please-manifest.json.
-      # The script also writes a Markdown table of the resolved tags
-      # to stdout; we save it for the publish-bundled-component-table
-      # step below.
-      - name: Resolve per-component image tags into values.yaml
+      # hack/chart-resolve-tags.sh emits the bundled-component table and,
+      # for the floating dev build (0.0.0-dev*), rewrites each
+      # <component>.image.tag to "dev" so the dev chart tracks main HEAD
+      # images. Release builds keep the per-component pins committed in
+      # values.yaml (Renovate keeps those current), so the diff below is
+      # empty for a release and confirms it ships exactly those pins. The
+      # table is saved for the publish-bundled-component-table step.
+      - name: Emit bundled-component table (dev build pins :dev)
         env:
           VERSION: ${{ needs.meta.outputs.version }}
         run: |

--- a/Makefile
+++ b/Makefile
@@ -86,14 +86,14 @@ chart-check: chart-crd-sync chart-schema chart-docs
 		exit 1; \
 	fi
 
-# Pin per-component image tags in charts/mxl-k8s/values.yaml so a
+# Set per-component image tags in charts/mxl-k8s/values.yaml for a
 # local `helm install ./charts/mxl-k8s` or `helm template
-# ./charts/mxl-k8s` resolves to the same image tags the CI-published
-# chart would carry. `MODE` is one of `dev`, `rc`, `stable` (default
-# `rc`). The chart workflow runs the same script with the chart's
-# version at package time; local users can match either flow.
+# ./charts/mxl-k8s`. `MODE=dev` rewrites every tag to "dev" to match
+# the floating dev chart; `MODE=release` (default) keeps the committed
+# per-component pins, which is what a release chart ships. The chart
+# workflow runs the same script at package time.
 # `make chart-resolve-reset` reverts values.yaml.
-MODE ?= rc
+MODE ?= release
 
 .PHONY: chart-resolve
 chart-resolve:

--- a/charts/mxl-k8s/README.md
+++ b/charts/mxl-k8s/README.md
@@ -71,24 +71,24 @@ on every merge to `main`; Helm encodes the `+` as `_` in the OCI tag.
 ## Per-component image versions
 
 Operator, agent, and gateway release independently from the chart;
-their versions can diverge. The published chart pins
-`<component>.image.tag` per component at package time so a chart
-release at `1.0.0-rc.5` can ship operator at `v1.0.0-rc.4`, agent at
-`v1.0.0-rc.5`, and gateway at `v1.0.0-rc.2` without the user
-touching values.
+their versions can diverge. `<component>.image.tag` is pinned per
+component in `values.yaml` and committed, so a chart release at
+`1.0.0-rc.5` can ship operator at `v1.0.0-rc.4`, agent at
+`v1.0.0-rc.5`, and gateway at `v1.0.0-rc.2` without the user touching
+values. Renovate keeps each committed pin current; a bump opens a
+`deps(chart)` PR that release-please turns into a chart release.
 
-The pinned table for each released chart appears in the chart's
-GitHub release notes
+The bundled-versions table for each released chart appears in the
+chart's GitHub release notes
 (`https://github.com/qvest-digital/mxl-k8s/releases/tag/charts/mxl-k8s/v<X>`).
-The `:dev` chart pins every tag to `dev` so it tracks main HEAD
-images.
+The `:dev` chart published on every merge to `main` rewrites every tag
+to `dev` so it tracks main HEAD images.
 
-A `helm install ./charts/mxl-k8s` from a clone of the repo (source
-values.yaml, no pin) falls back to `v<Chart.AppVersion>` for every
-component, which is fine for the rare case where the contributor
-wants the same version across all components from one checkout.
-
-`--set <comp>.image.tag=<tag>` overrides the pin as usual.
+A `helm install ./charts/mxl-k8s` from a clone uses the committed pins
+as-is. Each component must resolve to an image: set `image.tag` or
+`image.digest` (both ship pinned in `values.yaml`); leaving both empty
+makes rendering fail. `--set <comp>.image.tag=<tag>` overrides the pin
+as usual.
 
 ## Common overrides
 
@@ -167,7 +167,7 @@ Kubernetes: `>=1.28-0`
 | agent.containerSecurityContext.runAsNonRoot | bool | `false` | fanotify on /run/mxl/domain reads host inodes, so the agent currently runs as root. PSA-restricted environments cannot host the agent without a policy exception. |
 | agent.hostPID | bool | `true` | Run the agent in the host PID namespace. Required for the intent socket's SO_PEERCRED-based pod identification: without it the connecting consumer pod's PID is not visible to the agent and the on-demand mirror materialization path silently fails. |
 | agent.hostPath | object | `{"run":"/run/mxl","type":"DirectoryOrCreate"}` | hostPath layout. The agent mounts the whole /run/mxl so the intent socket lands on the host where consumer pods can see it. |
-| agent.image.tag | string | `"v1.0.0-rc.4"` | Image tag, pinned to the agent release this chart version bundles. An empty value falls back to `v<Chart.AppVersion>` for a local `helm install ./charts/mxl-k8s` from a checkout. |
+| agent.image.tag | string | `"v1.0.0-rc.4"` | Image tag for the agent, pinned to the release this chart version bundles and kept current by Renovate. Set this or image.digest; with both empty, rendering fails. |
 | cleanup | object | `{"preDeleteDomainWipe":{"enabled":true,"guardImage":"bitnami/kubectl:1.31","image":"busybox:1.38","nodeCount":1,"timeoutSeconds":120}}` | Pre-delete lifecycle hooks. The domain wipe removes stale .mxl-flow directories under gateway.flags.domainPath at chart uninstall, because they live on a hostPath and survive namespace and CRD teardown. |
 | cleanup.preDeleteDomainWipe.enabled | bool | `true` | Wipe stale .mxl-flow directories under gateway.flags.domainPath during helm uninstall, closing the cold-reinstall lifecycle bug where surviving hostPath state from a prior install causes the agent classifier to default the dirs to Origin on the next install (ghost source-side initiator).  Set to false if either applies:   - producers (libmxl writers) are still mmap-attached to files     under domainPath at uninstall time. rm -rf does not crash     producers (mmap regions survive unlink), but their writes     are orphaned from any new consumer. Drain producers first,     then uninstall.   - host state under domainPath is intentionally reused across     chart reinstalls (advanced; expect to clean up manually to     avoid the ghost-initiator bug). |
 | cleanup.preDeleteDomainWipe.guardImage | string | `"bitnami/kubectl:1.31"` | Image used by the nodecount-guard init-container. Must carry a kubectl binary on PATH. |
@@ -181,7 +181,7 @@ Kubernetes: `>=1.28-0`
 | gateway.flags.degradedAfter | string | `"10s"` | Grain-commit inactivity after which the target gateway demotes a mirror to Degraded. Same threshold gates the Reconcile fast-path so a stale Ready status falls through to re-establish. |
 | gateway.flags.pprofBindAddress | string | `""` | Bind address for the net/http/pprof endpoint. Empty disables; otherwise must be a loopback bind (127.0.0.1: or localhost:). Use kubectl port-forward to reach the endpoint; see docs/diagnostics/perf-shortfall.md for the capture recipe. |
 | gateway.hostNetwork | bool | `true` | hostNetwork is required because the libmxl-fabrics TargetInfo embeds the host:port a peer dials; a CNI overlay IP would not be reachable cross-node. |
-| gateway.image.tag | string | `"v1.0.0-rc.5"` | Image tag, pinned to the gateway release this chart version bundles. An empty value falls back to `v<Chart.AppVersion>` for a local `helm install ./charts/mxl-k8s` from a checkout. |
+| gateway.image.tag | string | `"v1.0.0-rc.5"` | Image tag for the gateway, pinned to the release this chart version bundles and kept current by Renovate. Set this or image.digest; with both empty, rendering fails. |
 | gateway.rdma.enabled | bool | `false` | Add the capabilities and mounts the verbs/efa providers need. |
 | gateway.rdma.resourceName | string | `""` | Extended-resource name advertised by a Kubernetes device plugin (for example `rdma/hca_shared_devices` from k8s-rdma-shared-dev-plugin). When non-empty, the gateway container gets `<resourceName>: 1` on both requests and limits. Empty disables the request. |
 | global | object | `{"commonAnnotations":{},"commonLabels":{},"image":{"pullPolicy":"IfNotPresent","pullSecrets":[],"registry":"ghcr.io/qvest-digital/mxl-k8s"}}` | Global settings inherited by every component unless overridden. |
@@ -197,7 +197,7 @@ Kubernetes: `>=1.28-0`
 | operator.flags.leaderElect | bool | `false` | Enable leader election. Required for replicaCount > 1. |
 | operator.image.digest | string | `""` | Image digest. Wins over tag when set. @schema pattern: ^$|^sha256:[0-9a-f]{64}$ @schema |
 | operator.image.pullPolicy | string | `""` | imagePullPolicy override. Empty falls back to global. @schema enum: ["", "Always", "IfNotPresent", "Never"] @schema |
-| operator.image.tag | string | `"v1.0.0-rc.3"` | Image tag, pinned to the operator release this chart version bundles. An empty value falls back to `v<Chart.AppVersion>` for a local `helm install ./charts/mxl-k8s` from a checkout. |
+| operator.image.tag | string | `"v1.0.0-rc.3"` | Image tag for the operator, pinned to the release this chart version bundles and kept current by Renovate. Set this or image.digest; with both empty, rendering fails. |
 | operator.metrics.serviceMonitor.enabled | bool | `false` | Render a Prometheus Operator ServiceMonitor. Requires the monitoring.coreos.com CRDs to be installed cluster-wide. |
 | operator.serviceAccount.name | string | `""` | ServiceAccount name. Empty falls back to a generated name. |
 | rbac | object | `{"create":true}` | ClusterRoles and ClusterRoleBindings for every enabled component. Set to false when RBAC is centrally managed. |

--- a/charts/mxl-k8s/README.md.gotmpl
+++ b/charts/mxl-k8s/README.md.gotmpl
@@ -71,24 +71,24 @@ on every merge to `main`; Helm encodes the `+` as `_` in the OCI tag.
 ## Per-component image versions
 
 Operator, agent, and gateway release independently from the chart;
-their versions can diverge. The published chart pins
-`<component>.image.tag` per component at package time so a chart
-release at `1.0.0-rc.5` can ship operator at `v1.0.0-rc.4`, agent at
-`v1.0.0-rc.5`, and gateway at `v1.0.0-rc.2` without the user
-touching values.
+their versions can diverge. `<component>.image.tag` is pinned per
+component in `values.yaml` and committed, so a chart release at
+`1.0.0-rc.5` can ship operator at `v1.0.0-rc.4`, agent at
+`v1.0.0-rc.5`, and gateway at `v1.0.0-rc.2` without the user touching
+values. Renovate keeps each committed pin current; a bump opens a
+`deps(chart)` PR that release-please turns into a chart release.
 
-The pinned table for each released chart appears in the chart's
-GitHub release notes
+The bundled-versions table for each released chart appears in the
+chart's GitHub release notes
 (`https://github.com/qvest-digital/mxl-k8s/releases/tag/charts/mxl-k8s/v<X>`).
-The `:dev` chart pins every tag to `dev` so it tracks main HEAD
-images.
+The `:dev` chart published on every merge to `main` rewrites every tag
+to `dev` so it tracks main HEAD images.
 
-A `helm install ./charts/mxl-k8s` from a clone of the repo (source
-values.yaml, no pin) falls back to `v<Chart.AppVersion>` for every
-component, which is fine for the rare case where the contributor
-wants the same version across all components from one checkout.
-
-`--set <comp>.image.tag=<tag>` overrides the pin as usual.
+A `helm install ./charts/mxl-k8s` from a clone uses the committed pins
+as-is. Each component must resolve to an image: set `image.tag` or
+`image.digest` (both ship pinned in `values.yaml`); leaving both empty
+makes rendering fail. `--set <comp>.image.tag=<tag>` overrides the pin
+as usual.
 
 ## Common overrides
 

--- a/charts/mxl-k8s/values.schema.json
+++ b/charts/mxl-k8s/values.schema.json
@@ -228,7 +228,7 @@
             },
             "tag": {
               "default": "v1.0.0-rc.4",
-              "description": "Image tag, pinned to the agent release this chart version bundles. An empty value falls back to `v\u003cChart.AppVersion\u003e` for a local `helm install ./charts/mxl-k8s` from a checkout.",
+              "description": "Image tag for the agent, pinned to the release this chart version bundles and kept current by Renovate. Set this or image.digest; with both empty, rendering fails.",
               "required": [],
               "title": "tag"
             }
@@ -898,7 +898,7 @@
             },
             "tag": {
               "default": "v1.0.0-rc.5",
-              "description": "Image tag, pinned to the gateway release this chart version bundles. An empty value falls back to `v\u003cChart.AppVersion\u003e` for a local `helm install ./charts/mxl-k8s` from a checkout.",
+              "description": "Image tag for the gateway, pinned to the release this chart version bundles and kept current by Renovate. Set this or image.digest; with both empty, rendering fails.",
               "required": [],
               "title": "tag"
             }
@@ -1530,7 +1530,7 @@
             },
             "tag": {
               "default": "v1.0.0-rc.3",
-              "description": "Image tag, pinned to the operator release this chart version bundles. An empty value falls back to `v\u003cChart.AppVersion\u003e` for a local `helm install ./charts/mxl-k8s` from a checkout.",
+              "description": "Image tag for the operator, pinned to the release this chart version bundles and kept current by Renovate. Set this or image.digest; with both empty, rendering fails.",
               "required": [],
               "title": "tag"
             }

--- a/charts/mxl-k8s/values.yaml
+++ b/charts/mxl-k8s/values.yaml
@@ -87,9 +87,9 @@ operator:
   replicaCount: 1
   image:
     repository: operator
-    # -- Image tag, pinned to the operator release this chart version
-    # bundles. An empty value falls back to `v<Chart.AppVersion>` for a
-    # local `helm install ./charts/mxl-k8s` from a checkout.
+    # -- Image tag for the operator, pinned to the release this chart
+    # version bundles and kept current by Renovate. Set this or
+    # image.digest; with both empty, rendering fails.
     tag: "v1.0.0-rc.3" # renovate: datasource=docker depName=ghcr.io/qvest-digital/mxl-k8s/operator versioning=semver
     # -- Image digest. Wins over tag when set.
     # @schema
@@ -203,9 +203,9 @@ agent:
       maxUnavailable: 1
   image:
     repository: agent
-    # -- Image tag, pinned to the agent release this chart version
-    # bundles. An empty value falls back to `v<Chart.AppVersion>` for a
-    # local `helm install ./charts/mxl-k8s` from a checkout.
+    # -- Image tag for the agent, pinned to the release this chart
+    # version bundles and kept current by Renovate. Set this or
+    # image.digest; with both empty, rendering fails.
     tag: "v1.0.0-rc.4" # renovate: datasource=docker depName=ghcr.io/qvest-digital/mxl-k8s/agent versioning=semver
     # @schema
     # pattern: ^$|^sha256:[0-9a-f]{64}$
@@ -333,9 +333,9 @@ gateway:
       maxUnavailable: 1
   image:
     repository: gateway
-    # -- Image tag, pinned to the gateway release this chart version
-    # bundles. An empty value falls back to `v<Chart.AppVersion>` for a
-    # local `helm install ./charts/mxl-k8s` from a checkout.
+    # -- Image tag for the gateway, pinned to the release this chart
+    # version bundles and kept current by Renovate. Set this or
+    # image.digest; with both empty, rendering fails.
     tag: "v1.0.0-rc.5" # renovate: datasource=docker depName=ghcr.io/qvest-digital/mxl-k8s/gateway versioning=semver
     # @schema
     # pattern: ^$|^sha256:[0-9a-f]{64}$

--- a/hack/chart-resolve-tags.sh
+++ b/hack/chart-resolve-tags.sh
@@ -1,22 +1,27 @@
 #!/usr/bin/env bash
-# Resolve <component>.image.tag in charts/mxl-k8s/values.yaml from
-# .github/release-please-manifest.json so the chart pins per
-# component instead of falling back to a single chart-wide
-# Chart.AppVersion.
+# Set <component>.image.tag in charts/mxl-k8s/values.yaml for the
+# floating dev chart, and emit the bundled-component table for any
+# build.
 #
 # Usage:
 #   hack/chart-resolve-tags.sh <mode-or-version>
 #
-# The single argument is either an explicit mode (dev | release)
-# or a chart version string, in which case the mode is auto-
-# detected:
-#   - "0.0.0-dev*"  -> dev      (track main HEAD; pin "dev")
-#   - anything else -> release  (read .github/release-please-manifest.json)
+# The single argument is either an explicit mode (dev | release) or a
+# chart version string, in which case the mode is auto-detected:
+#   - "0.0.0-dev*"  -> dev      (track main HEAD; rewrite tags to "dev")
+#   - anything else -> release  (keep the committed per-component pins)
 #
-# The script writes in place. After running locally,
+# Release builds ship the pins committed in values.yaml as-is. Renovate
+# keeps those current: a bump opens a deps(chart) PR that release-please
+# turns into a chart release, so the committed pins are already correct
+# at package time and nothing is resolved. Only the dev channel rewrites
+# the tags, to "dev", so the 0.0.0-dev chart tracks the :dev images
+# built on every merge to main.
+#
+# In dev mode the script writes in place; after running locally,
 # `git checkout -- charts/mxl-k8s/values.yaml` reverts.
 #
-# On stdout: a Markdown table of the resolved tags so a caller (the
+# On stdout: a Markdown table of the effective tags so a caller (the
 # chart workflow) can paste it into the GitHub release notes or the
 # workflow summary.
 
@@ -24,7 +29,6 @@ set -euo pipefail
 
 arg="${1:?usage: $0 <dev|release|<chart-version>>}"
 values=charts/mxl-k8s/values.yaml
-manifest=.github/release-please-manifest.json
 components=(operator agent gateway)
 
 case "$arg" in
@@ -33,19 +37,11 @@ case "$arg" in
   *)            mode=release ;;
 esac
 
-case "$mode" in
-  dev)
-    for c in "${components[@]}"; do
-      yq -i ".${c}.image.tag = \"dev\"" "$values"
-    done
-    ;;
-  release)
-    for c in "${components[@]}"; do
-      v=$(jq -r ".\"${c}\"" "$manifest")
-      yq -i ".${c}.image.tag = \"v${v}\"" "$values"
-    done
-    ;;
-esac
+if [ "$mode" = dev ]; then
+  for c in "${components[@]}"; do
+    yq -i ".${c}.image.tag = \"dev\"" "$values"
+  done
+fi
 
 echo "## Bundled component versions"
 echo ""


### PR DESCRIPTION
Follow-up to #115, part 2 (chart-pin cleanup); #117 covers the Renovate side.

#115 committed the per-component image tags in `values.yaml` and turned an empty tag+digest into a hard `required()` render error, but two leftovers still described and recreated the old "fall back to a single `v<Chart.AppVersion>`" model.

## Package the committed pins

`hack/chart-resolve-tags.sh` re-resolved the release tags from `release-please-manifest.json` at package time and overwrote the committed pins. The pins are now committed and kept current by Renovate (a bump opens the `deps(chart)` PR that triggers the chart release), so re-resolving is redundant, and it is a second source of truth that could publish a chart whose images differ from the reviewed `values.yaml` (for example when one component's re-pin merges after the chart release PR). Release builds now ship the committed pins as-is; only the floating dev build still rewrites the tags to `dev`. The chart.yml package step and the Makefile `chart-resolve` help match.

## Correct the docs

The three `values.yaml` tag comments and the README "Per-component image versions" section still claimed an empty tag falls back to `v<Chart.AppVersion>`; that fallback was removed in #115. They now describe the committed-pin / required-image behaviour. `values.schema.json` and `README.md` are regenerated (the descriptions flow in via `--helm-docs-compatibility-mode`).

Validated: `make chart-check` clean on the committed tree; `helm lint` and 59 unittests pass; `chart-resolve-tags.sh release` is a no-op on values.yaml while `dev` rewrites all three tags to `dev`; `actionlint` clean.

Touches `chart.yml` and `Makefile` in regions disjoint from #117, so the two merge cleanly in either order.
