### PR TITLE
[DO NOT MERGE] test: gateway image with go-mxl serialize-setup fix (#226 e2e)

### DIFF
--- a/docker/gateway.Dockerfile
+++ b/docker/gateway.Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /workspace
 COPY api/ api/
 COPY gateway/ gateway/
 WORKDIR /workspace/gateway
-ENV GOWORK=off
+ENV GOWORK=off GOFLAGS=-mod=mod
 RUN git config --global --add safe.directory '*' && \
     go mod download && \
     go build -trimpath -ldflags="-s -w" -o /out/mxl-fabrics-gateway ./cmd/mxl-fabrics-gateway

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/gateway
 go 1.26.0
 
 require (
-	github.com/qvest-digital/go-mxl v1.0.0-rc.9
+	github.com/qvest-digital/go-mxl v1.0.0-rc.9.test226
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.2
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0


### PR DESCRIPTION
Throwaway: builds a gateway image against go-mxl's fabricSetupMu fix (v1.0.0-rc.9.test226 / PR #64) for the AWS full-env e2e of qvest-digital/mxl-dmf-terraform#226. Not for merge; branch + tag deleted after.