### PR TITLE
fix(operator): stop the receiver adopting a terminating mirror

### DIFF
--- a/operator/internal/receiver/controller.go
+++ b/operator/internal/receiver/controller.go
@@ -11,6 +11,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"strings"
 	"time"
@@ -187,12 +188,17 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	var primary *mxlv1alpha1.MirrorRef
+	terminating := false
 	for _, t := range targets {
 		if t.node == res.Node {
 			continue
 		}
 		mirror, err := r.ensureMirror(ctx, &recv, res.Node, t)
 		if err != nil {
+			if errors.Is(err, errMirrorTerminating) {
+				terminating = true
+				continue
+			}
 			return ctrl.Result{}, fmt.Errorf("ensure mirror for %s in %s: %w", t.node, t.namespace, err)
 		}
 		if primary == nil {
@@ -201,6 +207,15 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 				Namespace: mirror.Namespace,
 			}
 		}
+	}
+	if terminating {
+		// A target the receiver still wants has no usable mirror, so
+		// the receiver is not bound however the other targets fared.
+		// markPending's requeue is what retries the create once the
+		// name frees up: mirror deletion completing raises an event
+		// here, but only while the object still carries a finalizer
+		// this operator watches.
+		return r.markPending(ctx, &recv, "mirror for a target is still terminating")
 	}
 
 	l.V(1).Info("reconciled",
@@ -636,6 +651,15 @@ func (r *Reconciler) nodeCapabilities(ctx context.Context, nodeName string) (mxl
 	return caps.Status, nil
 }
 
+// errMirrorTerminating reports that the mirror for a (flow, target)
+// pair exists but is being deleted. Mirror names are derived from
+// the pair, so the name stays taken until deletion completes and no
+// replacement can be created in the meantime. Adopting the dying
+// object instead would add an owner reference and patch spec on
+// something about to disappear, and would let the receiver report
+// Bound against a mirror that is already gone.
+var errMirrorTerminating = errors.New("mirror is terminating")
+
 // ensureMirror creates the MxlFlowMirror for (flow, target) if it
 // does not already exist, or merge-patches spec.sourceNode and
 // spec.provider on the existing mirror when they no longer match
@@ -658,6 +682,9 @@ func (r *Reconciler) ensureMirror(ctx context.Context, recv *mxlv1alpha1.MxlRece
 	var existing mxlv1alpha1.MxlFlowMirror
 	err = r.Get(ctx, types.NamespacedName{Namespace: target.namespace, Name: name}, &existing)
 	if err == nil {
+		if !existing.DeletionTimestamp.IsZero() {
+			return nil, errMirrorTerminating
+		}
 		if sameNs {
 			if err := r.ensureOwnerRef(ctx, recv, &existing); err != nil {
 				return nil, fmt.Errorf("ensure owner ref on %s/%s: %w",
@@ -696,6 +723,9 @@ func (r *Reconciler) ensureMirror(ctx context.Context, recv *mxlv1alpha1.MxlRece
 		if apierrors.IsAlreadyExists(err) {
 			if err := r.Get(ctx, types.NamespacedName{Namespace: target.namespace, Name: name}, &existing); err != nil {
 				return nil, err
+			}
+			if !existing.DeletionTimestamp.IsZero() {
+				return nil, errMirrorTerminating
 			}
 			if sameNs {
 				if err := r.ensureOwnerRef(ctx, recv, &existing); err != nil {

--- a/operator/internal/receiver/controller_envtest_test.go
+++ b/operator/internal/receiver/controller_envtest_test.go
@@ -1054,3 +1054,66 @@ func TestReconcile_LegacyLabelOnlyMirror_AdoptsOwnerRef(t *testing.T) {
 // the controller-runtime client.
 var _ = apierrors.IsNotFound
 var _ = corev1.Pod{}
+
+// A mirror pinned open by a gateway finalizer stays Terminating until
+// that gateway releases it. Mirror names are derived from (flow,
+// target node), so the receiver cannot create a replacement while the
+// name is taken: it reports Pending and retries rather than binding
+// to an object on its way out.
+func TestReconcile_TerminatingMirror_MarksPendingUntilNameFrees(t *testing.T) {
+	const keepalive = "test.mxl.qvest-digital.com/keepalive"
+	ctx := context.Background()
+	ns := env.NewNamespace(t)
+	r := &receiver.Reconciler{Client: env.Client, Scheme: env.Scheme}
+
+	require.NoError(t, env.Client.Create(ctx, testutil.NewPod(ns, "consumer-a", "worker-target")))
+	flow := newFlow(t, "worker-source")
+	require.NoError(t, env.Client.Create(ctx,
+		testutil.NewReceiver(ns, "r", testutil.WithReceiverFlowID(flow.Spec.ID))))
+
+	reconcile(t, r, ns, "r")
+	require.Equal(t, mxlv1alpha1.MxlReceiverBound,
+		mustGetReceiver(t, env.Client, ns, "r").Status.Phase)
+
+	var mirrors mxlv1alpha1.MxlFlowMirrorList
+	require.NoError(t, env.Client.List(ctx, &mirrors, client.InNamespace(ns)))
+	require.Len(t, mirrors.Items, 1)
+	mirror := mirrors.Items[0]
+	originalUID := mirror.UID
+
+	pinned := mirror.DeepCopy()
+	pinned.Finalizers = append(pinned.Finalizers, keepalive)
+	require.NoError(t, env.Client.Update(ctx, pinned))
+	require.NoError(t, env.Client.Delete(ctx, pinned))
+
+	var terminating mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, env.Client.Get(ctx,
+		types.NamespacedName{Namespace: ns, Name: mirror.Name}, &terminating))
+	require.False(t, terminating.DeletionTimestamp.IsZero(),
+		"fixture must leave the mirror terminating")
+
+	res := reconcile(t, r, ns, "r")
+	assert.Positive(t, res.RequeueAfter,
+		"the receiver has to come back once the name frees up")
+	assert.Equal(t, mxlv1alpha1.MxlReceiverPending,
+		mustGetReceiver(t, env.Client, ns, "r").Status.Phase,
+		"a target whose mirror is mid-deletion has no usable mirror, so the "+
+			"receiver is not Bound")
+
+	require.NoError(t, env.Client.Get(ctx,
+		types.NamespacedName{Namespace: ns, Name: mirror.Name}, &terminating))
+	assert.Equal(t, "worker-source", terminating.Spec.SourceNode,
+		"the reconcile must not patch spec onto a terminating mirror")
+
+	require.NoError(t, clearGatewayFinalizer(env.Client, &mirror, keepalive))
+	reconcile(t, r, ns, "r")
+
+	assert.Equal(t, mxlv1alpha1.MxlReceiverBound,
+		mustGetReceiver(t, env.Client, ns, "r").Status.Phase,
+		"once the name frees up the receiver creates a replacement and binds")
+	require.NoError(t, env.Client.List(ctx, &mirrors, client.InNamespace(ns)))
+	require.Len(t, mirrors.Items, 1)
+	assert.NotEqual(t, originalUID, mirrors.Items[0].UID,
+		"the replacement is a new object, not the resurrected tombstone")
+	assert.True(t, mirrors.Items[0].DeletionTimestamp.IsZero())
+}

--- a/operator/internal/receiver/controller_terminating_test.go
+++ b/operator/internal/receiver/controller_terminating_test.go
@@ -1,0 +1,75 @@
+package receiver
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// A mirror mid-deletion still owns its name, so the receiver cannot
+// replace it yet. Adopting it instead writes an owner reference and
+// a spec patch onto an object about to disappear, and lets the
+// receiver report Bound against a mirror that is already gone.
+func Test_ensureMirror_TerminatingMirrorIsNotAdopted(t *testing.T) {
+	ctx := context.Background()
+	const (
+		flowID = "11111111-2222-3333-4444-555555555555"
+		recvNS = "ns"
+		oldSrc = "n-old"
+		newSrc = "n-new"
+		tgt    = "n-target"
+	)
+
+	recv := &mxlv1alpha1.MxlReceiver{
+		ObjectMeta: metav1.ObjectMeta{Namespace: recvNS, Name: "r", UID: "recv-uid"},
+		Spec: mxlv1alpha1.MxlReceiverSpec{
+			FlowID:   flowID,
+			Provider: mxlv1alpha1.ProviderTCP,
+		},
+	}
+
+	now := metav1.Now()
+	existing := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         recvNS,
+			Name:              mirrorName(flowID, tgt),
+			DeletionTimestamp: &now,
+			Finalizers:        []string{"gateway.mxl.qvest-digital.com/source-side"},
+		},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     flowID,
+			SourceNode: oldSrc,
+			TargetNode: tgt,
+			Provider:   mxlv1alpha1.ProviderTCP,
+		},
+	}
+
+	c := fake.NewClientBuilder().
+		WithScheme(unitScheme(t)).
+		WithObjects(existing).
+		Build()
+	r := &Reconciler{Client: c}
+
+	got, err := r.ensureMirror(ctx, recv, newSrc, nodeTarget{node: tgt, namespace: recvNS})
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, errMirrorTerminating),
+		"a terminating mirror is reported through the sentinel so Reconcile "+
+			"can wait for the name instead of failing the whole receiver")
+	assert.Nil(t, got)
+
+	var live mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(ctx, types.NamespacedName{Namespace: recvNS, Name: existing.Name}, &live))
+	assert.Equal(t, oldSrc, live.Spec.SourceNode,
+		"spec must not be patched onto an object that is being deleted")
+	assert.Empty(t, live.OwnerReferences,
+		"an owner reference on a terminating mirror buys nothing and is a "+
+			"write against an object on its way out")
+}


### PR DESCRIPTION
ensureMirror treated any pre-existing MxlFlowMirror as usable and went
straight to ensureOwnerRef plus patchMirrorIfDrifted on it. A mirror
still working through its finalizers is not usable: mirror names are
derived from (flowID, targetNode), so the name stays taken until
deletion completes and no replacement can be created in the meantime.

Two consequences. The receiver wrote an owner reference and a spec
patch onto an object about to disappear, and it reported Bound with
status.boundMirror pointing at a mirror that was already going away.
A consumer reading that status sees a mirror reference it cannot use.

A mirror in that state is now reported through a sentinel error, and
the reconcile marks the receiver Pending. Pending already carries a
requeue, which is what retries the create once the name frees up; the
envtest covers the full round trip, including that the replacement is
a new object rather than the tombstone coming back.

Reaching this state needs something holding the mirror open past its
deletion: a gateway finalizer whose node still has to run the
teardown, or one that has been orphaned outright.