### PR TITLE
fix(gateway): surface target-open failures in MxlFlowMirror status

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -36,6 +36,17 @@ const (
 	// could not register the target descriptor with the initiator.
 	ReasonAddTargetFailed = "AddTargetFailed"
 
+	// ReasonOpenTargetFailed marks a mirror whose target gateway could
+	// not open the local writer or the libmxl-fabrics target endpoint
+	// (Target.Setup). Without it the failure surfaced only in the
+	// gateway log while the mirror sat silently at an empty phase.
+	ReasonOpenTargetFailed = "OpenTargetFailed"
+
+	// ReasonFlowDefinitionEmpty marks a mirror whose MxlFlow exists but
+	// carries no spec.definition yet, so the target side cannot open the
+	// local writer. Transient while the producer publishes the flow.
+	ReasonFlowDefinitionEmpty = "FlowDefinitionEmpty"
+
 	// ReasonReaderAgedOut marks a mirror whose source-side flow
 	// reader fell behind the writer and advanced past the missed
 	// grains.

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -288,13 +288,26 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, fmt.Errorf("get MxlFlow %s: %w", mirror.Spec.FlowID, err)
 	}
 	if len(flow.Spec.Definition.Raw) == 0 {
-		return ctrl.Result{}, fmt.Errorf("MxlFlow %s has empty spec.definition", mirror.Spec.FlowID)
+		// The MxlFlow exists but the producer has not published its
+		// definition yet. Treat it like a not-yet-materialized flow:
+		// surface the reason and requeue instead of returning a bare
+		// error that leaves the mirror sitting at an empty phase.
+		r.surfaceTargetFailure(ctx, &mirror, mxlv1alpha1.ReasonFlowDefinitionEmpty,
+			fmt.Sprintf("MxlFlow %s has empty spec.definition", mirror.Spec.FlowID))
+		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
 
 	provider := mapProvider(mirror.Spec.Provider)
 
 	entry, err := r.openTarget(req.NamespacedName, string(flow.Spec.Definition.Raw), provider)
 	if err != nil {
+		// openTarget wraps NewWriter + the libmxl-fabrics Target.Setup,
+		// whose errors otherwise land only in the gateway log — the mirror
+		// is left at an empty phase, so the consumer (and cluster
+		// diagnostics, which only see the CR) get no signal for why it
+		// never went Ready. Surface the cause, then let the rate-limited
+		// requeue retry.
+		r.surfaceTargetFailure(ctx, &mirror, mxlv1alpha1.ReasonOpenTargetFailed, err.Error())
 		return ctrl.Result{}, fmt.Errorf("open target: %w", err)
 	}
 
@@ -832,6 +845,27 @@ func (r *TargetReconciler) applyTargetStatus(
 		client.FieldOwner(targetFieldOwner),
 		client.ForceOwnership,
 	)
+}
+
+// surfaceTargetFailure publishes Phase=Materializing plus a
+// TargetProgress=False condition carrying the reason the target side
+// could not be established yet. Best-effort: a failed status write must
+// not mask the original error the caller returns/requeues on, so the
+// result is intentionally ignored. It exists so a target-open failure
+// shows up in MxlFlowMirror status (and `kubectl describe`) instead of
+// the mirror wedging silently at an empty phase — the producer, the
+// consumer, and the cluster diagnostics only observe the CR, never the
+// gateway log. Only reached on the pre-Ready path (the Reconcile
+// fast-path returns earlier for a live, fresh, Ready mirror), so this
+// never demotes a healthy mirror.
+func (r *TargetReconciler) surfaceTargetFailure(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror, reason, message string) {
+	_ = r.applyTargetStatus(ctx, mirror, mxlv1alpha1.MxlFlowMirrorMaterializing, nil, nil, &metav1.Condition{
+		Type:               mxlv1alpha1.ConditionTypeTargetProgress,
+		Status:             metav1.ConditionFalse,
+		Reason:             reason,
+		Message:            message,
+		LastTransitionTime: metav1.Now(),
+	})
 }
 
 // degradedAfter returns the configured grain-commit freshness window,

--- a/gateway/internal/mirror/target_test.go
+++ b/gateway/internal/mirror/target_test.go
@@ -608,6 +608,56 @@ func TestTarget_FlowNotFoundOmitsTargetInfoAndLastGrain(t *testing.T) {
 			"flusher records a real commit")
 }
 
