### PR TITLE
fix(gateway): detect origin rotation for a reader opened before Stale clears

### DIFF
--- a/agent/internal/flowpublisher/publisher.go
+++ b/agent/internal/flowpublisher/publisher.go
@@ -13,6 +13,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
@@ -166,33 +167,45 @@ func (p *Publisher) PublishVanished(ctx context.Context, dirName string) error {
 	return nil
 }
 
+// upsertLocation is retried on a conflict: status.locations is read-
+// modify-written by every node's agent concurrently (each node owns
+// only its own slice entry, but all entries live in the same status
+// subresource), so a fanotify event racing another node's write is
+// routine, not exceptional. The fanotify dispatcher calls this once
+// per event and only logs a returned error -- an unretried conflict
+// here permanently drops the appearance/vanish it was reporting, and
+// for an Origin location that is the source gateway's only signal
+// that the flow's writer rotated.
 func (p *Publisher) upsertLocation(ctx context.Context, flowID string, phase mxlv1alpha1.MxlFlowLocationPhase, observed *metav1.Time) error {
-	var obj mxlv1alpha1.MxlFlow
-	if err := p.Client.Get(ctx, types.NamespacedName{Name: flowID}, &obj); err != nil {
-		if apierrors.IsNotFound(err) {
-			return nil
+	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var obj mxlv1alpha1.MxlFlow
+		if err := p.Client.Get(ctx, types.NamespacedName{Name: flowID}, &obj); err != nil {
+			if apierrors.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("get MxlFlow %s: %w", flowID, err)
 		}
-		return fmt.Errorf("get MxlFlow %s: %w", flowID, err)
-	}
 
-	found := false
-	for i := range obj.Status.Locations {
-		if obj.Status.Locations[i].NodeName == p.NodeName {
-			obj.Status.Locations[i].Phase = phase
-			obj.Status.Locations[i].LastObserved = observed
-			found = true
-			break
+		found := false
+		for i := range obj.Status.Locations {
+			if obj.Status.Locations[i].NodeName == p.NodeName {
+				obj.Status.Locations[i].Phase = phase
+				obj.Status.Locations[i].LastObserved = observed
+				found = true
+				break
+			}
 		}
-	}
-	if !found {
-		obj.Status.Locations = append(obj.Status.Locations, mxlv1alpha1.MxlFlowLocation{
-			NodeName:     p.NodeName,
-			Phase:        phase,
-			LastObserved: observed,
-		})
-	}
+		if !found {
+			obj.Status.Locations = append(obj.Status.Locations, mxlv1alpha1.MxlFlowLocation{
+				NodeName:     p.NodeName,
+				Phase:        phase,
+				LastObserved: observed,
+			})
+		}
 
-	if err := p.Client.Status().Update(ctx, &obj); err != nil {
+		return p.Client.Status().Update(ctx, &obj)
+	})
+	if err != nil {
 		return fmt.Errorf("update MxlFlow %s status: %w", flowID, err)
 	}
 	return nil
@@ -298,6 +311,62 @@ func (p *Publisher) demoteVanishedLocalOrigins(ctx context.Context, onDisk map[s
 	return nil
 }
 
+// localLocationHealthy reports whether flow.status.locations carries
+// a non-Stale entry for this node with a LastObserved timestamp. A
+// missing entry, a Stale phase, or a nil timestamp are all states
+// that leave the source gateway's rotation detector permanently
+// unable to fire: its baseline is recorded once at reader-open, and
+// a nil baseline never counts as rotated no matter what arrives
+// later.
+func (p *Publisher) localLocationHealthy(flow *mxlv1alpha1.MxlFlow) bool {
+	for _, loc := range flow.Status.Locations {
+		if loc.NodeName != p.NodeName {
+			continue
+		}
+		return loc.Phase != mxlv1alpha1.MxlFlowLocationStale && loc.LastObserved != nil
+	}
+	return false
+}
+
+// promoteStaleLocalOrigins re-publishes any on-disk flow whose
+// location entry for this node is unhealthy per localLocationHealthy
+// -- missing, Stale, or timestamp-less. It is the symmetric repair to
+// demoteVanishedLocalOrigins: that function heals a location that
+// outlived its directory, this one heals a directory whose location
+// never landed or got stuck, most commonly a status-update conflict
+// that exhausted upsertLocation's retries, or a fanotify event lost
+// before the watcher started.
+//
+// Gating on health (rather than unconditionally re-publishing, the
+// way InitialSync does at startup) matters here: RunLocalRescan calls
+// this on every tick, and an unconditional PublishAppeared would
+// refresh LastObserved on already-healthy flows too, which the
+// source gateway's rotation detector reads as a genuine rotation --
+// producing a spurious reader reopen on every steady-state flow once
+// per rescan interval.
+func (p *Publisher) promoteStaleLocalOrigins(ctx context.Context, onDisk map[string]struct{}) error {
+	l := log.FromContext(ctx).WithName("flowpublisher.promote")
+	for id := range onDisk {
+		var flow mxlv1alpha1.MxlFlow
+		err := p.Client.Get(ctx, types.NamespacedName{Name: id}, &flow)
+		switch {
+		case apierrors.IsNotFound(err):
+			// No MxlFlow yet; PublishAppeared below creates it.
+		case err != nil:
+			l.Error(err, "get MxlFlow for promote pass", "flowID", id)
+			continue
+		default:
+			if p.localLocationHealthy(&flow) {
+				continue
+			}
+		}
+		if err := p.PublishAppeared(ctx, id+FlowDirSuffix); err != nil {
+			l.Error(err, "promote stale local origin failed", "flowID", id)
+		}
+	}
+	return nil
+}
+
 // RunRenewLoop renews the Lease for every Origin flow currently on
 // disk on a fixed interval. Stops when ctx is done. A zero or
 // negative interval falls back to 10s -- a third of the agent's
@@ -354,6 +423,9 @@ func (p *Publisher) RunLocalRescan(ctx context.Context, interval time.Duration) 
 			}
 			if err := p.demoteVanishedLocalOrigins(ctx, ids); err != nil {
 				l.Error(err, "demote pass failed")
+			}
+			if err := p.promoteStaleLocalOrigins(ctx, ids); err != nil {
+				l.Error(err, "promote pass failed")
 			}
 		}
 	}

