### PR TITLE
fix(gateway): gate stuck-handshake recovery on source activity

### DIFF
--- a/agent/cmd/mxl-domain-agent/main.go
+++ b/agent/cmd/mxl-domain-agent/main.go
@@ -60,6 +60,10 @@ func run(args []string) error {
 	if err != nil {
 		return fmt.Errorf("build kubeconfig: %w", err)
 	}
+	// client-go defaults to 5 QPS / 10 burst when the limits are left
+	// zero; flow appear/vanish bursts on a busy domain exceed that.
+	restCfg.QPS = float32(cfg.KubeAPIQPS)
+	restCfg.Burst = cfg.KubeAPIBurst
 	kClient, err := client.New(restCfg, client.Options{Scheme: scheme})
 	if err != nil {
 		return fmt.Errorf("build client: %w", err)

--- a/agent/internal/config/config.go
+++ b/agent/internal/config/config.go
@@ -48,6 +48,17 @@ type Config struct {
 	// target nodes' MxlNodeCapabilities; any other value is stamped
 	// onto every intent mirror verbatim and bypasses resolution.
 	Provider string
+
+	// KubeAPIQPS is the sustained request rate the Kubernetes API
+	// client allows before throttling. client-go falls back to
+	// 5 QPS when the limit is unset, which queues MxlFlow status
+	// publishes and intent mirror writes behind second-long delays
+	// during flow appear/vanish bursts.
+	KubeAPIQPS float64
+
+	// KubeAPIBurst is the burst ceiling of the Kubernetes API client
+	// rate limiter.
+	KubeAPIBurst int
 }
 
 // FromFlags populates a Config from command-line flags.
@@ -73,6 +84,10 @@ func FromFlags(fs *flag.FlagSet, args []string) (*Config, error) {
 		"Explicit libmxl-fabrics provider (tcp, verbs, efa, shm) stamped "+
 			"onto on-demand mirrors. Empty or 'auto' resolves per node from "+
 			"MxlNodeCapabilities.")
+	fs.Float64Var(&c.KubeAPIQPS, "kube-api-qps", 50,
+		"Sustained Kubernetes API request rate allowed before client-side throttling.")
+	fs.IntVar(&c.KubeAPIBurst, "kube-api-burst", 100,
+		"Burst ceiling of the Kubernetes API client rate limiter.")
 	if err := fs.Parse(args); err != nil {
 		return nil, err
 	}
@@ -102,6 +117,12 @@ func (c *Config) Validate() error {
 		mxlv1alpha1.ProviderSHM:
 	default:
 		return fmt.Errorf("--provider %q is not one of tcp, verbs, efa, shm, auto", c.Provider)
+	}
+	if c.KubeAPIQPS <= 0 {
+		return fmt.Errorf("--kube-api-qps must be positive, got %v", c.KubeAPIQPS)
+	}
+	if c.KubeAPIBurst <= 0 {
+		return fmt.Errorf("--kube-api-burst must be positive, got %d", c.KubeAPIBurst)
 	}
 	return nil
 }

--- a/agent/internal/config/config_test.go
+++ b/agent/internal/config/config_test.go
@@ -41,6 +41,11 @@ func TestFromFlags_DefaultsFireWhenArgsProvided(t *testing.T) {
 	assert.Equal(t, 30*time.Second, c.ResyncPeriod)
 	assert.Equal(t, "/run/mxl/agent.sock", c.IntentSocketPath)
 	assert.Equal(t, 5*time.Second, c.MaterializeTimeout)
+	assert.Equal(t, 50.0, c.KubeAPIQPS,
+		"client-go's 5 QPS fallback queues status publishes behind "+
+			"second-long delays during flow appear/vanish bursts; the "+
+			"default must stay well above that")
+	assert.Equal(t, 100, c.KubeAPIBurst)
 }
 
 func TestFromFlags_OverridesAreRespected(t *testing.T) {
@@ -104,18 +109,28 @@ func TestValidate(t *testing.T) {
 		},
 		{
 			name:    "valid",
-			c:       Config{DomainPath: "/run/mxl/domain", NodeName: "n1"},
+			c:       Config{DomainPath: "/run/mxl/domain", NodeName: "n1", KubeAPIQPS: 50, KubeAPIBurst: 100},
 			wantErr: "",
 		},
 		{
 			name:    "explicit provider override",
-			c:       Config{DomainPath: "/run/mxl/domain", NodeName: "n1", Provider: "verbs"},
+			c:       Config{DomainPath: "/run/mxl/domain", NodeName: "n1", Provider: "verbs", KubeAPIQPS: 50, KubeAPIBurst: 100},
 			wantErr: "",
 		},
 		{
 			name:    "auto provider is accepted (resolves per node)",
-			c:       Config{DomainPath: "/run/mxl/domain", NodeName: "n1", Provider: "auto"},
+			c:       Config{DomainPath: "/run/mxl/domain", NodeName: "n1", Provider: "auto", KubeAPIQPS: 50, KubeAPIBurst: 100},
 			wantErr: "",
+		},
+		{
+			name:    "zero qps rejected",
+			c:       Config{DomainPath: "/run/mxl/domain", NodeName: "n1", KubeAPIBurst: 100},
+			wantErr: "--kube-api-qps",
+		},
+		{
+			name:    "zero burst rejected",
+			c:       Config{DomainPath: "/run/mxl/domain", NodeName: "n1", KubeAPIQPS: 50},
+			wantErr: "--kube-api-burst",
 		},
 		{
 			name:    "unknown provider rejected",

--- a/gateway/cmd/mxl-fabrics-gateway/main.go
+++ b/gateway/cmd/mxl-fabrics-gateway/main.go
@@ -60,6 +60,11 @@ func run(args []string) error {
 	if err != nil {
 		return fmt.Errorf("build kubeconfig: %w", err)
 	}
+	// client-go defaults to 5 QPS / 10 burst when the limits are left
+	// zero; the per-mirror status flushers alone exceed that with a
+	// handful of flowing mirrors on the node.
+	restCfg.QPS = float32(cfg.KubeAPIQPS)
+	restCfg.Burst = cfg.KubeAPIBurst
 
 	// Open libmxl handles up front so any misconfiguration (bad
 	// domain path, missing .so) fails before the manager comes up.

--- a/gateway/internal/config/config.go
+++ b/gateway/internal/config/config.go
@@ -56,6 +56,20 @@ type Config struct {
 	// invalidate its Reconcile fast-path. Matches the operator-side
 	// MxlFlowMirror freshness expectation.
 	DegradedAfter time.Duration
+
+	// KubeAPIQPS is the sustained request rate the Kubernetes API
+	// client allows before throttling. The per-mirror status flushers
+	// publish roughly one PATCH per second per flowing mirror, so the
+	// sustained write rate scales with the flowing mirrors on the
+	// node. client-go falls back to 5 QPS when the limit is unset,
+	// which saturates at a handful of mirrors and queues status
+	// writes behind second-long delays - stale LastSentAt/LastGrainAt
+	// then skews the cross-side stuck-handshake comparison.
+	KubeAPIQPS float64
+
+	// KubeAPIBurst is the burst ceiling of the Kubernetes API client
+	// rate limiter.
+	KubeAPIBurst int
 }
 
 // FromFlags populates a Config from command-line flags.
@@ -84,6 +98,10 @@ func FromFlags(fs *flag.FlagSet, args []string) (*Config, error) {
 		"How often to refresh MxlNodeCapabilities status.")
 	fs.DurationVar(&c.DegradedAfter, "degraded-after", 10*time.Second,
 		"Grain-commit inactivity after which the target gateway demotes a mirror to Degraded.")
+	fs.Float64Var(&c.KubeAPIQPS, "kube-api-qps", 50,
+		"Sustained Kubernetes API request rate allowed before client-side throttling.")
+	fs.IntVar(&c.KubeAPIBurst, "kube-api-burst", 100,
+		"Burst ceiling of the Kubernetes API client rate limiter.")
 	if err := fs.Parse(args); err != nil {
 		return nil, err
 	}
@@ -126,6 +144,12 @@ func (c *Config) Validate() error {
 	}
 	if len(c.Providers) == 0 {
 		return fmt.Errorf("--providers must list at least one provider")
+	}
+	if c.KubeAPIQPS <= 0 {
+		return fmt.Errorf("--kube-api-qps must be positive, got %v", c.KubeAPIQPS)
+	}
+	if c.KubeAPIBurst <= 0 {
+		return fmt.Errorf("--kube-api-burst must be positive, got %d", c.KubeAPIBurst)
 	}
 	return nil
 }

--- a/gateway/internal/config/config_test.go
+++ b/gateway/internal/config/config_test.go
@@ -43,6 +43,11 @@ func TestFromFlags_DefaultsAndProvidersCSV(t *testing.T) {
 		"pprof endpoint is opt-in; the default must leave it off so a "+
 			"production gateway never serves /debug/pprof unprompted")
 	assert.Equal(t, 30*time.Second, c.ResyncPeriod)
+	assert.Equal(t, 50.0, c.KubeAPIQPS,
+		"client-go's 5 QPS fallback throttles the per-mirror status "+
+			"flushers at a handful of flowing mirrors; the default must "+
+			"stay well above that")
+	assert.Equal(t, 100, c.KubeAPIBurst)
 	require.Equal(t, []fabrics.Provider{fabrics.ProviderTCP}, c.Providers,
 		"default provider list must be exactly [tcp]; --providers tcp is the only "+
 			"setup that works out of the box without RDMA hardware on every node")
@@ -147,7 +152,9 @@ func TestValidate(t *testing.T) {
 		{"missing domain", Config{NodeName: "n", Providers: []fabrics.Provider{fabrics.ProviderTCP}}, "--domain-path"},
 		{"relative domain", Config{NodeName: "n", DomainPath: "rel", Providers: []fabrics.Provider{fabrics.ProviderTCP}}, "absolute"},
 		{"empty providers", Config{NodeName: "n", DomainPath: "/d"}, "--providers"},
-		{"valid", Config{NodeName: "n", DomainPath: "/d", Providers: []fabrics.Provider{fabrics.ProviderTCP}}, ""},
+		{"zero qps", Config{NodeName: "n", DomainPath: "/d", Providers: []fabrics.Provider{fabrics.ProviderTCP}, KubeAPIBurst: 100}, "--kube-api-qps"},
+		{"zero burst", Config{NodeName: "n", DomainPath: "/d", Providers: []fabrics.Provider{fabrics.ProviderTCP}, KubeAPIQPS: 50}, "--kube-api-burst"},
+		{"valid", Config{NodeName: "n", DomainPath: "/d", Providers: []fabrics.Provider{fabrics.ProviderTCP}, KubeAPIQPS: 50, KubeAPIBurst: 100}, ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -979,9 +979,16 @@ func (r *TargetReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 		// ErrNotReady forever - the progress loop never raises
 		// onFatal, so recoverFromFatalError never fires, and the
 		// flusher would otherwise just oscillate between Ready and
-		// Degraded as time goes by. Spawn recovery explicitly when
-		// no commit has landed since the fabric side opened and the
-		// stuck-handshake window has elapsed.
+		// Degraded as time goes by. Spawn recovery when no commit has
+		// landed since the fabric side opened, the stuck-handshake
+		// window has elapsed, *and* mirror.Status.LastSentAt postdates
+		// the open: zero commits alone cannot distinguish a wedged
+		// handshake from a flow whose producer simply is not sending.
+		// Without the source-activity gate an idle flow loops
+		// spawn->cap->drop->reopen forever - each reopen resets
+		// fabricOpenedAt, the window elapses again, and the cycle
+		// closes the writer (and every consumer FlowReader) every few
+		// seconds for as long as the producer stays quiet.
 		//
 		// postHandshakeWedge: the handshake succeeded and at least
 		// one grain committed, then the fabric side wedged silently.
@@ -998,9 +1005,16 @@ func (r *TargetReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 		// the flusher directly): the watchdog must not fire on an
 		// entry whose fabric side was never actually opened.
 		openedAt := entry.fabricOpenedAt.Load()
-		neverHandshook := openedAt != nil &&
+		neverHandshook := false
+		if openedAt != nil &&
 			entry.commits.Load() == entry.commitsAtFabricOpen.Load() &&
-			time.Since(*openedAt) > r.stuckHandshakeAfter()
+			time.Since(*openedAt) > r.stuckHandshakeAfter() {
+			if mirror, err := r.fetchMirror(ctx, key); err == nil &&
+				mirror.Status.LastSentAt != nil &&
+				mirror.Status.LastSentAt.Time.After(*openedAt) {
+				neverHandshook = true
+			}
+		}
 		postHandshakeWedge := false
 		if openedAt != nil && entry.commits.Load() > entry.commitsAtFabricOpen.Load() {
 			lastCommit := entry.lastCommitAt.Load()
@@ -1087,9 +1101,16 @@ func (r *TargetReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 				// LastSentAt change that lands in the same window
 				// must be observed before the spawn commits.
 				openedAt2 := entry.fabricOpenedAt.Load()
-				neverHandshook2 := openedAt2 != nil &&
+				neverHandshook2 := false
+				if openedAt2 != nil &&
 					entry.commits.Load() == entry.commitsAtFabricOpen.Load() &&
-					time.Since(*openedAt2) > r.stuckHandshakeAfter()
+					time.Since(*openedAt2) > r.stuckHandshakeAfter() {
+					if mirror, err := r.fetchMirror(ctx, key); err == nil &&
+						mirror.Status.LastSentAt != nil &&
+						mirror.Status.LastSentAt.Time.After(*openedAt2) {
+						neverHandshook2 = true
+					}
+				}
 				postHandshakeWedge2 := false
 				if openedAt2 != nil && entry.commits.Load() > entry.commitsAtFabricOpen.Load() {
 					lastCommit2 := entry.lastCommitAt.Load()

--- a/gateway/internal/mirror/target_test.go
+++ b/gateway/internal/mirror/target_test.go
@@ -904,13 +904,36 @@ func (f *targetWatchdogFixture) stopFlusher(t *testing.T) {
 	f.cancel = nil
 }
 
+// stampSourceActivity publishes a LastSentAt onto the fixture's
+// mirror status. The neverHandshook branch requires source activity
+// after fabricOpenedAt before it escalates, so watchdog tests that
+// want the branch to fire stamp a fresh LastSentAt first.
+//
+// The status is re-fetched before each attempt so concurrent flusher
+// writes do not collide on resourceVersion (same shape as
+// armPostHandshakeWedge).
+func (f *targetWatchdogFixture) stampSourceActivity(t *testing.T, at time.Time) {
+	t.Helper()
+	for i := 0; i < 5; i++ {
+		var current mxlv1alpha1.MxlFlowMirror
+		require.NoError(t, f.c.Get(context.Background(), f.key, &current))
+		current.Status.LastSentAt = &metav1.Time{Time: at}
+		if err := f.c.Status().Update(context.Background(), &current); err == nil {
+			return
+		}
+	}
+	t.Fatal("stampSourceActivity: status update raced concurrent writes after 5 attempts")
+}
+
 func TestRunFlusher_StuckHandshake_TriggersRecovery(t *testing.T) {
-	// Fabric opened in the distant past, zero commits: the flusher
-	// must escalate into the recovery seam exactly once and increment
-	// recoveryAttempts. Without the escalation a silently-wedged
-	// libmxl-fabrics target stays Ready forever (no fatal ReadGrain
-	// to trigger onFatal) and consumer FlowReaders see no grains.
+	// Fabric opened in the distant past, zero commits, source active:
+	// the flusher must escalate into the recovery seam exactly once
+	// and increment recoveryAttempts. Without the escalation a
+	// silently-wedged libmxl-fabrics target stays Ready forever (no
+	// fatal ReadGrain to trigger onFatal) and consumer FlowReaders
+	// see no grains.
 	f := newTargetWatchdogFixture(t, 4)
+	f.stampSourceActivity(t, time.Now())
 	f.startFlusher(t)
 	defer f.stopFlusher(t)
 
@@ -925,6 +948,52 @@ func TestRunFlusher_StuckHandshake_TriggersRecovery(t *testing.T) {
 	}, time.Second, 5*time.Millisecond,
 		"the watchdog spawn must increment recoveryAttempts so the cap "+
 			"branch can count consecutive failures")
+}
+
+func TestRunFlusher_NeverHandshook_IdleSource_DoesNotTrigger(t *testing.T) {
+	// Zero commits since the fabric open is not enough to call a
+	// target wedged: a mirror status without any LastSentAt means the
+	// producer has never pushed a grain at this fabric side, and a
+	// rebuild cannot attract data that is not being sent. Without the
+	// source-activity gate an idle flow loops spawn->cap->drop->reopen
+	// forever, closing the writer (and every consumer FlowReader)
+	// every few seconds for as long as the producer stays quiet.
+	f := newTargetWatchdogFixture(t, 4)
+	f.startFlusher(t)
+	defer f.stopFlusher(t)
+
+	select {
+	case <-f.spawnCh:
+		t.Fatal("watchdog spawned recovery for a flow whose source never " +
+			"sent; neverHandshook requires LastSentAt after fabricOpenedAt")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	assert.Equal(t, uint32(0), f.entry.recoveryAttempts.Load(),
+		"an idle flow must not accumulate recovery attempts")
+}
+
+func TestRunFlusher_NeverHandshook_StaleSource_DoesNotTrigger(t *testing.T) {
+	// A LastSentAt that predates fabricOpenedAt belongs to a previous
+	// fabric side: those grains can never commit here, so they say
+	// nothing about the current handshake. Only source activity after
+	// the current open marks a genuine wedge.
+	f := newTargetWatchdogFixture(t, 4)
+	// Fixture stamps fabricOpenedAt an hour in the past; a send two
+	// hours ago predates it.
+	f.stampSourceActivity(t, time.Now().Add(-2*time.Hour))
+	f.startFlusher(t)
+	defer f.stopFlusher(t)
+
+	select {
+	case <-f.spawnCh:
+		t.Fatal("watchdog spawned recovery on pre-open source activity; " +
+			"neverHandshook requires LastSentAt after fabricOpenedAt")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	assert.Equal(t, uint32(0), f.entry.recoveryAttempts.Load(),
+		"pre-open source activity must not accumulate recovery attempts")
 }
 
 func TestRunFlusher_CommitDisarmsWatchdog(t *testing.T) {
@@ -960,6 +1029,7 @@ func TestRunFlusher_CapsRecoveryAttempts(t *testing.T) {
 	// exact spawn count + terminal status + entry removal + flusher
 	// exit in one test.
 	f := newTargetWatchdogFixture(t, int(maxStuckRebuilds)+2)
+	f.stampSourceActivity(t, time.Now())
 	f.startFlusher(t)
 
 	for i := uint32(0); i < maxStuckRebuilds; i++ {
@@ -1014,6 +1084,7 @@ func TestRunFlusher_CapPath_TerminalStatus(t *testing.T) {
 	// unable to distinguish this failure mode from other terminal
 	// states.
 	f := newTargetWatchdogFixture(t, int(maxStuckRebuilds)+2)
+	f.stampSourceActivity(t, time.Now())
 	f.startFlusher(t)
 
 	for i := uint32(0); i < maxStuckRebuilds; i++ {
@@ -1069,6 +1140,7 @@ func TestRunFlusher_CapResetsAfterCommit(t *testing.T) {
 		f.entry.recovering.Store(false)
 	}
 
+	f.stampSourceActivity(t, time.Now())
 	f.startFlusher(t)
 	defer func() {
 		if f.cancel != nil {
@@ -1146,6 +1218,7 @@ func TestRunFlusher_CapPath_NoDeadlock(t *testing.T) {
 	cancelCalled := make(chan struct{})
 	f.entry.cancel = func() { close(cancelCalled) }
 
+	f.stampSourceActivity(t, time.Now())
 	f.startFlusher(t)
 
 	for i := uint32(0); i < maxStuckRebuilds; i++ {
@@ -1197,6 +1270,7 @@ func TestRunFlusher_RecoveryGate_NoDoubleSpawnUnderRace(t *testing.T) {
 		// recovery still in flight when the next flusher tick fires.
 	}
 
+	f.stampSourceActivity(t, time.Now())
 	f.startFlusher(t)
 	defer f.stopFlusher(t)
 


### PR DESCRIPTION
Two defects that compound on a node with several flowing mirrors.

The neverHandshook branch of the target-side stuck-handshake watchdog
escalated any mirror with zero commits since the fabric side opened,
without checking whether the source was sending at all. A mirror for
an idle flow therefore looped spawn -> cap -> drop entry -> reopen
indefinitely (one observed mirror rebuilt every ~21s for six hours),
closing the flow writer and invalidating every consumer FlowReader on
each cycle. The watchdog now requires mirror.Status.LastSentAt to
postdate fabricOpenedAt before escalating - the same cross-side
coordination postHandshakeWedge already applies to spare legitimately
idle flows.

Both the gateway and the agent build their rest.Config via
clientcmd.BuildConfigFromFlags, which leaves client-go's 5 QPS /
10 burst fallback in effect. The per-mirror status flushers publish
roughly one PATCH per second per flowing mirror on both mirror ends,
so a handful of flowing mirrors saturates the limiter permanently:
requests queue behind second-long waits (client-go logs "Waited
before sending request" client-side throttling), stale
LastSentAt/LastGrainAt skews the wedge comparison, and TargetInfo
propagation after a rebuild lags behind the same queue. Both binaries
gain --kube-api-qps / --kube-api-burst, defaulting to 50/100.

fix(gateway): raise Kubernetes API client rate limits
fix(agent): raise Kubernetes API client rate limits