### PR TITLE
chore: drop unused libmxl.version pin and fix module cgo docs

### DIFF
--- a/.github/libmxl.version
+++ b/.github/libmxl.version
@@ -1,1 +1,0 @@
-https://github.com/dmf-mxl/mxl/tree/351899248ac90ee4d4186ea15b228b45ac3c273f

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ This repo is a Go workspace with four modules:
 | `api/` | `github.com/qvest-digital/mxl-k8s/api` | no |
 | `operator/` | `github.com/qvest-digital/mxl-k8s/operator` | no |
 | `agent/` | `github.com/qvest-digital/mxl-k8s/agent` | no |
-| `gateway/` | `github.com/qvest-digital/mxl-k8s/gateway` | libmxl + libmxl-fabrics (via `go-mxl/fabrics`) |
+| `gateway/` | `github.com/qvest-digital/mxl-k8s/gateway` | libmxl + libmxl-fabrics (via `go-mxl`) |
 
 `go.work` at the repo root enumerates all four `use` paths. Don't add
 a `replace` directive to it. `api` and `operator` must not gain any
@@ -218,13 +218,13 @@ the work that produced it. The same rules apply to PR descriptions.
 
 ## Build
 
-- `api` and `operator` are pure Go.
-- `agent` and `gateway` are cgo. `libmxl` (and for the gateway,
-  `libmxl-fabrics`) must be installed with headers and a pkg-config file
-  before `go build` works in those modules. See `docs/BUILD.md`.
-- Integration tests that require a running libmxl writer go under the
-  build tag `mxl_integration`. The CI lint/vet/build jobs don't run
-  them.
+- `api`, `operator`, and `agent` are pure Go.
+- `gateway` is the only cgo module. It links `libmxl` + `libmxl-fabrics`
+  through the `go-mxl` binding, so both must be installed with headers
+  and pkg-config files before `go build` works there. See `docs/BUILD.md`.
+- Integration testing runs against a local KIND cluster (`make kind-up`,
+  `make kind-test`); see `docs/KIND.md`. Plain `go test ./...` jobs need
+  no cluster.
 
 ## Shell scripts
 

--- a/README.md
+++ b/README.md
@@ -172,14 +172,14 @@ The repo is a Go workspace with four modules:
 | --- | --- | --- |
 | `api` | `github.com/qvest-digital/mxl-k8s/api` | CRD types. |
 | `operator` | `github.com/qvest-digital/mxl-k8s/operator` | Cluster operator that reconciles the CRDs. |
-| `agent` | `github.com/qvest-digital/mxl-k8s/agent` | Per-node DaemonSet. Links libmxl via [`go-mxl`][go-mxl]. |
-| `gateway` | `github.com/qvest-digital/mxl-k8s/gateway` | Per-node DaemonSet. Links libmxl-fabrics via [`go-mxl/fabrics`][go-mxl]. |
+| `agent` | `github.com/qvest-digital/mxl-k8s/agent` | Per-node DaemonSet. Pure Go; watches the domain via `fanotify`, does not link libmxl. |
+| `gateway` | `github.com/qvest-digital/mxl-k8s/gateway` | Per-node DaemonSet. Links libmxl + libmxl-fabrics via [`go-mxl`][go-mxl]. |
 
 [`docs/USAGE.md`](docs/USAGE.md) covers the prerequisites for a
 media function (container, libmxl link, capabilities) and how to
 integrate it as a producer or consumer.
 [`docs/BUILD.md`](docs/BUILD.md) covers local-build prerequisites
-and the cgo lane for `agent` and `gateway`.
+and the cgo lane for `gateway`.
 [`CLAUDE.md`](CLAUDE.md) carries the contributor rules.
 
 [mxl]: https://github.com/dmf-mxl/mxl

--- a/docs/BUILD.md
+++ b/docs/BUILD.md
@@ -1,96 +1,65 @@
 # Local build
 
-This repo is a Go workspace with five modules. Two of them (`agent`,
-`gateway`) link against libmxl and libmxl-fabrics via cgo; the rest are
-pure Go.
+This repo is a Go workspace with four modules. One of them (`gateway`)
+links libmxl and libmxl-fabrics via cgo, transitively through the
+`go-mxl` binding; the rest are pure Go.
 
 ## Toolchain
 
-- Go >= 1.26
-- A C/C++ toolchain (clang-19 or gcc), CMake >= 3.20, Ninja, pkg-config.
+- Go >= 1.26.
+- For the `gateway` cgo build: a C compiler, `pkg-config`, and libmxl +
+  libmxl-fabrics installed with headers and pkg-config files (see
+  below).
 - Linux kernel >= 5.17 on the host that will run the agent. The
   agent's `fanotify` watcher needs `FAN_REPORT_DFID_NAME`.
 
 ## Pure-Go modules
 
-`api` and `operator` build without any system libraries:
+`api`, `operator`, and `agent` build without any system libraries.
+`agent` watches the libmxl domain through `fanotify`
+(`golang.org/x/sys/unix`) and does not link libmxl itself:
 
 ```sh
-for m in api operator; do (cd "$m" && go build ./... && go vet ./...); done
+for m in api operator agent; do (cd "$m" && go build ./... && go vet ./...); done
 ```
 