--- a/agent/internal/flowpublisher/publisher_conflict_test.go
+++ b/agent/internal/flowpublisher/publisher_conflict_test.go
@@ -1,0 +1,70 @@
+package flowpublisher
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+func TestPublishAppeared_SurvivesStatusUpdateConflict(t *testing.T) {
+	// status.locations of one MxlFlow is read-modify-written by every
+	// node's agent, so concurrent publishes conflict routinely. The
+	// fanotify dispatcher fires PublishAppeared exactly once per event
+	// and only logs a failure, which turns a single 409 into a lost
+	// appearance: LastObserved never advances, and the source gateway
+	// never learns the origin rotated. A conflict must therefore be
+	// retried inside the publisher instead of surfacing to the
+	// dispatcher.
+	scheme := newScheme(t)
+	domain := t.TempDir()
+	flowDir := filepath.Join(domain, validFlowID+".mxl-flow")
+	require.NoError(t, os.Mkdir(flowDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(flowDir, FlowDefName),
+		[]byte(`{"id":"`+validFlowID+`"}`), 0o644))
+
+	var updates atomic.Int32
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			SubResourceUpdate: func(ctx context.Context, cl client.Client, sub string, obj client.Object, opts ...client.SubResourceUpdateOption) error {
+				if updates.Add(1) == 1 {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: mxlv1alpha1.GroupVersion.Group, Resource: "mxlflows"},
+						obj.GetName(),
+						errors.New("the object has been modified"))
+				}
+				return cl.SubResource(sub).Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	p := &Publisher{Client: c, DomainPath: domain, NodeName: "n1"}
+	require.NoError(t, p.PublishAppeared(context.Background(), validFlowID+FlowDirSuffix),
+		"a single optimistic-concurrency conflict must not surface to the "+
+			"dispatcher: the fanotify event fires once and its error is only "+
+			"logged, so an unretried conflict permanently drops the appearance")
+
+	var flow mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: validFlowID}, &flow))
+	require.Len(t, flow.Status.Locations, 1)
+	assert.Equal(t, mxlv1alpha1.MxlFlowLocationOrigin, flow.Status.Locations[0].Phase)
+	assert.NotNil(t, flow.Status.Locations[0].LastObserved,
+		"the appearance timestamp is the source gateway's only rotation "+
+			"signal; losing it leaves a restarted writer's ring untailed")
+}

