### PR TITLE
fix(gateway): reap mirror finalizers orphaned by node removal

### DIFF
--- a/agent/internal/intent/dispatcher.go
+++ b/agent/internal/intent/dispatcher.go
@@ -118,13 +118,17 @@ func (d *Dispatcher) Materialize(ctx context.Context, pid int32, path string) er
 	)
 	l.Info("intent request received")
 
-	sourceNode, ok, err := d.resolveSourceNode(wctx, flowID)
+	res, err := d.resolveSourceNode(wctx, flowID)
 	if err != nil {
 		return fmt.Errorf("resolve source node: %w", err)
 	}
-	if !ok {
+	if !res.Found {
+		if res.AllStale {
+			return errors.New("all Origin locations have an expired Lease")
+		}
 		return errors.New("MxlFlow not yet known cluster-wide")
 	}
+	sourceNode := res.Node
 	if sourceNode == d.NodeName {
 		// The flow's origin is this node; the producer should have
 		// created the file already. Either we raced with the agent's
@@ -184,50 +188,54 @@ func (d *Dispatcher) flowExistsLocally(flowID string) bool {
 	return err == nil
 }
 
-func (d *Dispatcher) resolveSourceNode(ctx context.Context, flowID string) (string, bool, error) {
+// originResolution separates the two ways resolving an origin can
+// come up empty, so the reason handed back to the shim says which
+// one happened. Mirrors originResolution in the operator's
+// receiver package, minus the Deadline the reconciler needs for its
+// RequeueAfter and a request-driven dispatcher does not.
+type originResolution struct {
+	Node     string
+	Found    bool
+	AllStale bool
+}
+
+func (d *Dispatcher) resolveSourceNode(ctx context.Context, flowID string) (originResolution, error) {
 	var flow mxlv1alpha1.MxlFlow
 	if err := d.Client.Get(ctx, types.NamespacedName{Name: flowID}, &flow); err != nil {
 		if apierrors.IsNotFound(err) {
-			return "", false, nil
+			return originResolution{}, nil
 		}
-		return "", false, err
+		return originResolution{}, err
 	}
+	sawOrigin := false
 	for _, loc := range flow.Status.Locations {
 		if loc.Phase != mxlv1alpha1.MxlFlowLocationOrigin {
 			continue
 		}
+		sawOrigin = true
 		if d.Lease == nil {
-			return loc.NodeName, true, nil
+			return originResolution{Node: loc.NodeName, Found: true}, nil
 		}
 		fresh, err := d.Lease.IsFresh(ctx, flowID, loc.NodeName)
 		if err != nil {
-			return "", false, err
+			return originResolution{}, err
 		}
 		if fresh {
-			return loc.NodeName, true, nil
+			return originResolution{Node: loc.NodeName, Found: true}, nil
 		}
 	}
-	return "", false, nil
+	return originResolution{AllStale: sawOrigin}, nil
 }
 
-// repointMirror patches spec.sourceNode, and the provider that
-// follows from it, when the flow's origin has moved since the mirror
-// was created.
-//
-// Mirror names do not encode the source node, so a mirror created
-// while the origin sat on one node keeps addressing that node for
-// its entire life unless something rewrites the field. The node can
-// be drained, cordoned, or deleted outright and the mirror stays
-// pointed at it, permanently Degraded, while the consumer's every
-// retry finds the same stale object.
-//
-// Only intent-authored mirrors are touched. The receiver reconciler
-// owns drift on the mirrors it authored (patchMirrorIfDrifted) and
-// two writers on one field would fight over it.
-//
-// The merge-patch lists only the two spec keys, so the agent-owned
-// Requestor field and the labels that decide the GC contract stay
-// where they are.
+// repointMirror patches spec.sourceNode, and the provider derived
+// from it, when the flow's origin has moved since the mirror was
+// created. Mirror names do not encode the source node, so without
+// this the mirror addresses its create-time node for life and stays
+// Degraded once that node goes away. Only intent-authored mirrors
+// are touched: patchMirrorIfDrifted owns the same drift for
+// receiver-authored ones, and two writers would fight. The
+// merge-patch lists only the two spec keys, leaving the agent-owned
+// Requestor and the GC labels alone.
 func (d *Dispatcher) repointMirror(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror, flowID, sourceNode string) error {
 	if _, intent := mirror.Labels[mxlv1alpha1.LabelCreatedByIntent]; !intent {
 		return nil
@@ -269,12 +277,9 @@ func (d *Dispatcher) ensureMirror(ctx context.Context, flowID, sourceNode string
 	var existing mxlv1alpha1.MxlFlowMirror
 	err := d.Client.Get(ctx, types.NamespacedName{Namespace: pod.GetNamespace(), Name: name}, &existing)
 	if err == nil {
-		// Mirror names are a pure function of (flowID, targetNode),
-		// so a mirror still working through its finalizers occupies
-		// the only name this consumer can ever use. Handing it back
-		// would block the caller on an object that cannot become
-		// Ready. Fail instead; the shim retries and the name frees
-		// up once deletion completes.
+		// A mirror working through its finalizers occupies the only
+		// name this consumer can use and can never reach Ready. Fail
+		// so the shim retries once the name frees up.
 		if !existing.DeletionTimestamp.IsZero() {
 			return nil, fmt.Errorf("mirror %s/%s is terminating",
 				existing.Namespace, existing.Name)
@@ -416,23 +421,11 @@ func (d *Dispatcher) waitReady(ctx context.Context, mirror *mxlv1alpha1.MxlFlowM
 	}
 }
 
-// MirrorName mirrors the operator's helper (operator/internal/
-// receiver.mirrorName). Keeping the algorithm identical here
-// guarantees the agent's on-demand path and the operator's
-// declarative path converge on the same MxlFlowMirror name for a
-// given (flow, target node), so the gateway sees exactly one
-// mirror per pair.
+// MirrorName re-exports the shared api/v1alpha1 helper. The agent's
+// on-demand path and the operator's declarative path must land on
+// the same name for a given (flow, target node) so the gateway sees
+// one mirror per pair; the shared definition makes that agreement
+// structural rather than a matter of two copies staying in step.
 func MirrorName(flowID, targetNode string) string {
-	joined := strings.ToLower(flowID + "--" + targetNode)
-	var b strings.Builder
-	b.Grow(len(joined))
-	for _, c := range joined {
-		switch {
-		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '-':
-			b.WriteRune(c)
-		default:
-			b.WriteRune('-')
-		}
-	}
-	return b.String()
+	return mxlv1alpha1.MirrorName(flowID, targetNode)
 }

--- a/agent/internal/intent/dispatcher.go
+++ b/agent/internal/intent/dispatcher.go
@@ -13,6 +13,7 @@ package intent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -209,12 +210,78 @@ func (d *Dispatcher) resolveSourceNode(ctx context.Context, flowID string) (stri
 	return "", false, nil
 }
 
+// repointMirror patches spec.sourceNode, and the provider that
+// follows from it, when the flow's origin has moved since the mirror
+// was created.
+//
+// Mirror names do not encode the source node, so a mirror created
+// while the origin sat on one node keeps addressing that node for
+// its entire life unless something rewrites the field. The node can
+// be drained, cordoned, or deleted outright and the mirror stays
+// pointed at it, permanently Degraded, while the consumer's every
+// retry finds the same stale object.
+//
+// Only intent-authored mirrors are touched. The receiver reconciler
+// owns drift on the mirrors it authored (patchMirrorIfDrifted) and
+// two writers on one field would fight over it.
+//
+// The merge-patch lists only the two spec keys, so the agent-owned
+// Requestor field and the labels that decide the GC contract stay
+// where they are.
+func (d *Dispatcher) repointMirror(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror, flowID, sourceNode string) error {
+	if _, intent := mirror.Labels[mxlv1alpha1.LabelCreatedByIntent]; !intent {
+		return nil
+	}
+	if mirror.Spec.SourceNode == sourceNode {
+		return nil
+	}
+
+	provider, err := d.resolveProvider(ctx, flowID, sourceNode)
+	if err != nil {
+		return fmt.Errorf("resolve provider for repointed source %s: %w", sourceNode, err)
+	}
+
+	patch, err := json.Marshal(map[string]any{
+		"spec": map[string]any{
+			"sourceNode": sourceNode,
+			"provider":   string(provider),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("marshal repoint patch: %w", err)
+	}
+	if err := d.Client.Patch(ctx, mirror, client.RawPatch(types.MergePatchType, patch)); err != nil {
+		return fmt.Errorf("repoint mirror %s/%s to source %s: %w",
+			mirror.Namespace, mirror.Name, sourceNode, err)
+	}
+
+	log.FromContext(ctx).WithName("intent").Info("repointed mirror to new origin",
+		"flowID", flowID,
+		"mirror", mirror.Namespace+"/"+mirror.Name,
+		"sourceNode", sourceNode,
+		"provider", provider)
+	return nil
+}
+
 func (d *Dispatcher) ensureMirror(ctx context.Context, flowID, sourceNode string, pod metav1.Object) (*mxlv1alpha1.MxlFlowMirror, error) {
 	name := MirrorName(flowID, d.NodeName)
 
 	var existing mxlv1alpha1.MxlFlowMirror
 	err := d.Client.Get(ctx, types.NamespacedName{Namespace: pod.GetNamespace(), Name: name}, &existing)
 	if err == nil {
+		// Mirror names are a pure function of (flowID, targetNode),
+		// so a mirror still working through its finalizers occupies
+		// the only name this consumer can ever use. Handing it back
+		// would block the caller on an object that cannot become
+		// Ready. Fail instead; the shim retries and the name frees
+		// up once deletion completes.
+		if !existing.DeletionTimestamp.IsZero() {
+			return nil, fmt.Errorf("mirror %s/%s is terminating",
+				existing.Namespace, existing.Name)
+		}
+		if err := d.repointMirror(ctx, &existing, flowID, sourceNode); err != nil {
+			return nil, err
+		}
 		// A mirror with the same (flow, target node) name already
 		// exists. The pre-existing object is functionally
 		// sufficient for this consumer pod; reuse it as-is. The

--- a/agent/internal/intent/dispatcher_repoint_test.go
+++ b/agent/internal/intent/dispatcher_repoint_test.go
@@ -1,0 +1,171 @@
+package intent
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// TestEnsureMirror_RepointsIntentMirrorAfterOriginMove covers a flow
+// whose origin moved to another node after the mirror was created.
+// Mirror names are a function of (flowID, targetNode) only, so the
+// same consumer keeps resolving to the same object; leaving
+// spec.sourceNode at its create-time value pins the mirror to a node
+// that may have been drained or deleted, and it stays Degraded there
+// forever.
+func TestEnsureMirror_RepointsIntentMirrorAfterOriginMove(t *testing.T) {
+	scheme := newScheme(t)
+	existing := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      MirrorName(flowID, "n-target"),
+			Labels: map[string]string{
+				mxlv1alpha1.LabelCreatedByIntent: "n-target",
+				mxlv1alpha1.LabelRequestorPodUID: "uid-1",
+			},
+		},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     flowID,
+			SourceNode: "n-old",
+			TargetNode: "n-target",
+			Provider:   mxlv1alpha1.ProviderTCP,
+			Requestor: &mxlv1alpha1.PodRef{
+				Name: "consumer", Namespace: "ns", UID: "uid-1",
+			},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(existing).
+		Build()
+
+	d := &Dispatcher{
+		Client:     c,
+		DomainPath: "/run/mxl/domain",
+		NodeName:   "n-target",
+		Provider:   mxlv1alpha1.ProviderTCP,
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "consumer", UID: "uid-1"},
+	}
+
+	got, err := d.ensureMirror(context.Background(), flowID, "n-new", pod)
+	require.NoError(t, err)
+	assert.Equal(t, existing.Name, got.Name)
+
+	var live mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: "ns", Name: existing.Name}, &live))
+	assert.Equal(t, "n-new", live.Spec.SourceNode,
+		"an intent mirror must follow the flow's origin; pinning it to the "+
+			"create-time node leaves it Degraded once that node goes away")
+	require.NotNil(t, live.Spec.Requestor)
+	assert.Equal(t, "uid-1", live.Spec.Requestor.UID,
+		"the repoint patch must not disturb the agent-owned Requestor")
+	assert.Equal(t, "n-target", live.Labels[mxlv1alpha1.LabelCreatedByIntent],
+		"the repoint patch must not disturb the labels that decide GC ownership")
+}
+
+// TestEnsureMirror_ReceiverMirrorNotRepointed keeps the two ownership
+// domains apart. The receiver reconciler patches drift on the mirrors
+// it authored; a second writer on the same field would fight it.
+func TestEnsureMirror_ReceiverMirrorNotRepointed(t *testing.T) {
+	scheme := newScheme(t)
+	existing := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      MirrorName(flowID, "n-target"),
+			Labels: map[string]string{
+				mxlv1alpha1.LabelCreatedByReceiver: "rcv-1",
+			},
+		},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     flowID,
+			SourceNode: "n-old",
+			TargetNode: "n-target",
+			Provider:   mxlv1alpha1.ProviderTCP,
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(existing).
+		Build()
+
+	d := &Dispatcher{
+		Client:     c,
+		DomainPath: "/run/mxl/domain",
+		NodeName:   "n-target",
+		Provider:   mxlv1alpha1.ProviderTCP,
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "consumer", UID: "uid-2"},
+	}
+
+	_, err := d.ensureMirror(context.Background(), flowID, "n-new", pod)
+	require.NoError(t, err)
+
+	var live mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Namespace: "ns", Name: existing.Name}, &live))
+	assert.Equal(t, "n-old", live.Spec.SourceNode,
+		"receiver-authored mirrors are the receiver reconciler's to repoint")
+}
+
+// TestEnsureMirror_TerminatingMirrorNotReused stops the dispatcher
+// handing a consumer an object that is on its way out. Because the
+// name is derived from (flowID, targetNode), a mirror stuck on a
+// finalizer occupies the only name this consumer can use; returning
+// it would park the caller on a mirror that can never go Ready.
+func TestEnsureMirror_TerminatingMirrorNotReused(t *testing.T) {
+	scheme := newScheme(t)
+	now := metav1.Now()
+	existing := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "ns",
+			Name:              MirrorName(flowID, "n-target"),
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"gateway.mxl.qvest-digital.com/source-side"},
+			Labels: map[string]string{
+				mxlv1alpha1.LabelCreatedByIntent: "n-target",
+			},
+		},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     flowID,
+			SourceNode: "n-src",
+			TargetNode: "n-target",
+			Provider:   mxlv1alpha1.ProviderTCP,
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(existing).
+		Build()
+
+	d := &Dispatcher{
+		Client:     c,
+		DomainPath: "/run/mxl/domain",
+		NodeName:   "n-target",
+		Provider:   mxlv1alpha1.ProviderTCP,
+	}
+	pod := &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "consumer", UID: "uid-3"},
+	}
+
+	got, err := d.ensureMirror(context.Background(), flowID, "n-src", pod)
+	require.Error(t, err,
+		"a terminating mirror is not a usable mirror; the shim has to retry "+
+			"rather than block on an object that cannot become Ready")
+	assert.Nil(t, got)
+	assert.Contains(t, err.Error(), "terminating")
+}