-## CGo modules (libmxl + libmxl-fabrics)
+## CGo module: gateway (libmxl + libmxl-fabrics)
 
-`agent` requires libmxl. `gateway` additionally requires libmxl-fabrics.
-Both are built from the same upstream source pinned by
-[`.github/libmxl.version`](../.github/libmxl.version): the file holds
-one `https://github.com/<owner>/<repo>/tree/<ref>` URL. Renovate
-maintains it; humans should update it the same way.
+`gateway` is the only cgo module. It imports the `go-mxl` binding
+(`go-mxl/mxl` and `go-mxl/fabrics`), so the build links both libmxl and
+libmxl-fabrics. Both libraries must be installed with headers and
+pkg-config files (`libmxl.pc`, `libmxl-fabrics.pc`). `go-mxl` owns the
+libmxl version.
 
-### Install once
+### In the go-mxl builder image (CI path)
 
-```sh
-# Build deps.
-sudo apt-get install -y --no-install-recommends \
-    build-essential cmake ninja-build clang-19 lld-19 \
-    pkg-config bison flex curl zip unzip tar git ca-certificates \
-    libgstreamer1.0-dev libgstreamer-plugins-base1.0-dev \
-    libfabric-dev libfabric-bin
+CI and [`docker/gateway.Dockerfile`](../docker/gateway.Dockerfile) build
+`gateway` inside the published `go-mxl` builder image, which already has
+the Go toolchain, libmxl, libmxl-fabrics, libfabric, and a working
+`PKG_CONFIG_PATH`. The image tag tracks the `go-mxl` release the
+`gateway` module requires (currently
+`ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.9`); bump it together
+with the `go-mxl` require in `gateway/go.mod`.
 
-# vcpkg (libmxl pulls its third-party deps through vcpkg).
-git clone --filter=tree:0 https://github.com/microsoft/vcpkg.git ~/vcpkg
-~/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+### On the host
 
-# Read the pin and split the URL.
-url=$(tr -d '[:space:]' < .github/libmxl.version)
-rest=${url#https://github.com/}
-repo=${rest%%/tree/*}
-ref=${rest#*/tree/}
-
-# Clone and build libmxl with fabrics enabled.
-git clone "https://github.com/$repo.git" /tmp/mxl
-git -C /tmp/mxl checkout "$ref"
-cmake --preset Linux-Clang-Release -S /tmp/mxl \
-    -DBUILD_DOCS=OFF \
-    -DMXL_ENABLE_FABRICS_OFI=ON \
-    -DCMAKE_INSTALL_PREFIX=/opt/libmxl
-cmake --build /tmp/mxl/build/Linux-Clang-Release
-sudo cmake --install /tmp/mxl/build/Linux-Clang-Release
-
-# libmxl.pc declares Requires.private: spdlog but ships spdlog as a
-# static lib; strip the line so pkg-config doesn't trip over it.
-sudo sed -i '/^Requires.private:/d' /opt/libmxl/lib/pkgconfig/libmxl.pc
-```
-
-### Per-shell
+Install libmxl + libmxl-fabrics by following
+[go-mxl's README](https://github.com/qvest-digital/go-mxl), then point
+pkg-config at them and build:
 
 ```sh
 export PKG_CONFIG_PATH=/opt/libmxl/lib/pkgconfig
 export LD_LIBRARY_PATH=/opt/libmxl/lib
-```
-
-Verify pkg-config sees both libraries:
-
-```sh
 pkg-config --exists libmxl libmxl-fabrics && echo OK
-```
-
-### Build the CGo modules
-
-```sh
-for m in agent gateway; do (cd "$m" && go build ./... && go vet ./...); done
+(cd gateway && go build ./... && go vet ./...)
 ```
 
 ## Integration tests
 
-Integration tests under the `mxl_integration` build tag exercise a real
-libmxl install (and, for the gateway, real fabric endpoints):
-
-```sh
-(cd agent && go test -tags mxl_integration ./...)
-```
-
-The default unit/vet/build jobs don't run these.
+Integration testing runs against a local KIND cluster: `make kind-up`
+brings up the demo and `make kind-test` runs the suite (see
+[`docs/KIND.md`](KIND.md)). Plain `go test ./...` per module needs no
+cluster.
 
 ## Graphify
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -292,7 +292,7 @@ work in code but have not been exercised continuously.
 - [`docs/architecture/`](./architecture/): runtime walkthrough of
   the operator, agent, gateway, and shim.
 - [`docs/BUILD.md`](./BUILD.md): local-build prerequisites and the
-  cgo lane for `agent` and `gateway`.
+  cgo lane for `gateway`.
 - [`docs/RDMA.md`](./RDMA.md): host setup for the `verbs` and
   `efa` providers.
 - [`docs/KIND.md`](./KIND.md): KIND demo walkthrough.

--- a/docs/architecture/01-system-context.md
+++ b/docs/architecture/01-system-context.md
@@ -37,8 +37,8 @@ node, and then get out of the way of the data path.
     code paths are accepted by the API but not exercised in routine
     CI).
 - **External, linked in**