--- a/agent/internal/flowpublisher/publisher_test.go
+++ b/agent/internal/flowpublisher/publisher_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -325,6 +326,133 @@ func TestInitialSync_DemotesOriginForFlowsNoLongerOnDisk(t *testing.T) {
 	assert.Equal(t, mxlv1alpha1.MxlFlowLocationReady, byNode["other"],
 		"other-node locations are out of this agent's scope; "+
 			"InitialSync must not touch them")
+}
+
+func TestPromoteStaleLocalOrigins_RepublishesStaleLocation(t *testing.T) {
+	scheme := newScheme(t)
+	domain := t.TempDir()
+	flowDir := filepath.Join(domain, validFlowID+".mxl-flow")
+	require.NoError(t, os.Mkdir(flowDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(flowDir, FlowDefName),
+		[]byte(`{"id":"`+validFlowID+`"}`), 0o644))
+
+	// Stale with no LastObserved: the shape PublishVanished leaves
+	// behind, and the shape a dropped PublishAppeared conflict never
+	// repairs.
+	existing := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: ObjectMeta(validFlowID),
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: validFlowID},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{
+				{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationStale},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(existing).
+		Build()
+
+	p := &Publisher{Client: c, DomainPath: domain, NodeName: "n1"}
+	require.NoError(t, p.promoteStaleLocalOrigins(context.Background(),
+		map[string]struct{}{validFlowID: {}}))
+
+	var got mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: validFlowID}, &got))
+	require.Len(t, got.Status.Locations, 1)
+	loc := got.Status.Locations[0]
+	assert.Equal(t, mxlv1alpha1.MxlFlowLocationOrigin, loc.Phase,
+		"an on-disk flow stuck Stale must be re-published to Origin; "+
+			"leaving it Stale strands the source gateway's rotation "+
+			"detector, which only re-arms on a fresh LastObserved")
+	require.NotNil(t, loc.LastObserved)
+}
+
+func TestPromoteStaleLocalOrigins_RepublishesMissingLocationEntry(t *testing.T) {
+	scheme := newScheme(t)
+	domain := t.TempDir()
+	flowDir := filepath.Join(domain, validFlowID+".mxl-flow")
+	require.NoError(t, os.Mkdir(flowDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(flowDir, FlowDefName),
+		[]byte(`{"id":"`+validFlowID+`"}`), 0o644))
+
+	// MxlFlow exists (another node published it) but carries no
+	// location entry for n1 at all -- the shape a dropped first-ever
+	// PublishAppeared on this node leaves behind.
+	existing := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: ObjectMeta(validFlowID),
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: validFlowID},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(existing).
+		Build()
+
+	p := &Publisher{Client: c, DomainPath: domain, NodeName: "n1"}
+	require.NoError(t, p.promoteStaleLocalOrigins(context.Background(),
+		map[string]struct{}{validFlowID: {}}))
+
+	var got mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: validFlowID}, &got))
+	require.Len(t, got.Status.Locations, 1)
+	assert.Equal(t, "n1", got.Status.Locations[0].NodeName)
+	assert.Equal(t, mxlv1alpha1.MxlFlowLocationOrigin, got.Status.Locations[0].Phase)
+}
+
+func TestPromoteStaleLocalOrigins_LeavesHealthyLocationUntouched(t *testing.T) {
+	scheme := newScheme(t)
+	domain := t.TempDir()
+	flowDir := filepath.Join(domain, validFlowID+".mxl-flow")
+	require.NoError(t, os.Mkdir(flowDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(flowDir, FlowDefName),
+		[]byte(`{"id":"`+validFlowID+`"}`), 0o644))
+
+	originalObserved := metav1.NewTime(metav1.Now().Add(-time.Hour))
+	existing := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: ObjectMeta(validFlowID),
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: validFlowID},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{
+				{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin, LastObserved: &originalObserved},
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(existing).
+		Build()
+
+	// The fake client's object tracker round-trips seeded objects
+	// through its codec, which truncates metav1.Time to second
+	// precision -- read the seeded value back instead of comparing
+	// against originalObserved directly, or a same-second reopen
+	// (impossible below in the second-truncated stored value, but
+	// generally the discipline to follow for metav1.Time) would look
+	// identical to a no-op regardless of whether the code under test
+	// actually left it alone.
+	var before mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: validFlowID}, &before))
+	beforeObserved := before.Status.Locations[0].LastObserved
+
+	p := &Publisher{Client: c, DomainPath: domain, NodeName: "n1"}
+	require.NoError(t, p.promoteStaleLocalOrigins(context.Background(),
+		map[string]struct{}{validFlowID: {}}))
+
+	var got mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: validFlowID}, &got))
+	require.Len(t, got.Status.Locations, 1)
+	assert.True(t, got.Status.Locations[0].LastObserved.Equal(beforeObserved),
+		"promoteStaleLocalOrigins must not touch an already-healthy "+
+			"location: RunLocalRescan calls it on every tick, and "+
+			"refreshing LastObserved on a steady-state flow would read "+
+			"to the source gateway as a genuine rotation, forcing a "+
+			"spurious reader reopen once per rescan interval")
 }
 
 // fakeLease records Renew/Release calls and lets a test return a

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -140,8 +140,16 @@ type sourceEntry struct {
 	// entry's LastObserved timestamp for r.NodeName at the moment
 	// the FlowReader was opened. A subsequent reconcile that sees
 	// a newer timestamp tears the reader down and reopens it so
-	// the gateway tails the freshly rebound writer.
+	// the gateway tails the freshly rebound writer. May be nil (the
+	// location carried no LastObserved at open time); see
+	// originRotated for how that case is handled.
 	lastObservedOriginAt atomic.Pointer[time.Time]
+
+	// openedAt is the wall-clock time this entry's FlowReader was
+	// opened. Read-only after construction, set before the entry is
+	// published into r.sources under r.mu -- safe to read from
+	// Reconcile without its own synchronization, same as infoStr.
+	openedAt time.Time
 
 	// cancel stops the per-flow transfer goroutine; done is closed
 	// when the goroutine returns.
@@ -232,7 +240,7 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// re-registered the flow, typically after a pod restart).
 		// Tear down + reopen so the reader tails the fresh writer
 		// instead of holding a handle on a now-invalid ring.
-		if originRotated(existing.lastObservedOriginAt.Load(), originAt) {
+		if originRotated(existing.lastObservedOriginAt.Load(), originAt, existing.openedAt) {
 			l.Info("flow origin rotated, reopening reader")
 			r.closeEntry(req.NamespacedName)
 		} else if existing.infoStr == mirror.Status.TargetInfo {
@@ -288,6 +296,7 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 		return ctrl.Result{}, fmt.Errorf("open initiator: %w", err)
 	}
+	entry.openedAt = time.Now()
 	if originAt != nil {
 		t := *originAt
 		entry.lastObservedOriginAt.Store(&t)
@@ -377,15 +386,49 @@ func (r *SourceReconciler) observedOriginAt(ctx context.Context, flowID string) 
 }
 
 // originRotated reports whether the freshly observed origin
-// timestamp is strictly after the one recorded on the entry. A nil
-// observation means "no data yet" and never counts as a rotation;
-// a nil baseline (entry never saw an origin timestamp) means the
-// first observation is not a rotation either.
-func originRotated(baseline, observed *time.Time) bool {
-	if observed == nil || baseline == nil {
+// timestamp indicates the flow's writer has rotated since this
+// reader was opened. A nil observation means "no data yet" and never
+// counts as a rotation.
+//
+// A non-nil baseline is the common case: the reader was opened while
+// the location already carried a LastObserved value, and any newer
+// observation is a rotation.
+//
+// A nil baseline means the reader opened while the location carried
+// no LastObserved yet -- Stale, or an appearance whose status write
+// had not landed (a status-update conflict, or a fanotify event that
+// raced the watcher's startup). Treating that case as "never rotated"
+// is wrong: lastObservedOriginAt is set once at open and never
+// reassigned except by a rotation-triggered reopen, so a permanently
+// false comparison leaves the reader unable to detect any future
+// rotation for its entire lifetime -- exactly the failure mode that
+// stranded a flow's mirror on a dead ring for two hours during a
+// production incident. Falling back to openedAt instead means any
+// origin observation landing after the reader opened counts as a
+// rotation, which can trigger one avoidable reopen (the writer that
+// created the pre-open observation might still be the live one) but
+// never silently strands the reader.
+func originRotated(baseline, observed *time.Time, openedAt time.Time) bool {
+	if observed == nil {
 		return false
 	}
-	return observed.After(*baseline)
+	if baseline != nil {
+		return observed.After(*baseline)
+	}
+	// observed is sourced from MxlFlow.status.locations[].lastObserved,
+	// a metav1.Time -- the Kubernetes API always truncates timestamps
+	// to second precision on the round trip through the apiserver,
+	// while openedAt is a full-precision local time.Time. Comparing
+	// them directly is unsafe: openedAt almost always carries a
+	// nonzero sub-second component, so a genuinely later observation
+	// that floors to the same second still compares Before it,
+	// spuriously reporting "not rotated". Truncate openedAt to the
+	// same second-floor grain before comparing so both sides use
+	// consistent precision; the cost is, at most, one extra reopen
+	// for an observation that turns out to predate the current
+	// reader by under a second, which is cheap next to silently
+	// stranding the reader for its entire lifetime.
+	return !observed.Before(openedAt.Truncate(time.Second))
 }
 
 // libmxlOpener is the production initiatorOpener implementation. It

--- a/gateway/internal/mirror/source_rotation_test.go
+++ b/gateway/internal/mirror/source_rotation_test.go
@@ -1,0 +1,91 @@
+package mirror
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+func TestReconcile_FlowOriginRotation_DetectedAfterStaleOpen(t *testing.T) {
+	// A FlowReader can legally open while the MxlFlow carries no live
+	// Origin location for this node: PublishVanished leaves the entry
+	// Stale with LastObserved nil, and a dropped PublishAppeared (the
+	// dispatcher fires once per fanotify event and only logs errors)
+	// never repairs it. The on-disk flow directory exists either way.
+	//
+	// lastObservedOriginAt is stored only at open, so an open in that
+	// window records a nil baseline -- and originRotated treats a nil
+	// baseline as "never a rotation". A later writer restart then goes
+	// undetected for the entry's whole lifetime: the reader tails the
+	// dead ring until the mirror itself is deleted and recreated.
+	scheme := newSourceTestScheme(t)
+	flowID := "flow-1"
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", flowID, "info-1")
+	flow := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: flowID},
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: flowID},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{{
+				NodeName: "node-a",
+				Phase:    mxlv1alpha1.MxlFlowLocationStale,
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}, &mxlv1alpha1.MxlFlow{}).
+		WithObjects(mirror, flow).
+		Build()
+
+	opener := &fakeOpener{
+		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+			return &sourceEntry{infoStr: "info-1"}, nil
+		},
+	}
+	r := &SourceReconciler{
+		Client:        c,
+		Scheme:        scheme,
+		NodeName:      "node-a",
+		opener:        opener,
+		FlushInterval: time.Hour,
+		sources:       map[types.NamespacedName]*sourceEntry{},
+		attempts:      map[types.NamespacedName]uint32{},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	req := reconcile.Request{NamespacedName: key}
+
+	// Reader opens while the node's location is Stale/nil: the entry
+	// records no origin observation.
+	_, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), opener.calls.Load())
+	t.Cleanup(func() { r.closeEntry(key) })
+
+	// Writer restarts: the agent publishes Origin with a fresh
+	// LastObserved that postdates the reader.
+	var f mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: flowID}, &f))
+	now := metav1.Now()
+	f.Status.Locations[0].Phase = mxlv1alpha1.MxlFlowLocationOrigin
+	f.Status.Locations[0].LastObserved = &now
+	require.NoError(t, c.Status().Update(context.Background(), &f))
+
+	_, err = r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), opener.calls.Load(),
+		"an Origin observation newer than the running reader must reopen "+
+			"it even when the reader was opened during a Stale/nil window: "+
+			"a nil baseline that never re-arms leaves the reader on a dead "+
+			"ring until the mirror is deleted")
+}


