### PR TITLE
fix(shim): build libmxl-intent.so on Rocky 8 to keep EL8 loadable

### DIFF
--- a/docker/shim.Dockerfile
+++ b/docker/shim.Dockerfile
@@ -4,11 +4,15 @@
 # consumer pod can mount it as an initContainer and copy it onto an
 # emptyDir shared with the main container.
 # Build context: repo root.
+#
+# Builder is pinned to Rocky Linux 8 (glibc 2.28) so the resulting
+# .so links against versioned glibc symbols no newer than 2.28 and
+# stays loadable on EL8-based consumer images. A trixie builder
+# produced an .so that failed to load on RHEL/Rocky/Alma 8 hosts
+# with "version GLIBC_2.34 not found".
 
-FROM docker.io/library/debian:trixie-slim AS builder
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc libc6-dev make && \
-    rm -rf /var/lib/apt/lists/*
+FROM docker.io/library/rockylinux:8 AS builder
+RUN dnf install -y gcc glibc-devel make && dnf clean all
 WORKDIR /src
 COPY shim/libmxl-intent.c shim/Makefile ./
 RUN make


### PR DESCRIPTION
The shim image ships a precompiled `libmxl-intent.so` that consumer
pods `LD_PRELOAD` from their own image. The build-stage glibc is
therefore the floor of the supported consumer glibc, not just a
local detail.

The current Debian trixie builder produces an .so versioned against
glibc 2.41. A consumer pod on Rocky Linux 8 (glibc 2.28) refuses to
start with:

    /lib64/libc.so.6: version `GLIBC_2.34' not found
    (required by /opt/mxl-intent/libmxl-intent.so)

EL8 (RHEL/Rocky/Alma) is a realistic target for the broadcast
manager images this shim is meant to plug into.

Pin the builder to `rockylinux:8`. Newer-glibc consumers stay
compatible because glibc preserves backward ABI; the .so now works
across the EL8…current Debian range.