-  - `libmxl.so` is linked into the gateway, the agent, the writer
-    pod, and the consumer pod.
+  - `libmxl.so` is linked into the gateway, the writer pod, and the
+    consumer pod.
   - `libmxl-fabrics.so` is linked into the gateway only.
 
 ## Actors

--- a/docs/architecture/03-node-anatomy.md
+++ b/docs/architecture/03-node-anatomy.md
@@ -94,7 +94,7 @@ table:
 | --- | --- | --- | --- |
 | writer pod | rw | -- | libmxl |
 | consumer pod | rw | rw (bind-mount of the socket file) | libmxl + libmxl-intent.so via `LD_PRELOAD` |
-| agent DaemonSet | rw | rw (binds, listens) | libmxl |
+| agent DaemonSet | rw | rw (binds, listens) | none (pure Go) |
 | gateway DaemonSet | rw | -- | libmxl + libmxl-fabrics + libfabric provider |
 
 The LD_PRELOAD shim is delivered through a small two-container

--- a/renovate.json
+++ b/renovate.json
@@ -9,16 +9,6 @@
   "customManagers": [
     {
       "customType": "regex",
-      "description": "Track tagged releases of dmf-mxl/mxl (or any fork) pinned in .github/libmxl.version",
-      "fileMatch": ["^\\.github/libmxl\\.version$"],
-      "matchStrings": [
-        "^https://github\\.com/(?<depName>[^/]+/[^/]+)/tree/(?<currentValue>[^\\s/]+)\\s*$"
-      ],
-      "datasourceTemplate": "github-releases",
-      "versioningTemplate": "loose"
-    },
-    {
-      "customType": "regex",
       "description": "Pin the chart-bundled module images (operator, agent, gateway) to their ghcr releases via inline markers in values.yaml",
       "fileMatch": ["^charts/mxl-k8s/values\\.yaml$"],
       "matchStrings": [
@@ -65,17 +55,6 @@
       "groupName": "CI tool versions",
       "semanticCommitType": "deps",
       "semanticCommitScope": "tools"
-    },
-    {
-      "description": "libmxl is intentionally not delayed so upstream-breaking releases surface immediately via a CI-red PR",
-      "matchManagers": ["custom.regex"],
-      "matchFileNames": [".github/libmxl.version"],
-      "minimumReleaseAge": "0 days",
-      "schedule": ["at any time"],
-      "commitMessageTopic": "libmxl",
-      "semanticCommitType": "deps",
-      "semanticCommitScope": "libmxl",
-      "labels": ["dependencies", "libmxl"]
     },
     {
       "description": "operator/agent/gateway are tracked by the custom regex manager below with their full ghcr path. Renovate's built-in helm-values manager also detects them from values.yaml, but only as the bare repository (operator/agent/gateway) because the registry lives under global.image.registry; that docker lookup returns no-result and warns on the dependency dashboard. Disable the helm-values copies; busybox and bitnami/kubectl keep their working helm-values detection.",


### PR DESCRIPTION
`.github/libmxl.version` pinned a dmf-mxl/mxl source ref for building
libmxl from source. After the gateway moved to the `go-mxl` binding,
it builds inside the published `go-mxl` builder/runtime images, which
already carry libmxl, libmxl-fabrics, and libfabric at go-mxl's own
pin. Nothing in the repo consumes the pin any more: no workflow,
Makefile target, or Dockerfile reads it. The only references were the
Renovate custom manager that tracked it and the build-from-source
steps in `docs/BUILD.md`.

This removes the pin file, its Renovate custom manager and package
rule, and the build-from-source instructions. `docs/BUILD.md` now
documents the gateway cgo build via the go-mxl builder image (the path
`ci.yml` and `docker/gateway.Dockerfile` already use) and a host
install through go-mxl's README.

The module dependency docs are corrected to the post-migration
reality:

- `agent` is pure Go (cgo disabled). It watches the libmxl domain via
  `fanotify` (`golang.org/x/sys/unix`) and links no libmxl. Docs that
  grouped it with the gateway as a cgo/libmxl module were stale.
- `gateway` is the only cgo module. It imports both `go-mxl/mxl` and
  `go-mxl/fabrics`, so it links libmxl and libmxl-fabrics transitively
  through go-mxl. The "links libmxl-fabrics only" wording understated
  this.

The `mxl_integration` build-tag references in `docs/BUILD.md` and
`CLAUDE.md` are also dropped: no test in the tree carries that tag.
Integration testing is the KIND suite (`make kind-up` / `make
kind-test`, `docs/KIND.md`).

Corrected files: `README.md`, `CLAUDE.md`, `docs/USAGE.md`,
`docs/BUILD.md`, `docs/architecture/01-system-context.md`,
`docs/architecture/03-node-anatomy.md`.