--- a/agent/internal/intent/dispatcher_repoint_test.go
+++ b/agent/internal/intent/dispatcher_repoint_test.go
@@ -14,13 +14,10 @@ import (
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 )
 
-// TestEnsureMirror_RepointsIntentMirrorAfterOriginMove covers a flow
-// whose origin moved to another node after the mirror was created.
-// Mirror names are a function of (flowID, targetNode) only, so the
-// same consumer keeps resolving to the same object; leaving
+// Mirror names encode only (flowID, targetNode), so a consumer keeps
+// resolving to the same object while the origin moves. Leaving
 // spec.sourceNode at its create-time value pins the mirror to a node
-// that may have been drained or deleted, and it stays Degraded there
-// forever.
+// that may since have been drained or deleted.
 func TestEnsureMirror_RepointsIntentMirrorAfterOriginMove(t *testing.T) {
 	scheme := newScheme(t)
 	existing := &mxlv1alpha1.MxlFlowMirror{
@@ -75,9 +72,8 @@ func TestEnsureMirror_RepointsIntentMirrorAfterOriginMove(t *testing.T) {
 		"the repoint patch must not disturb the labels that decide GC ownership")
 }
 
-// TestEnsureMirror_ReceiverMirrorNotRepointed keeps the two ownership
-// domains apart. The receiver reconciler patches drift on the mirrors
-// it authored; a second writer on the same field would fight it.
+// Keeps the two ownership domains apart: patchMirrorIfDrifted owns
+// drift on receiver-authored mirrors.
 func TestEnsureMirror_ReceiverMirrorNotRepointed(t *testing.T) {
 	scheme := newScheme(t)
 	existing := &mxlv1alpha1.MxlFlowMirror{
@@ -121,11 +117,9 @@ func TestEnsureMirror_ReceiverMirrorNotRepointed(t *testing.T) {
 		"receiver-authored mirrors are the receiver reconciler's to repoint")
 }
 
-// TestEnsureMirror_TerminatingMirrorNotReused stops the dispatcher
-// handing a consumer an object that is on its way out. Because the
-// name is derived from (flowID, targetNode), a mirror stuck on a
-// finalizer occupies the only name this consumer can use; returning
-// it would park the caller on a mirror that can never go Ready.
+// A mirror stuck on a finalizer occupies the only name this consumer
+// can use; returning it parks the caller on an object that can never
+// go Ready.
 func TestEnsureMirror_TerminatingMirrorNotReused(t *testing.T) {
 	scheme := newScheme(t)
 	now := metav1.Now()

--- a/agent/internal/intent/dispatcher_test.go
+++ b/agent/internal/intent/dispatcher_test.go
@@ -194,9 +194,12 @@ func TestMaterialize_MissingFlow_Errors(t *testing.T) {
 	// shortcut: when FlowChecker says true on second call, the
 	// dispatcher early-returns. Instead test the
 	// resolveSourceNode-missing-flow case by exercising it directly.
-	_, ok, err := d.resolveSourceNode(context.Background(), "missing-flow")
+	res, err := d.resolveSourceNode(context.Background(), "missing-flow")
 	require.NoError(t, err)
-	assert.False(t, ok)
+	assert.False(t, res.Found)
+	assert.False(t, res.AllStale,
+		"a flow with no MxlFlow at all is not the same as one whose "+
+			"Origins are all stale; the shim is told which")
 }
 
 func TestMaterialize_SourceIsLocalNode_NoOps(t *testing.T) {
@@ -227,14 +230,10 @@ func TestMaterialize_SourceIsLocalNode_NoOps(t *testing.T) {
 		NodeName:    "n1",
 		FlowChecker: func(string) bool { return false },
 	}
-	_, ok, err := d.resolveSourceNode(context.Background(), flowID)
+	res, err := d.resolveSourceNode(context.Background(), flowID)
 	require.NoError(t, err)
-	require.True(t, ok)
-
-	// Manually drive the same logic Materialize uses for the
-	// same-node branch by inspecting resolveSourceNode plus a check.
-	src, _, _ := d.resolveSourceNode(context.Background(), flowID)
-	assert.Equal(t, "n1", src)
+	require.True(t, res.Found)
+	assert.Equal(t, "n1", res.Node)
 
 	// No mirror has been created at this point.
 	var list mxlv1alpha1.MxlFlowMirrorList
@@ -598,13 +597,13 @@ func TestResolveSourceNode_SkipsStaleOriginByLease(t *testing.T) {
 		}},
 	}
 
-	node, ok, err := d.resolveSourceNode(ctx, flowID)
+	res, err := d.resolveSourceNode(ctx, flowID)
 	require.NoError(t, err)
-	assert.True(t, ok,
+	assert.True(t, res.Found,
 		"a second Origin with a fresh Lease must be the dispatcher's "+
 			"answer even when an earlier Origin entry is present but stale; "+
 			"otherwise a partitioned producer permanently masks a recovered one")
-	assert.Equal(t, "n-fresh", node)
+	assert.Equal(t, "n-fresh", res.Node)
 }
 
 func TestResolveSourceNode_AllStaleOriginsReturnsNotOK(t *testing.T) {
@@ -631,12 +630,15 @@ func TestResolveSourceNode_AllStaleOriginsReturnsNotOK(t *testing.T) {
 		Lease:    &fakeLeaseChecker{fresh: map[string]bool{}},
 	}
 
-	_, ok, err := d.resolveSourceNode(ctx, flowID)
+	res, err := d.resolveSourceNode(ctx, flowID)
 	require.NoError(t, err)
-	assert.False(t, ok,
+	assert.False(t, res.Found,
 		"when every Origin's Lease is expired the dispatcher must report "+
 			"no source; routing a Materialize call at a stale Origin would "+
 			"only hand the shim back a 'no grains' wait until the timeout")
+	assert.True(t, res.AllStale,
+		"every Origin candidate was rejected by the Lease check, which is "+
+			"a different answer from the flow being unknown")
 }
 
 // TestEnsureMirror_ExplicitProviderBypassesResolution asserts that a

--- a/agent/internal/originlease/lease.go
+++ b/agent/internal/originlease/lease.go
@@ -29,10 +29,11 @@ import (
 const LeaseNamespace = apiv1alpha1.LeaseNamespace
 
 const (
-	// DefaultLeaseDuration is the renewal window stamped on every
-	// Lease the manager writes. A consumer treats RenewTime +
-	// LeaseDurationSeconds as the freshness deadline.
-	DefaultLeaseDuration = 30 * time.Second
+	// DefaultLeaseDuration re-exports the shared api/v1alpha1
+	// constant. It is the window stamped on every Lease the manager
+	// writes; a consumer treats RenewTime + LeaseDurationSeconds as
+	// the freshness deadline, so writer and checker have to agree.
+	DefaultLeaseDuration = apiv1alpha1.DefaultLeaseDuration
 
 	// DefaultRenewInterval is the cadence RunRenewLoop uses when the
 	// caller does not pass one. Set to a third of the default

--- a/api/v1alpha1/lease.go
+++ b/api/v1alpha1/lease.go
@@ -1,6 +1,16 @@
 package v1alpha1
 
-import "strings"
+import (
+	"strings"
+	"time"
+)
+
+// DefaultLeaseDuration is the validity window stamped on an Origin
+// Lease that carries no explicit spec.leaseDurationSeconds. The
+// renewer and both freshness checkers read it from here: a renewer
+// writing on one window while a checker expires on another would
+// make the two sides disagree about where a flow's Origin is.
+const DefaultLeaseDuration = 30 * time.Second
 
 // LeaseNamespace is the namespace every per-flow Origin Lease lives
 // in. Pinned so the agent's Role can be scoped to a single namespace

--- a/api/v1alpha1/mirror.go
+++ b/api/v1alpha1/mirror.go
@@ -1,0 +1,29 @@
+package v1alpha1
+
+import "strings"
+
+// MirrorName produces the MxlFlowMirror object name for a (flowID,
+// targetNode) pair, lowercased with every rune outside [a-z0-9-]
+// replaced by "-" so the result is a DNS subdomain. FlowIDs are
+// UUIDs and node names are DNS-compliant, so the substitution is a
+// guard rather than a routine rewrite.
+//
+// The name is the key on which the two ownership domains meet: the
+// agent's intent dispatcher and the operator's receiver reconciler
+// both derive it from the same inputs, so a mirror one of them
+// created is the mirror the other finds. Computing it here keeps
+// that agreement from depending on two copies staying in step.
+func MirrorName(flowID, targetNode string) string {
+	joined := strings.ToLower(flowID + "--" + targetNode)
+	var b strings.Builder
+	b.Grow(len(joined))
+	for _, c := range joined {
+		switch {
+		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '-':
+			b.WriteRune(c)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}

--- a/api/v1alpha1/mirror_test.go
+++ b/api/v1alpha1/mirror_test.go
@@ -1,0 +1,59 @@
+package v1alpha1
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMirrorName_Format(t *testing.T) {
+	// Pin the wire format. The agent's intent dispatcher and the
+	// operator's receiver reconciler both address mirrors by this
+	// name; a change here would stop them meeting on one object and
+	// let both create their own for the same (flow, target node).
+	assert.Equal(t,
+		"11111111-2222-3333-4444-555555555555--node-a",
+		MirrorName("11111111-2222-3333-4444-555555555555", "node-a"),
+	)
+}
+
+func TestMirrorName_SanitisesToDNSSubdomain(t *testing.T) {
+	cases := []struct {
+		name       string
+		flowID     string
+		targetNode string
+		want       string
+	}{
+		{
+			name:       "uppercase is lowered",
+			flowID:     "ABC",
+			targetNode: "Node-B",
+			want:       "abc--node-b",
+		},
+		{
+			name:       "dots and underscores become dashes",
+			flowID:     "a.b_c",
+			targetNode: "ip-10.0.0.1",
+			want:       "a-b-c--ip-10-0-0-1",
+		},
+		{
+			name:       "empty target still yields the separator",
+			flowID:     "abc",
+			targetNode: "",
+			want:       "abc--",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, MirrorName(tc.flowID, tc.targetNode))
+		})
+	}
+}
+
+func TestDefaultLeaseDuration_MatchesRenewerAndCheckerExpectation(t *testing.T) {
+	// The renewer stamps this on every Lease and both freshness
+	// checkers fall back to it. Writer and checker disagreeing on
+	// the window would make the two sides disagree about where a
+	// flow's Origin is.
+	assert.Equal(t, "30s", DefaultLeaseDuration.String())
+}

--- a/charts/mxl-k8s/templates/rbac-gateway.yaml
+++ b/charts/mxl-k8s/templates/rbac-gateway.yaml
@@ -21,6 +21,11 @@ rules:
   - apiGroups: [coordination.k8s.io]
     resources: [leases]
     verbs: [get, list, watch]
+  # Reaping a finalizer left behind by a gateway whose node was
+  # removed requires confirming the node is actually gone.
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding

--- a/charts/mxl-k8s/tests/unit/rbac_test.yaml
+++ b/charts/mxl-k8s/tests/unit/rbac_test.yaml
@@ -42,3 +42,14 @@ tests:
             apiGroups: [""]
             resources: [pods]
             verbs: [get, list, watch]
+
+  - it: gateway role can get nodes so it can tell a reclaimed node from a live one
+    template: templates/rbac-gateway.yaml
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get]

--- a/gateway/internal/mirror/orphan.go
+++ b/gateway/internal/mirror/orphan.go
@@ -10,29 +10,15 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// orphanRecheckInterval is how often a reconciler re-examines a
-// deleting MxlFlowMirror that belongs to another node. A Node
-// deletion produces no event on the MxlFlowMirror, so a mirror whose
-// deletion started while its node was still registered would
-// otherwise never be looked at again once the owning gateway died
-// mid-teardown. The interval only costs a cached Get per deleting
-// foreign mirror; in the common case the owning gateway completes
-// the deletion long before the first re-check fires.
+// orphanRecheckInterval re-examines a deleting foreign mirror on a
+// timer, because a Node deletion raises no event on the mirror.
 const orphanRecheckInterval = time.Minute
 
-// nodeGone reports whether the named Node object is absent from the
-// API.
-//
-// The read deliberately bypasses the manager cache. The gateway runs
-// as a DaemonSet and has no other reason to hold a cluster-wide Node
-// informer; a cached Get would start one on every node in the
-// cluster to serve a lookup that only fires while a mirror is being
-// deleted.
-//
-// An empty nodeName reports false: a mirror with no node recorded
-// has no owner to be orphaned from, and reaping on that basis would
-// strip the finalizer from an object a gateway may still be setting
-// up.
+// nodeGone reports whether the named Node is absent from the API.
+// The read bypasses the manager cache so a DaemonSet does not carry
+// a cluster-wide Node informer for a lookup that only fires while a
+// mirror is deleting. An empty nodeName reports false: a mirror with
+// no node recorded has no owner to be orphaned from.
 func nodeGone(ctx context.Context, reader client.Reader, nodeName string) (bool, error) {
 	if nodeName == "" {
 		return false, nil

--- a/gateway/internal/mirror/orphan.go
+++ b/gateway/internal/mirror/orphan.go
@@ -1,0 +1,50 @@
+package mirror
+
+import (
+	"context"
+	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// orphanRecheckInterval is how often a reconciler re-examines a
+// deleting MxlFlowMirror that belongs to another node. A Node
+// deletion produces no event on the MxlFlowMirror, so a mirror whose
+// deletion started while its node was still registered would
+// otherwise never be looked at again once the owning gateway died
+// mid-teardown. The interval only costs a cached Get per deleting
+// foreign mirror; in the common case the owning gateway completes
+// the deletion long before the first re-check fires.
+const orphanRecheckInterval = time.Minute
+
+// nodeGone reports whether the named Node object is absent from the
+// API.
+//
+// The read deliberately bypasses the manager cache. The gateway runs
+// as a DaemonSet and has no other reason to hold a cluster-wide Node
+// informer; a cached Get would start one on every node in the
+// cluster to serve a lookup that only fires while a mirror is being
+// deleted.
+//
+// An empty nodeName reports false: a mirror with no node recorded
+// has no owner to be orphaned from, and reaping on that basis would
+// strip the finalizer from an object a gateway may still be setting
+// up.
+func nodeGone(ctx context.Context, reader client.Reader, nodeName string) (bool, error) {
+	if nodeName == "" {
+		return false, nil
+	}
+	var node corev1.Node
+	err := reader.Get(ctx, types.NamespacedName{Name: nodeName}, &node)
+	switch {
+	case err == nil:
+		return false, nil
+	case apierrors.IsNotFound(err):
+		return true, nil
+	default:
+		return false, err
+	}
+}

--- a/gateway/internal/mirror/orphan_test.go
+++ b/gateway/internal/mirror/orphan_test.go
@@ -1,0 +1,224 @@
+package mirror
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// deletingMirror builds a mirror that is already terminating and
+// carries both gateway finalizers. Holding both lets each test assert
+// that a reconciler drops only its own.
+func deletingMirror(sourceNode, targetNode string) *mxlv1alpha1.MxlFlowMirror {
+	now := metav1.Now()
+	return &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "m1",
+			Namespace:         "ns1",
+			DeletionTimestamp: &now,
+			Finalizers: []string{
+				SourceFinalizerName,
+				TargetFinalizerName,
+			},
+		},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     "flow-1",
+			SourceNode: sourceNode,
+			TargetNode: targetNode,
+		},
+	}
+}
+
+// TestReconcile_SourceFinalizerReapedWhenSourceNodeGone covers the
+// deadlock that leaves a mirror in Terminating forever. Every branch
+// of the source reconciler past the ownership check is gated on
+// spec.sourceNode naming this node, so when that node is removed from
+// the cluster the only pod that would run the teardown is gone with
+// it. Nothing else owns the finalizer, so without the reaper the
+// object is undeletable for the lifetime of the cluster.
+func TestReconcile_SourceFinalizerReapedWhenSourceNodeGone(t *testing.T) {
+	scheme := newSourceTestScheme(t)
+	mirror := deletingMirror("node-reclaimed", "node-c")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	r := &SourceReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: "node-a",
+		sources:  map[types.NamespacedName]*sourceEntry{},
+		attempts: map[types.NamespacedName]uint32{},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	var live mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &live))
+	assert.False(t, controllerutil.ContainsFinalizer(&live, SourceFinalizerName),
+		"a deleting mirror whose spec.sourceNode names a node that no longer "+
+			"exists has no gateway left to tear it down; the source-side "+
+			"finalizer must be reaped or the object never deletes")
+	assert.True(t, controllerutil.ContainsFinalizer(&live, TargetFinalizerName),
+		"the source reconciler must not touch the target side's finalizer")
+}
+
+// TestReconcile_SourceFinalizerKeptWhileSourceNodeExists is the guard
+// on the reaper: while the node is registered its gateway owns the
+// teardown, and stripping the finalizer here would race that pod into
+// leaking an open initiator.
+func TestReconcile_SourceFinalizerKeptWhileSourceNodeExists(t *testing.T) {
+	scheme := newSourceTestScheme(t)
+	mirror := deletingMirror("node-b", "node-c")
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-b"}}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror, node).
+		Build()
+
+	r := &SourceReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: "node-a",
+		sources:  map[types.NamespacedName]*sourceEntry{},
+		attempts: map[types.NamespacedName]uint32{},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, orphanRecheckInterval, res.RequeueAfter,
+		"a Node deletion raises no event on the mirror, so a deleting "+
+			"foreign mirror has to be re-examined on a timer")
+
+	var live mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &live))
+	assert.True(t, controllerutil.ContainsFinalizer(&live, SourceFinalizerName),
+		"while the source node is registered its gateway owns the teardown")
+}
+
+// TestReconcile_TargetFinalizerReapedWhenTargetNodeGone is the
+// target-side mirror image: the same ownership gate gives the same
+// orphaned finalizer when a target node is reclaimed.
+func TestReconcile_TargetFinalizerReapedWhenTargetNodeGone(t *testing.T) {
+	scheme := newSourceTestScheme(t)
+	mirror := deletingMirror("node-b", "node-reclaimed")
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	r := &TargetReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: "node-a",
+		targets:  map[types.NamespacedName]*targetEntry{},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	var live mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &live))
+	assert.False(t, controllerutil.ContainsFinalizer(&live, TargetFinalizerName),
+		"a deleting mirror whose spec.targetNode names a node that no longer "+
+			"exists has no gateway left to tear it down")
+	assert.True(t, controllerutil.ContainsFinalizer(&live, SourceFinalizerName),
+		"the target reconciler must not touch the source side's finalizer")
+}
+
+// TestReconcile_TargetFinalizerKeptWhileTargetNodeExists mirrors the
+// source-side guard.
+func TestReconcile_TargetFinalizerKeptWhileTargetNodeExists(t *testing.T) {
+	scheme := newSourceTestScheme(t)
+	mirror := deletingMirror("node-b", "node-c")
+	node := &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: "node-c"}}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror, node).
+		Build()
+
+	r := &TargetReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: "node-a",
+		targets:  map[types.NamespacedName]*targetEntry{},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, orphanRecheckInterval, res.RequeueAfter)
+
+	var live mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &live))
+	assert.True(t, controllerutil.ContainsFinalizer(&live, TargetFinalizerName),
+		"while the target node is registered its gateway owns the teardown")
+}
+
+// TestReconcile_LastOrphanedFinalizerCompletesDeletion checks the end
+// state the incident actually needs: once the reaped finalizer is the
+// only one left, the API server is free to remove the object.
+func TestReconcile_LastOrphanedFinalizerCompletesDeletion(t *testing.T) {
+	scheme := newSourceTestScheme(t)
+	now := metav1.Now()
+	mirror := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:              "m1",
+			Namespace:         "ns1",
+			DeletionTimestamp: &now,
+			Finalizers:        []string{SourceFinalizerName},
+		},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     "flow-1",
+			SourceNode: "node-reclaimed",
+			TargetNode: "node-c",
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	r := &SourceReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: "node-a",
+		sources:  map[types.NamespacedName]*sourceEntry{},
+		attempts: map[types.NamespacedName]uint32{},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+
+	var live mxlv1alpha1.MxlFlowMirror
+	err = c.Get(context.Background(), key, &live)
+	assert.True(t, apierrors.IsNotFound(err),
+		"dropping the last finalizer must let the deletion complete, got %v", err)
+}

