### PR TITLE
fix(gateway): resync mirror to live head when it falls out of the producer ring

### DIFF
--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -517,6 +517,19 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 	return entry, nil
 }
 
+const (
+	// maxMirrorLag is how far lastSent may trail the live head before
+	// we give up trying to catch up grain-by-grain and resync to the
+	// tail. Kept below the producer's ring depth (a handful of grains)
+	// so we only resync once the backlog is genuinely unreadable, not
+	// during a normal one- or two-grain catch-up.
+	maxMirrorLag int64 = 4
+	// mirrorResyncLag is how many grains behind the head we resume
+	// after a resync, so we land on a fully committed grain rather than
+	// one still being written at the head.
+	mirrorResyncLag int64 = 2
+)
+
 // progressTracker is the subset of sourceEntry the transfer loop
 // updates. Defined as an interface so tests can inject a stub
 // without constructing a full sourceEntry.
@@ -585,6 +598,29 @@ func runTransferLoop(
 			l.Error(err, "Runtime")
 			continue
 		}
+
+		// A mirror can only transfer grains the producer still holds in
+		// its ring, which is only a handful of grains deep. Two cases
+		// strand lastSent far behind the live head, where every
+		// GetGrain fails "out of range (too late)" and the loop wedges
+		// forever retrying the same dead index:
+		//
+		//   - attach: the first Runtime() probe can report head 0
+		//     before the reader has observed a grain, pinning lastSent
+		//     at 0 while the real (large) head only appears later;
+		//   - fall-behind: a stall (scheduling, fabric backpressure)
+		//     lets the producer lap us by more than the ring depth.
+		//
+		// In both cases the aged-out grains are gone for good; the only
+		// recovery is to abandon them and resync to the live tail.
+		if h := int64(head); h > maxMirrorLag && lastSent < h-maxMirrorLag {
+			if lastSent > 0 {
+				l.V(1).Info("mirror fell out of producer ring, resyncing to head",
+					"lastSent", lastSent, "head", h)
+			}
+			lastSent = h - mirrorResyncLag - 1
+		}
+
 		for idx := lastSent + 1; idx <= int64(head); idx++ {
 			if _, err := transferGrain(uint64(idx)); err != nil {
 				// libmxl reports "out of range (too late)" when the
@@ -606,7 +642,11 @@ func runTransferLoop(
 					lastSent = int64(head)
 					break
 				}
-				l.Error(err, "TransferGrain", "index", idx)
+				// Otherwise the head grain is still committing; it lands
+				// next tick. V(1) so the steady-state "not yet committed"
+				// case doesn't spam error logs every tick.
+				l.V(1).Info("grain not transferable yet, will retry",
+					"index", idx, "head", head)
 				break
 			}
 			if tracker != nil {

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -617,6 +617,15 @@ func runTransferLoop(
 			if lastSent > 0 {
 				l.V(1).Info("mirror fell out of producer ring, resyncing to head",
 					"lastSent", lastSent, "head", h)
+				// Resyncing abandons the grains between lastSent and
+				// the tail. Signal the tracker so the reconciler can
+				// publish SourceProgress=ReaderAgedOut, matching the
+				// skip-ahead path in runSampleTransferLoop. The attach
+				// case (lastSent == 0) never held those grains, so it
+				// tails the live flow silently.
+				if tracker != nil {
+					tracker.recordAgedOut(time.Now())
+				}
 			}
 			lastSent = h - mirrorResyncLag - 1
 		}

--- a/gateway/internal/mirror/source_test.go
+++ b/gateway/internal/mirror/source_test.go
@@ -323,22 +323,24 @@ func (rt *recordingTracker) snapshot() ([]uint64, int) {
 }
 
 func TestRunTransferLoop_AdvancesLastSentOnAgedOutError(t *testing.T) {
-	// The writer has lapped the reader. Initial probe head=0 means
-	// the loop's lastSent starts at 0. On the first tick the probe
-	// reports head=5, so the loop tries idx=1 first; transferGrain
+	// A grain ages out while the lag stays within maxMirrorLag, so the
+	// proactive resync never fires and the aged-out grain surfaces only
+	// as a transferGrain error. Initial probe head=0 pins lastSent at
+	// 0. On the first tick the probe reports head=3 (lag 3, at or below
+	// maxMirrorLag), so the loop tries idx=1 first; transferGrain
 	// returns the libmxl "out of range (too late)" string. The loop
-	// must advance lastSent to head (5) and signal the tracker. On
-	// the next tick the probe reports head=20: transfers must resume
-	// from 6 onward, never re-attempting the unrecoverable 2..5.
+	// must advance lastSent to head (3) and signal the tracker. On the
+	// next tick the probe reports head=6: transfers must resume from 4
+	// onward, never re-attempting the unrecoverable 2..3.
 	var probeCalls atomic.Int32
 	probe := func() (uint64, error) {
 		switch probeCalls.Add(1) {
 		case 1:
 			return 0, nil
 		case 2:
-			return 5, nil
+			return 3, nil
 		default:
-			return 20, nil
+			return 6, nil
 		}
 	}
 
@@ -363,7 +365,7 @@ func TestRunTransferLoop_AdvancesLastSentOnAgedOutError(t *testing.T) {
 		mu.Lock()
 		defer mu.Unlock()
 		for _, v := range attempts {
-			if v == 6 {
+			if v == 4 {
 				return true
 			}
 		}
@@ -387,9 +389,52 @@ func TestRunTransferLoop_AdvancesLastSentOnAgedOutError(t *testing.T) {
 		"the aged-out skip must reach the tracker so the reconciler "+
 			"can surface SourceProgress=ReaderAgedOut")
 	for _, idx := range transfers {
-		assert.NotContains(t, []uint64{1, 2, 3, 4, 5}, idx,
+		assert.NotContains(t, []uint64{1, 2, 3}, idx,
 			"a recorded transfer for an aged-out index would mean the "+
 				"loop counted a fictional success against the tracker")
+	}
+}
+
+func TestRunTransferLoop_ResyncRecordsAgedOutOnFallBehind(t *testing.T) {
+	// The mirror transfers a few grains, then the producer laps it by
+	// more than maxMirrorLag before the next tick. The proactive resync
+	// abandons the stranded grains and lands near the live head; it
+	// must also signal the tracker so the reconciler can surface
+	// SourceProgress=ReaderAgedOut, matching the aged-out error path.
+	var probeCalls atomic.Int32
+	probe := func() (uint64, error) {
+		switch probeCalls.Add(1) {
+		case 1:
+			return 0, nil
+		case 2:
+			return 2, nil
+		default:
+			return 100, nil
+		}
+	}
+
+	transfer := func(uint64) (bool, error) { return false, nil }
+
+	tracker := &recordingTracker{}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil }, time.Millisecond, tracker)
+
+	require.Eventually(t, func() bool {
+		_, agedOuts := tracker.snapshot()
+		return agedOuts >= 1
+	}, time.Second, time.Millisecond,
+		"a fall-behind resync must reach the tracker so the reconciler "+
+			"can surface SourceProgress=ReaderAgedOut")
+
+	cancel()
+	<-done
+
+	transfers, _ := tracker.snapshot()
+	for _, idx := range transfers {
+		assert.Truef(t, idx <= 2 || idx >= uint64(100-maxMirrorLag),
+			"transfers must be the pre-resync grains or land near the "+
+				"live head after resync; got %d", idx)
 	}
 }
 

--- a/gateway/internal/mirror/source_test.go
+++ b/gateway/internal/mirror/source_test.go
@@ -131,6 +131,58 @@ func TestRunTransferLoop_TailsFromHead(t *testing.T) {
 	}
 }
 
+func TestRunTransferLoop_ResyncsToHeadWhenLapped(t *testing.T) {
+	// Attach race: the first Runtime probe reports head 0 (the reader
+	// has not observed a grain yet), then the real head appears far
+	// ahead. The producer only still holds grains near the head in its
+	// ring, so replaying from index 1 fails "out of range (too late)".
+	// The loop must resync to the live head and transfer fresh grains
+	// rather than wedge forever on the aged-out index.
+	var calls atomic.Int32
+	probe := func() (uint64, error) {
+		if calls.Add(1) == 1 {
+			return 0, nil
+		}
+		return 1000, nil
+	}
+
+	var mu sync.Mutex
+	var transferred []uint64
+	transfer := func(idx uint64) (bool, error) {
+		// Only grains within maxMirrorLag of the head are still in the
+		// producer ring; older indices have aged out.
+		if int64(idx) < 1000-maxMirrorLag {
+			return false, errors.New("mxl: out of range (too late)")
+		}
+		mu.Lock()
+		transferred = append(transferred, idx)
+		mu.Unlock()
+		return false, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil }, time.Millisecond, nil)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return len(transferred) > 0
+	}, time.Second, time.Millisecond,
+		"loop must resync to the live head and transfer fresh grains, "+
+			"not wedge on the aged-out index 1")
+
+	cancel()
+	<-done
+
+	mu.Lock()
+	defer mu.Unlock()
+	for _, idx := range transferred {
+		assert.GreaterOrEqualf(t, int64(idx), 1000-maxMirrorLag-1,
+			"after resync, transfers must be near the live head; got %d", idx)
+	}
+}
+
 func TestRunTransferLoop_TransferErrorBreaksInnerLoopButLoopSurvives(t *testing.T) {
 	// On a tick that fails the transfer, the loop must break the
 	// per-grain inner pass but keep going on the next tick. If it


### PR DESCRIPTION
## Problem

Cross-node MXL mirrors freeze: the source-side `runTransferLoop` wedges forever on an aged-out grain index, so consumers (e.g. the demo compositor) read a frozen flow.

Root cause: the loop tails from the head index read at attach, but the first `reader.Runtime()` probe can report head `0` before the reader has observed a grain. `lastSent` stays pinned at `0`; once the real (large) head appears, the inner loop tries `idx=1`, which has aged out of the producer's shallow ring → `mxl: out of range (too late)` → break → retry the same dead index every tick. Nothing is ever mirrored. The same wedge occurs in steady state if a stall lets the producer lap the mirror by more than the ring depth.

## Fix

Detect when `lastSent` has fallen more than `maxMirrorLag` behind the live head and resync to the tail (`mirrorResyncLag` grains back, landing on a committed grain). Aged-out grains are gone; tailing live is the only correct behavior for a media mirror.

Adds `TestRunTransferLoop_ResyncsToHeadWhenLapped`.

Verified against a Talos based on premis cluster: 9 v210 flows were frozen with this exact `too late` loop on every flow; this restores live cross-node (RDMA/verbs) mirroring.