+func TestTarget_EmptyFlowDefinitionSurfacesConditionAndRequeues(t *testing.T) {
+	// An MxlFlow that exists but whose producer has not published a
+	// spec.definition yet must not wedge the mirror at an empty phase:
+	// the target side surfaces Phase=Materializing + a TargetProgress=
+	// False/FlowDefinitionEmpty condition and requeues, mirroring the
+	// flow-not-found branch. Before this, an empty definition returned a
+	// bare reconciler error and left the mirror at an empty phase, so the
+	// consumer and the cluster diagnostics (which only see the CR, not
+	// the gateway log) had no signal for why it never reached Ready.
+	scheme := newSourceTestScheme(t)
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	mirror := mirrorWithTargetFinalizer(key.Name, key.Namespace, "node-a", "flow-1", mxlv1alpha1.MxlFlowMirrorStatus{})
+	flow := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: "flow-1"},
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: "flow-1"},
+		// Definition intentionally omitted -> Raw is empty.
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}, &mxlv1alpha1.MxlFlow{}).
+		WithObjects(mirror, flow).
+		Build()
+
+	r := &TargetReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: "node-a",
+		targets:  map[types.NamespacedName]*targetEntry{},
+	}
+	req := reconcile.Request{NamespacedName: key}
+
+	res, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err,
+		"an unpublished flow definition is transient, not a reconciler "+
+			"error; it must come back as a benign requeue")
+	assert.Equal(t, 2*time.Second, res.RequeueAfter)
+
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &got))
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorMaterializing, got.Status.Phase,
+		"an existing flow with an empty definition must surface as "+
+			"Materializing, not the bare-error empty phase that left the "+
+			"mirror invisible to consumers and diagnostics")
+	require.Len(t, got.Status.Conditions, 1)
+	cond := got.Status.Conditions[0]
+	assert.Equal(t, mxlv1alpha1.ConditionTypeTargetProgress, cond.Type)
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, mxlv1alpha1.ReasonFlowDefinitionEmpty, cond.Reason)
+}
+
 func TestTarget_RecoverFromFatalErrorClearsRecoveringOnRebuildFailure(t *testing.T) {
 	// Codifies the comment above target.go's defer entry.recovering.Store(false):
 	// when openFabricSide returns an error during recovery the flusher


### PR DESCRIPTION
## What

The target-side gateway reconciler swallows pre-Ready failures. When `openTarget()` (NewWriter + libmxl-fabrics `Target.Setup`) fails, or when the `MxlFlow` exists but its `spec.definition` is still empty, it returned a bare reconciler error and left the `MxlFlowMirror` at an **empty phase** with no condition — the only trace was the gateway log.

This surfaces both pre-Ready paths into the CR status via a new `surfaceTargetFailure` helper:

- **`openTarget` failure** → `Phase=Materializing` + `TargetProgress=False` / `OpenTargetFailed` (error message attached), then the existing rate-limited requeue retries.
- **empty `spec.definition`** → `Phase=Materializing` + `TargetProgress=False` / `FlowDefinitionEmpty` + `RequeueAfter: 2s` — matching the existing flow-not-found branch (transient while the producer publishes), instead of a bare error.

## Why

Found while debugging an intermittent **0/N `MxlFlowMirror` wedge** on a 9-mirror media stack: mirrors sat at an empty phase and consumers crashed (`mxlCreateFlowReader … failed: 2`), but the CR carried **no reason** — the failure lived only in the gateway log, which the environment diagnostics don't capture.

After ruling out the reconcile-trigger / resync path, EFA (the gateway runs `providers: [tcp]`), and the handshake-stuck path (`Phase=Ready` is set eagerly *before* the handshake, so an empty phase means `openTarget` itself failed), the missing status signal was the blocker to root-causing it. This makes the failure **self-reporting** in `kubectl describe mxlflowmirror`.

## Scope / non-goals

- **Observability + graceful degradation only.** It does **not** fix the underlying `Target.Setup` failure (that code lives in `go-mxl` / libmxl-fabrics).
- No change to the fast-path or the recovery path; it never demotes a healthy mirror (the fast-path returns earlier for a live, fresh, Ready mirror).

## Testing

- Added `TestTarget_EmptyFlowDefinitionSurfacesConditionAndRequeues` (the `openTarget` path shares the same `surfaceTargetFailure` helper, so it is covered transitively; a direct test needs a real libmxl writer).
- ⚠️ Authored without a local Go toolchain — relying on CI for build / vet / test.

## Related

Found while investigating **qvest-digital/mxl-dmf-terraform#226** (intermittent full-media `MxlFlowMirror` 0/N wedge), which surfaced during **qvest-digital/mxl-dmf-terraform#190** (Talos PR-env parity).

This is an **independent observability / robustness improvement** — it does **not** close #226. The underlying `Target.Setup` failure lives in `go-mxl` / libmxl-fabrics; this change makes that failure self-reporting in the CR status so it can finally be pinned from a real run.
