### PR TITLE
fix(examples,shim): mount /run/mxl directory for intent socket access

### DIFF
--- a/examples/rdma-demo/21-reader.yaml
+++ b/examples/rdma-demo/21-reader.yaml
@@ -39,21 +39,23 @@ spec:
         capabilities:
           add: ["IPC_LOCK", "SYS_RESOURCE"]
       volumeMounts:
-        - name: mxl-domain
-          mountPath: /run/mxl/domain
+        # Mount /run/mxl as a whole rather than the domain subdir and
+        # agent.sock separately. A single-file hostPath mount pins the
+        # socket's inode at container start; when the agent DaemonSet
+        # restarts it unlinks and recreates agent.sock, and an
+        # already-running consumer pod would keep talking to the
+        # orphaned inode forever. Mounting the directory re-resolves
+        # the path on every connect, so it always reaches the agent
+        # that's actually listening.
+        - name: mxl-run
+          mountPath: /run/mxl
         - name: intent-shim
           mountPath: /opt/mxl-intent
           readOnly: true
-        - name: agent-sock
-          mountPath: /run/mxl/agent.sock
   volumes:
-    - name: mxl-domain
+    - name: mxl-run
       hostPath:
-        path: /run/mxl/domain
+        path: /run/mxl
         type: DirectoryOrCreate
     - name: intent-shim
       emptyDir: {}
-    - name: agent-sock
-      hostPath:
-        path: /run/mxl/agent.sock
-        type: Socket

--- a/shim/README.md
+++ b/shim/README.md
@@ -26,7 +26,15 @@ In a consumer pod:
 3. Set `LD_PRELOAD=/path/to/libmxl-intent.so`.
 4. Mount the agent's UDS (`/run/mxl/agent.sock`) into the main
    container so the shim can reach it. `MXL_INTENT_SOCK` overrides
-   the default path.
+   the default path. Mount the containing directory (`/run/mxl`),
+   not the socket file by itself: a single-file hostPath mount
+   pins the socket's inode at container start, and the agent
+   unlinks and recreates `agent.sock` on every restart. A consumer
+   pod already running when that happens keeps the old, orphaned
+   inode and never reaches the agent again until the pod itself
+   restarts. Mounting the directory re-resolves the path on every
+   connect, so it always reaches whichever agent is currently
+   listening.
 
 See `examples/tcp-demo/21-reader.yaml` for a working example.
 


### PR DESCRIPTION
Root-caused live on our cluster: a consumer pod's on-demand
`MxlFlowMirror` was never created even though the flow's Origin
location was healthy and fresh. The pod's `agent.sock` bind mount
had gone stale after an agent DaemonSet restart, so every
`libmxl-intent.so` request from that pod silently failed against an
orphaned socket inode and fell back to `ENOENT`.

`examples/rdma-demo/21-reader.yaml` mounted `/run/mxl/agent.sock`
directly as a hostPath `Socket`, separately from the `/run/mxl/domain`
mount. That pins the socket's inode at container start. The agent
(`agent/internal/intentsock/server.go`) unlinks and recreates
`agent.sock` on every restart, so any consumer pod already running
at that point keeps talking to the old, orphaned inode and never
reaches the agent again until the pod itself restarts.

`examples/tcp-demo/21-reader.yaml` already avoids this by mounting
the whole `/run/mxl` directory instead, which re-resolves the path
on every connect. This aligns rdma-demo's reader with that pattern
and adds the same explanation to `shim/README.md`'s mount
instructions so future consumer pod specs don't reintroduce it.

## Test plan

- `kubectl apply --dry-run=client -f examples/rdma-demo/21-reader.yaml` succeeds.
- Confirmed on our onprer cluster that a consumer pod using the
  directory-mount pattern (tcp-demo's) is unaffected by agent
  restarts, while the single-file-mount pattern (this file's, prior
  to the fix) reproduces the stale-inode failure exactly as described.