### PR TITLE
ci(renovate): ignore go-mxl .test CI tags

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -39,6 +39,12 @@
       "semanticCommitScope": "gomod"
     },
     {
+      "description": "go-mxl's CI publishes throwaway tags such as v1.0.0-rc.9.test226 that outsort the real rc.N prereleases only because they carry an extra semver prerelease identifier (rc.9.test226 > rc.9). Reject any version with a .test segment so only real releases and rc prereleases are tracked",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": ["github.com/qvest-digital/go-mxl"],
+      "allowedVersions": "!/\\.test/"
+    },
+    {
       "description": "Group GitHub Actions bumps into one PR",
       "matchManagers": ["github-actions"],
       "groupName": "GitHub Actions",


### PR DESCRIPTION
go-mxl's CI publishes tags like `v1.0.0-rc.9.test226` that carry an extra semver prerelease identifier, so they sort above the real `rc.N` line (`rc.9.test226` > `rc.9`) and Renovate offers them as upgrades (as seen in #123).

Restrict the `github.com/qvest-digital/go-mxl` gomod rule with `allowedVersions: "!/\\.test/"` so any version containing a `.test` segment is rejected. Real releases (`v1.0.0`) and rc prereleases (`v1.0.0-rc.9`, `v1.0.0-rc.10`) still flow.