### PR DESCRIPTION
## TL;DR

Video/audio streams could go permanently black after a producer pod restarted (or after a brief Kubernetes hiccup), and would only come back if someone manually deleted and recreated the mirror. Two separate bugs caused this, and this PR fixes both:

1. The receiving side sometimes could never notice a producer had restarted, so it kept reading from a dead connection forever.
2. The sending side's "the producer just restarted" report could silently get lost and never retried, which is what let bug #1's window stay open indefinitely.

Root-caused from a real onprem incident where a stream stayed black for about two hours.

## Background

Streaming a flow across nodes involves two gateway pods: one opens a reader on the producer's node, one opens a writer on the consumer's node. When a producer pod restarts, its replacement is a brand-new process -- the reader on the old connection is now pointed at a dead end and has to reopen. The signal for "reopen, the producer restarted" is a timestamp the producer's node agent writes onto a shared Kubernetes object every time it sees the producer appear.

## Bug 1: the reader can permanently miss the "reopen" signal

The reader remembers the timestamp it saw at the moment it opened, and only reopens when a newer timestamp shows up later. But there's a brief window right after a producer restart where no timestamp exists yet. If the reader happens to open during exactly that window, it remembers "nothing" instead of a real timestamp -- and "nothing" was being treated as "I can never tell if a restart happened," permanently, for as long as that reader stays open. A real restart's timestamp would show up moments later and just get ignored.

Fix: when there's no earlier timestamp to compare against, compare against the moment the reader itself opened instead. Any producer signal from after that point now correctly counts as "reopen."

(Along the way, testing this in a real cluster surfaced a subtler issue: Kubernetes always rounds these timestamps down to the nearest second, while the reader's own "moment I opened" clock reading is precise to the nanosecond. Comparing the two naively could make a signal that arrived a fraction of a second late look like it arrived before the reader opened. Fixed by rounding both sides down to the same second before comparing.)

## Bug 2: the "producer restarted" report can silently vanish

Multiple node agents write to the same shared object, so it's normal and frequent for one agent's write to briefly collide with another's and get rejected as a conflict -- Kubernetes expects callers to just retry. This code was not retrying: a single collision meant the report was dropped for good, with only a log line nobody was watching.

Fix: retry automatically on a collision. Also added a periodic self-check (every rescan cycle) that looks for any locally-running flow whose reported state looks stuck or missing, and re-reports it -- so even if a report gets lost some other way, it heals itself within one cycle instead of staying broken until a person notices.

fix(agent): retry status conflicts and repair stranded flow locations