--- a/gateway/internal/mirror/orphan_test.go
+++ b/gateway/internal/mirror/orphan_test.go
@@ -17,9 +17,8 @@ import (
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 )
 
-// deletingMirror builds a mirror that is already terminating and
-// carries both gateway finalizers. Holding both lets each test assert
-// that a reconciler drops only its own.
+// deletingMirror carries both gateway finalizers so each test can
+// assert a reconciler drops only its own.
 func deletingMirror(sourceNode, targetNode string) *mxlv1alpha1.MxlFlowMirror {
 	now := metav1.Now()
 	return &mxlv1alpha1.MxlFlowMirror{
@@ -40,13 +39,9 @@ func deletingMirror(sourceNode, targetNode string) *mxlv1alpha1.MxlFlowMirror {
 	}
 }
 
-// TestReconcile_SourceFinalizerReapedWhenSourceNodeGone covers the
-// deadlock that leaves a mirror in Terminating forever. Every branch
-// of the source reconciler past the ownership check is gated on
-// spec.sourceNode naming this node, so when that node is removed from
-// the cluster the only pod that would run the teardown is gone with
-// it. Nothing else owns the finalizer, so without the reaper the
-// object is undeletable for the lifetime of the cluster.
+// Without the reaper a mirror whose source node was removed is
+// undeletable: no surviving gateway claims it and nothing else owns
+// the finalizer.
 func TestReconcile_SourceFinalizerReapedWhenSourceNodeGone(t *testing.T) {
 	scheme := newSourceTestScheme(t)
 	mirror := deletingMirror("node-reclaimed", "node-c")
@@ -79,10 +74,9 @@ func TestReconcile_SourceFinalizerReapedWhenSourceNodeGone(t *testing.T) {
 		"the source reconciler must not touch the target side's finalizer")
 }
 
-// TestReconcile_SourceFinalizerKeptWhileSourceNodeExists is the guard
-// on the reaper: while the node is registered its gateway owns the
-// teardown, and stripping the finalizer here would race that pod into
-// leaking an open initiator.
+// The guard on the reaper: a registered node still has a gateway
+// that owns the teardown, and stripping the finalizer would race it
+// into leaking an open initiator.
 func TestReconcile_SourceFinalizerKeptWhileSourceNodeExists(t *testing.T) {
 	scheme := newSourceTestScheme(t)
 	mirror := deletingMirror("node-b", "node-c")
@@ -115,9 +109,8 @@ func TestReconcile_SourceFinalizerKeptWhileSourceNodeExists(t *testing.T) {
 		"while the source node is registered its gateway owns the teardown")
 }
 
-// TestReconcile_TargetFinalizerReapedWhenTargetNodeGone is the
-// target-side mirror image: the same ownership gate gives the same
-// orphaned finalizer when a target node is reclaimed.
+// Target-side mirror image: the same ownership gate orphans the same
+// way when a target node is reclaimed.
 func TestReconcile_TargetFinalizerReapedWhenTargetNodeGone(t *testing.T) {
 	scheme := newSourceTestScheme(t)
 	mirror := deletingMirror("node-b", "node-reclaimed")
@@ -148,8 +141,7 @@ func TestReconcile_TargetFinalizerReapedWhenTargetNodeGone(t *testing.T) {
 		"the target reconciler must not touch the source side's finalizer")
 }
 
-// TestReconcile_TargetFinalizerKeptWhileTargetNodeExists mirrors the
-// source-side guard.
+// Target-side counterpart of the source guard.
 func TestReconcile_TargetFinalizerKeptWhileTargetNodeExists(t *testing.T) {
 	scheme := newSourceTestScheme(t)
 	mirror := deletingMirror("node-b", "node-c")
@@ -179,9 +171,8 @@ func TestReconcile_TargetFinalizerKeptWhileTargetNodeExists(t *testing.T) {
 		"while the target node is registered its gateway owns the teardown")
 }
 
-// TestReconcile_LastOrphanedFinalizerCompletesDeletion checks the end
-// state the incident actually needs: once the reaped finalizer is the
-// only one left, the API server is free to remove the object.
+// The end state the incident needs: reaping the last finalizer lets
+// the deletion complete.
 func TestReconcile_LastOrphanedFinalizerCompletesDeletion(t *testing.T) {
 	scheme := newSourceTestScheme(t)
 	now := metav1.Now()

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -69,6 +69,12 @@ type SourceReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
+	// APIReader is an uncached reader used only for the Node lookup
+	// that gates orphaned-finalizer reaping. SetupWithManager binds
+	// it to the manager's API reader; tests may set it directly. A
+	// nil value falls back to Client.
+	APIReader client.Reader
+
 	// NodeName is the Kubernetes node this gateway runs on. Mirrors
 	// with spec.sourceNode set to a different node are ignored.
 	NodeName string
@@ -167,6 +173,62 @@ type sourceEntry struct {
 // +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflowmirrors/finalizers,verbs=update
 // +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflows,verbs=get;list;watch
 
+// reapOrphanedFinalizer drops SourceFinalizerName from a deleting
+// mirror whose spec.sourceNode names a Node that no longer exists.
+//
+// The source reconciler runs as a DaemonSet and every other branch
+// of Reconcile is gated on spec.sourceNode naming this node, so the
+// only pod that would otherwise complete the teardown is the one
+// that ran on the departed node. Nothing recreates it, no other
+// controller owns this finalizer, and the object hangs in
+// Terminating for the lifetime of the cluster.
+//
+// Node existence is what keeps this from racing a live owner: while
+// the Node object is present the finalizer is left alone and the
+// owning gateway performs the real teardown. Once the Node is gone
+// the libmxl reader and initiator it tracked went with it, so there
+// is no source-side state left to release.
+func (r *SourceReconciler) reapOrphanedFinalizer(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror) (ctrl.Result, error) {
+	if mirror.DeletionTimestamp.IsZero() ||
+		!controllerutil.ContainsFinalizer(mirror, SourceFinalizerName) {
+		return ctrl.Result{}, nil
+	}
+
+	gone, err := nodeGone(ctx, r.nodeReader(), mirror.Spec.SourceNode)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("look up source node %s: %w", mirror.Spec.SourceNode, err)
+	}
+	if !gone {
+		return ctrl.Result{RequeueAfter: orphanRecheckInterval}, nil
+	}
+
+	controllerutil.RemoveFinalizer(mirror, SourceFinalizerName)
+	if err := r.Update(ctx, mirror); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("remove orphaned source finalizer: %w", err)
+	}
+	log.FromContext(ctx).Info("reaped orphaned source-side finalizer",
+		"mxlflowmirror", client.ObjectKeyFromObject(mirror),
+		"sourceNode", mirror.Spec.SourceNode)
+	return ctrl.Result{}, nil
+}
+
+// nodeReader returns the reader used for Node lookups, preferring
+// the uncached APIReader when SetupWithManager has bound one.
+func (r *SourceReconciler) nodeReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get
+
 // Reconcile drives one MxlFlowMirror through its source-side
 // lifecycle.
 func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -183,7 +245,7 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// against a producer-less .mxl-flow until the pod is bounced.
 		// closeEntry is a no-op when key absent (def at line 592).
 		r.closeEntry(req.NamespacedName)
-		return ctrl.Result{}, nil
+		return r.reapOrphanedFinalizer(ctx, &mirror)
 	}
 
 	if !mirror.DeletionTimestamp.IsZero() {
@@ -1078,6 +1140,9 @@ func (r *SourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	if r.attempts == nil {
 		r.attempts = make(map[types.NamespacedName]uint32)
+	}
+	if r.APIReader == nil {
+		r.APIReader = mgr.GetAPIReader()
 	}
 	if r.opener == nil {
 		r.opener = &libmxlOpener{

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -69,10 +69,8 @@ type SourceReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	// APIReader is an uncached reader used only for the Node lookup
-	// that gates orphaned-finalizer reaping. SetupWithManager binds
-	// it to the manager's API reader; tests may set it directly. A
-	// nil value falls back to Client.
+	// APIReader is an uncached reader for the Node lookup that gates
+	// orphaned-finalizer reaping. Nil falls back to Client.
 	APIReader client.Reader
 
 	// NodeName is the Kubernetes node this gateway runs on. Mirrors
@@ -175,19 +173,11 @@ type sourceEntry struct {
 
 // reapOrphanedFinalizer drops SourceFinalizerName from a deleting
 // mirror whose spec.sourceNode names a Node that no longer exists.
-//
-// The source reconciler runs as a DaemonSet and every other branch
-// of Reconcile is gated on spec.sourceNode naming this node, so the
-// only pod that would otherwise complete the teardown is the one
-// that ran on the departed node. Nothing recreates it, no other
-// controller owns this finalizer, and the object hangs in
-// Terminating for the lifetime of the cluster.
-//
-// Node existence is what keeps this from racing a live owner: while
-// the Node object is present the finalizer is left alone and the
-// owning gateway performs the real teardown. Once the Node is gone
-// the libmxl reader and initiator it tracked went with it, so there
-// is no source-side state left to release.
+// Every other branch is gated on spec.sourceNode naming this node
+// and the gateway is a DaemonSet, so the pod that would run the
+// teardown died with the node and nothing else owns the finalizer.
+// Node existence is the guard against racing a live owner; once the
+// Node is gone so is the reader state the finalizer protected.
 func (r *SourceReconciler) reapOrphanedFinalizer(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror) (ctrl.Result, error) {
 	if mirror.DeletionTimestamp.IsZero() ||
 		!controllerutil.ContainsFinalizer(mirror, SourceFinalizerName) {
@@ -218,8 +208,7 @@ func (r *SourceReconciler) reapOrphanedFinalizer(ctx context.Context, mirror *mx
 	return ctrl.Result{}, nil
 }
 
-// nodeReader returns the reader used for Node lookups, preferring
-// the uncached APIReader when SetupWithManager has bound one.
+// nodeReader prefers the uncached APIReader SetupWithManager binds.
 func (r *SourceReconciler) nodeReader() client.Reader {
 	if r.APIReader != nil {
 		return r.APIReader

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -80,10 +80,8 @@ type TargetReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
-	// APIReader is an uncached reader used only for the Node lookup
-	// that gates orphaned-finalizer reaping. SetupWithManager binds
-	// it to the manager's API reader; tests may set it directly. A
-	// nil value falls back to Client.
+	// APIReader is an uncached reader for the Node lookup that gates
+	// orphaned-finalizer reaping. Nil falls back to Client.
 	APIReader client.Reader
 
 	// NodeName is the Kubernetes node this gateway runs on. Mirrors
@@ -214,10 +212,8 @@ type targetEntry struct {
 
 // reapOrphanedFinalizer drops TargetFinalizerName from a deleting
 // mirror whose spec.targetNode names a Node that no longer exists.
-// Symmetric with the source-side reaper: the target reconciler is
-// equally a DaemonSet gated on spec.targetNode, so a mirror whose
-// target node was removed has no pod left to complete its teardown
-// and would hang in Terminating indefinitely.
+// Symmetric with the source-side reaper; same DaemonSet gate, same
+// orphaned finalizer when the node it named is removed.
 func (r *TargetReconciler) reapOrphanedFinalizer(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror) (ctrl.Result, error) {
 	if mirror.DeletionTimestamp.IsZero() ||
 		!controllerutil.ContainsFinalizer(mirror, TargetFinalizerName) {
@@ -248,8 +244,7 @@ func (r *TargetReconciler) reapOrphanedFinalizer(ctx context.Context, mirror *mx
 	return ctrl.Result{}, nil
 }
 
-// nodeReader returns the reader used for Node lookups, preferring
-// the uncached APIReader when SetupWithManager has bound one.
+// nodeReader prefers the uncached APIReader SetupWithManager binds.
 func (r *TargetReconciler) nodeReader() client.Reader {
 	if r.APIReader != nil {
 		return r.APIReader

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -80,6 +80,12 @@ type TargetReconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 
+	// APIReader is an uncached reader used only for the Node lookup
+	// that gates orphaned-finalizer reaping. SetupWithManager binds
+	// it to the manager's API reader; tests may set it directly. A
+	// nil value falls back to Client.
+	APIReader client.Reader
+
 	// NodeName is the Kubernetes node this gateway runs on. Mirrors
 	// with spec.targetNode set to a different node are ignored.
 	NodeName string
@@ -206,6 +212,53 @@ type targetEntry struct {
 // +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflowmirrors/finalizers,verbs=update
 // +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflows,verbs=get;list;watch
 
+// reapOrphanedFinalizer drops TargetFinalizerName from a deleting
+// mirror whose spec.targetNode names a Node that no longer exists.
+// Symmetric with the source-side reaper: the target reconciler is
+// equally a DaemonSet gated on spec.targetNode, so a mirror whose
+// target node was removed has no pod left to complete its teardown
+// and would hang in Terminating indefinitely.
+func (r *TargetReconciler) reapOrphanedFinalizer(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror) (ctrl.Result, error) {
+	if mirror.DeletionTimestamp.IsZero() ||
+		!controllerutil.ContainsFinalizer(mirror, TargetFinalizerName) {
+		return ctrl.Result{}, nil
+	}
+
+	gone, err := nodeGone(ctx, r.nodeReader(), mirror.Spec.TargetNode)
+	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("look up target node %s: %w", mirror.Spec.TargetNode, err)
+	}
+	if !gone {
+		return ctrl.Result{RequeueAfter: orphanRecheckInterval}, nil
+	}
+
+	controllerutil.RemoveFinalizer(mirror, TargetFinalizerName)
+	if err := r.Update(ctx, mirror); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		if apierrors.IsConflict(err) {
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("remove orphaned target finalizer: %w", err)
+	}
+	log.FromContext(ctx).Info("reaped orphaned target-side finalizer",
+		"mxlflowmirror", client.ObjectKeyFromObject(mirror),
+		"targetNode", mirror.Spec.TargetNode)
+	return ctrl.Result{}, nil
+}
+
+// nodeReader returns the reader used for Node lookups, preferring
+// the uncached APIReader when SetupWithManager has bound one.
+func (r *TargetReconciler) nodeReader() client.Reader {
+	if r.APIReader != nil {
+		return r.APIReader
+	}
+	return r.Client
+}
+
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get
+
 // Reconcile drives one MxlFlowMirror through its target-side
 // lifecycle.
 func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
@@ -218,7 +271,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// Other-node mirrors are not ours.
 	if mirror.Spec.TargetNode != r.NodeName {
-		return ctrl.Result{}, nil
+		return r.reapOrphanedFinalizer(ctx, &mirror)
 	}
 
 	// Deletion path: tear down libmxl handles, drop the finalizer.
@@ -1251,6 +1304,9 @@ func (r *TargetReconciler) publishTargetProgress(ctx context.Context, key types.
 func (r *TargetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.targets == nil {
 		r.targets = make(map[types.NamespacedName]*targetEntry)
+	}
+	if r.APIReader == nil {
+		r.APIReader = mgr.GetAPIReader()
 	}
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mxlv1alpha1.MxlFlowMirror{}).

--- a/operator/internal/leasecheck/leasecheck.go
+++ b/operator/internal/leasecheck/leasecheck.go
@@ -21,10 +21,11 @@ import (
 // of cluster-scoped RBAC.
 const LeaseNamespace = apiv1alpha1.LeaseNamespace
 
-// DefaultLeaseDuration is the freshness window applied when a Lease
-// omits LeaseDurationSeconds. The agent writes 30s explicitly;
-// the fallback only matters for Leases authored outside the agent.
-const DefaultLeaseDuration = 30 * time.Second
+// DefaultLeaseDuration re-exports the shared api/v1alpha1 constant.
+// It is the freshness window applied when a Lease omits
+// LeaseDurationSeconds; the agent writes the same value explicitly,
+// so the fallback only matters for Leases authored elsewhere.
+const DefaultLeaseDuration = apiv1alpha1.DefaultLeaseDuration
 
 // Checker implements receiver.LeaseChecker on top of a kube client.
 type Checker struct {

--- a/operator/internal/receiver/controller.go
+++ b/operator/internal/receiver/controller.go
@@ -742,23 +742,13 @@ func (r *Reconciler) patchMirrorIfDrifted(ctx context.Context, recv *mxlv1alpha1
 	return mirror, nil
 }
 
-// mirrorName produces a deterministic, DNS-subdomain-safe name from
-// (flowID, targetNode). FlowIDs are UUIDs; node names are
-// DNS-compliant; the result is lowercased and any non
-// [a-z0-9-] runes are replaced with '-'.
+// mirrorName wraps the shared api/v1alpha1 helper. The agent's
+// intent dispatcher derives the same name from the same inputs, so
+// the two ownership domains meet on one object per (flow, target
+// node); the shared definition keeps that from depending on two
+// copies staying in step.
 func mirrorName(flowID, targetNode string) string {
-	joined := strings.ToLower(flowID + "--" + targetNode)
-	var b strings.Builder
-	b.Grow(len(joined))
-	for _, c := range joined {
-		switch {
-		case c >= 'a' && c <= 'z', c >= '0' && c <= '9', c == '-':
-			b.WriteRune(c)
-		default:
-			b.WriteRune('-')
-		}
-	}
-	return b.String()
+	return mxlv1alpha1.MirrorName(flowID, targetNode)
 }
 
 // mirrorNameForReceiver returns the mirror name the given receiver


### PR DESCRIPTION
Two defects that compose whenever a node leaves the cluster, observed
together on a Karpenter spot cluster where two MxlFlowMirrors sat
Degraded and undeletable after their source nodes were reclaimed, plus
the drift between the two mirror-management paths that the same audit
turned up.

The gateway side leaves the finalizer behind. Both mirror reconcilers
return early when spec.sourceNode / spec.targetNode names another node,
ahead of the branch that would drop the finalizer, and both run as a
DaemonSet. Once the named node is gone no pod is left to claim the
mirror, and no other controller owns that finalizer, so the object
stays in Terminating indefinitely. Reaping is gated on the Node object
actually being absent, so a live owner is never raced, and re-checked
on a timer because a Node deletion raises no event on the mirror.

The agent side stops the mirror recovering. Mirror names encode only
(flowID, targetNode), so ensureMirror keeps resolving to the same
object while the origin is free to move between nodes; returning it
untouched pinned spec.sourceNode to the creation-time node for the
mirror's whole life. That path also handed back mirrors that were
mid-deletion, which occupy the only name the consumer can use and can
never reach Ready.

Comparing the intent path against the receiver path surfaced three
more divergences. MirrorName and DefaultLeaseDuration were defined
twice with byte-identical bodies, one copy per module, while their
siblings LeaseName and LeaseNamespace already lived in api precisely
so the two sides could not drift; both move to join them. The agent's
resolveSourceNode collapsed "no Origin at all" and "every Origin's
Lease expired" into one bool and reported the former for both, which
is the wrong diagnostic on the exact path where an origin has gone
stale.

Gateway RBAC gains get on nodes, which the absence check requires.

One divergence is deliberately left out: the receiver's ensureMirror
has no DeletionTimestamp guard either, so it will adopt and patch a
terminating mirror. It self-heals on the next reconcile, and the fix
needs a control-flow decision rather than a guard clause, so it is
better reviewed on its own.

fix(agent): repoint intent mirrors when the flow origin moves
fix(agent): report a stale Origin distinctly from an unknown flow
feat(api): share MirrorName and DefaultLeaseDuration