### PR TITLE
fix(operator): prune MxlFlow locations for departed nodes

### DIFF
--- a/charts/mxl-k8s/templates/rbac-operator.yaml
+++ b/charts/mxl-k8s/templates/rbac-operator.yaml
@@ -9,6 +9,11 @@ rules:
   - apiGroups: [""]
     resources: [pods]
     verbs: [get, list, watch]
+  # Pruning MxlFlow locations whose node has left the cluster needs
+  # to see which nodes still exist, and to hear about departures.
+  - apiGroups: [""]
+    resources: [nodes]
+    verbs: [get, list, watch]
   - apiGroups: [coordination.k8s.io]
     resources: [leases]
     verbs: [get, list, watch]

--- a/charts/mxl-k8s/tests/unit/rbac_test.yaml
+++ b/charts/mxl-k8s/tests/unit/rbac_test.yaml
@@ -53,3 +53,14 @@ tests:
             apiGroups: [""]
             resources: [nodes]
             verbs: [get]
+
+  - it: operator role can watch nodes so it can prune locations of departed ones
+    template: templates/rbac-operator.yaml
+    documentIndex: 0
+    asserts:
+      - contains:
+          path: rules
+          content:
+            apiGroups: [""]
+            resources: [nodes]
+            verbs: [get, list, watch]

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -7,6 +7,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
   - pods
   verbs:
   - get
@@ -34,7 +35,6 @@ rules:
   - mxl.qvest-digital.com
   resources:
   - mxldomains/status
-  - mxlflows/status
   - mxlnodecapabilities/status
   verbs:
   - get
@@ -61,6 +61,7 @@ rules:
   - mxl.qvest-digital.com
   resources:
   - mxlflowmirrors/status
+  - mxlflows/status
   - mxlreceivers/status
   verbs:
   - get

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -1214,10 +1214,23 @@ func (r *TargetReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 func observedTargetState(entry *targetEntry, degradedAfter time.Duration, previous targetProgressState) targetProgressState {
 	lastAt := entry.lastCommitAt.Load()
 	if lastAt == nil {
-		// No commit observed yet. Leave Phase + Condition unset so the
-		// flusher does not publish before the handshake has produced
-		// any grain - the initial Reconcile already set Phase=Ready.
-		return targetProgressState{}
+		// Reconcile sets Phase=Ready the moment the fabric side opens,
+		// before any grain has arrived. Staying silent here leaves that
+		// optimistic Ready standing for the lifetime of a target that
+		// never receives one, which is what a mirror pointed at a
+		// departed source node looks like: Ready, no TargetProgress
+		// condition, no lastGrainAt. Once the open is older than the
+		// freshness window, report the absence for what it is.
+		openedAt := entry.fabricOpenedAt.Load()
+		if openedAt == nil || time.Since(*openedAt) < degradedAfter {
+			return targetProgressState{}
+		}
+		return targetProgressState{
+			phase:   mxlv1alpha1.MxlFlowMirrorDegraded,
+			status:  metav1.ConditionFalse,
+			reason:  mxlv1alpha1.ReasonNoGrains,
+			message: "no grain commits since the fabric side opened",
+		}
 	}
 	if time.Since(*lastAt) < degradedAfter {
 		reason := mxlv1alpha1.ReasonHandshakeComplete

--- a/gateway/internal/mirror/target_nograins_test.go
+++ b/gateway/internal/mirror/target_nograins_test.go
@@ -1,0 +1,85 @@
+package mirror
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// openedEntry builds a targetEntry whose fabric side opened openedAgo
+// in the past and which has never seen a grain commit.
+func openedEntry(openedAgo time.Duration) *targetEntry {
+	e := &targetEntry{}
+	t := time.Now().Add(-openedAgo)
+	e.fabricOpenedAt.Store(&t)
+	return e
+}
+
+// Reconcile sets Phase=Ready as soon as the fabric side opens, before
+// any grain arrives. A target that never receives one therefore kept
+// that optimistic Ready for its whole life, because the flusher
+// published nothing while lastCommitAt was nil. That is the exact
+// shape a mirror pointed at a departed source node takes: Ready, no
+// TargetProgress condition, no lastGrainAt -- indistinguishable from
+// a healthy mirror to anything reading status.
+func TestObservedTargetState_NeverAnyGrain_DemotesAfterWindow(t *testing.T) {
+	got := observedTargetState(openedEntry(time.Minute), 10*time.Second, targetProgressState{})
+
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorDegraded, got.phase,
+		"a target that has never received a grain must not keep reporting "+
+			"the Ready that Reconcile set optimistically at open time")
+	assert.Equal(t, metav1.ConditionFalse, got.status)
+	assert.Equal(t, mxlv1alpha1.ReasonNoGrains, got.reason)
+}
+
+// Inside the window the silence is still ordinary handshake latency,
+// so publishing Degraded would flap every freshly opened target.
+func TestObservedTargetState_NeverAnyGrain_SilentInsideWindow(t *testing.T) {
+	got := observedTargetState(openedEntry(time.Second), 10*time.Second, targetProgressState{})
+
+	assert.Equal(t, targetProgressState{}, got,
+		"a target still inside the freshness window has not failed yet; "+
+			"publishing here would demote every target during its handshake")
+}
+
+// A nil fabricOpenedAt means the flusher is running against an entry
+// whose fabric side is not up yet. There is no baseline to measure
+// against, so nothing is published.
+func TestObservedTargetState_NoOpenTimestamp_StaysSilent(t *testing.T) {
+	got := observedTargetState(&targetEntry{}, 10*time.Second, targetProgressState{})
+
+	assert.Equal(t, targetProgressState{}, got)
+}
+
+// The pre-existing path is untouched: an entry that has committed a
+// grain inside the window still reports Ready.
+func TestObservedTargetState_RecentCommit_StillReady(t *testing.T) {
+	e := openedEntry(time.Minute)
+	now := time.Now()
+	e.lastCommitAt.Store(&now)
+
+	got := observedTargetState(e, 10*time.Second, targetProgressState{})
+
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorReady, got.phase)
+	assert.Equal(t, metav1.ConditionTrue, got.status)
+}
+
+// And an entry that flowed and then stalled still demotes through the
+// original lastCommitAt path rather than the new open-time one.
+func TestObservedTargetState_StalledAfterCommit_DemotesOnCommitAge(t *testing.T) {
+	e := openedEntry(time.Hour)
+	stalled := time.Now().Add(-time.Minute)
+	e.lastCommitAt.Store(&stalled)
+
+	got := observedTargetState(e, 10*time.Second, targetProgressState{})
+
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorDegraded, got.phase)
+	assert.Equal(t, mxlv1alpha1.ReasonNoGrains, got.reason)
+	assert.NotNil(t, got.lastCommitAt,
+		"the stall path reports when the last grain landed; the "+
+			"never-flowed path has no such timestamp to offer")
+}

--- a/operator/internal/flow/controller.go
+++ b/operator/internal/flow/controller.go
@@ -2,34 +2,131 @@ package flow
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/util/retry"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 )
 
-// Reconciler observes MxlFlow resources. The agent owns their status;
-// the operator currently only records events.
+// Reconciler observes MxlFlow resources and prunes status.locations
+// entries naming a node the cluster no longer has.
+//
+// The agent owns the entry for its own node: it publishes on
+// fanotify create and demotes on delete. That contract holds only
+// while the agent runs. A node removed from the cluster takes its
+// agent with it, so the entry it published survives indefinitely,
+// and on a cluster that recycles capacity the list grows without
+// bound. Readers are kept off the corpses only by the origin Lease
+// going stale, which leaves an entry no consumer can tell apart from
+// a node that is merely quiet.
 type Reconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
 
 // +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflows,verbs=get;list;watch
-// +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflows/status,verbs=get
+// +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflows/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 
-// Reconcile is the entry point for MxlFlow change events.
+// Reconcile drops every status.locations entry whose node is absent
+// from the API.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := log.FromContext(ctx).WithValues("mxlflow", req.NamespacedName)
+
 	var obj mxlv1alpha1.MxlFlow
 	if err := r.Get(ctx, req.NamespacedName, &obj); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	l.V(1).Info("observed MxlFlow", "id", obj.Spec.ID, "locations", len(obj.Status.Locations))
+
+	departed, err := r.departedNodes(ctx, obj.Status.Locations)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if len(departed) == 0 {
+		l.V(1).Info("observed MxlFlow", "id", obj.Spec.ID, "locations", len(obj.Status.Locations))
+		return ctrl.Result{}, nil
+	}
+
+	// An agent rewrites its own entry on its own schedule, so this
+	// read-modify-write races it. Retrying on conflict re-reads and
+	// re-applies instead of clobbering an entry published between
+	// the Get and the Update.
+	if err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		var live mxlv1alpha1.MxlFlow
+		if err := r.Get(ctx, req.NamespacedName, &live); err != nil {
+			return err
+		}
+		kept := make([]mxlv1alpha1.MxlFlowLocation, 0, len(live.Status.Locations))
+		for _, loc := range live.Status.Locations {
+			if _, gone := departed[loc.NodeName]; !gone {
+				kept = append(kept, loc)
+			}
+		}
+		if len(kept) == len(live.Status.Locations) {
+			return nil
+		}
+		live.Status.Locations = kept
+		return r.Status().Update(ctx, &live)
+	}); err != nil {
+		if apierrors.IsNotFound(err) {
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("prune departed locations: %w", err)
+	}
+
+	l.Info("pruned MxlFlow locations for departed nodes",
+		"id", obj.Spec.ID, "nodes", departedNames(departed))
 	return ctrl.Result{}, nil
+}
+
+// departedNodes returns the node names in locs that have no Node
+// object. The reads are served by the cache the Node watch already
+// requires; the operator is a single Deployment, not a per-node
+// DaemonSet, so that cache exists once cluster-wide.
+func (r *Reconciler) departedNodes(ctx context.Context, locs []mxlv1alpha1.MxlFlowLocation) (map[string]struct{}, error) {
+	departed := map[string]struct{}{}
+	seen := map[string]struct{}{}
+	for _, loc := range locs {
+		if loc.NodeName == "" {
+			continue
+		}
+		if _, dup := seen[loc.NodeName]; dup {
+			continue
+		}
+		seen[loc.NodeName] = struct{}{}
+
+		var node corev1.Node
+		err := r.Get(ctx, types.NamespacedName{Name: loc.NodeName}, &node)
+		switch {
+		case err == nil:
+		case apierrors.IsNotFound(err):
+			departed[loc.NodeName] = struct{}{}
+		default:
+			return nil, fmt.Errorf("look up node %s: %w", loc.NodeName, err)
+		}
+	}
+	return departed, nil
+}
+
+func departedNames(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
 }
 
 // SetupWithManager wires the reconciler into the controller-runtime
@@ -37,6 +134,52 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mxlv1alpha1.MxlFlow{}).
+		Watches(
+			&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.nodeToFlows),
+			builder.WithPredicates(nodeDeletedOnly()),
+		).
 		Named("mxlflow").
 		Complete(r)
+}
+
+// nodeToFlows enqueues every MxlFlow carrying a location for the
+// departed node. A Node deletion raises no event on the flows that
+// reference it, so without this the stranded entry survives until
+// something else happens to touch the same flow.
+func (r *Reconciler) nodeToFlows(ctx context.Context, obj client.Object) []reconcile.Request {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return nil
+	}
+	var flows mxlv1alpha1.MxlFlowList
+	if err := r.List(ctx, &flows); err != nil {
+		log.FromContext(ctx).Error(err, "list MxlFlows for departed node", "node", node.Name)
+		return nil
+	}
+	var out []reconcile.Request
+	for i := range flows.Items {
+		for _, loc := range flows.Items[i].Status.Locations {
+			if loc.NodeName == node.Name {
+				out = append(out, reconcile.Request{
+					NamespacedName: types.NamespacedName{Name: flows.Items[i].Name},
+				})
+				break
+			}
+		}
+	}
+	return out
+}
+
+// nodeDeletedOnly limits the Node watch to deletions. Node objects
+// are among the busiest in a cluster -- heartbeats, conditions,
+// allocatable churn -- and only a departure can strand a location,
+// so reconciling every flow on the rest would be noise.
+func nodeDeletedOnly() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return false },
+		UpdateFunc:  func(event.UpdateEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+		DeleteFunc:  func(event.DeleteEvent) bool { return true },
+	}
 }

--- a/operator/internal/flow/controller_test.go
+++ b/operator/internal/flow/controller_test.go
@@ -13,10 +13,8 @@ import (
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 )
@@ -186,9 +184,80 @@ func TestNodeDeletedOnly_AcceptsDeletesOnly(t *testing.T) {
 	assert.False(t, p.Generic(event.GenericEvent{Object: node("n1")}))
 }
 
-var _ = (*Reconciler)(nil).Reconcile
+// notReadyNode is a node the kubelet has stopped heartbeating for.
+// The object survives; only its Ready condition flips.
+func notReadyNode(name string) *corev1.Node {
+	n := node(name)
+	n.Status.Conditions = []corev1.NodeCondition{{
+		Type:   corev1.NodeReady,
+		Status: corev1.ConditionFalse,
+	}}
+	return n
+}
 
-var (
-	_ = client.IgnoreNotFound
-	_ reconcile.Request
-)
+// Cordon is a scheduling signal, not a liveness one. The node keeps
+// running every pod it already had, and DaemonSet pods tolerate
+// node.kubernetes.io/unschedulable, so the agent on a cordoned node
+// still publishes and the gateway still serves. Pruning here would
+// delete a location that is entirely live.
+func TestReconcile_CordonedNodeLocation_IsKept(t *testing.T) {
+	scheme := newScheme(t)
+	cordoned := node("n1")
+	cordoned.Spec.Unschedulable = true
+	flow := newFlow(mxlv1alpha1.MxlFlowLocation{
+		NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin,
+	})
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy(), cordoned).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: flow.Name},
+	})
+	require.NoError(t, err)
+
+	var after mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: flow.Name}, &after))
+	assert.Equal(t, flow.Status, after.Status,
+		"a cordoned node still runs its agent and its flow; only scheduling "+
+			"of new pods is blocked")
+}
+
+// A NotReady node is deliberately not treated as departed either.
+// The node may come back, the entry is still the absent agent's to
+// own, and the origin Lease going stale is what already keeps
+// consumers off it. Pruning on unreadiness would churn the list on
+// every transient kubelet hiccup.
+//
+// The consequence is that a permanently unreachable node whose Node
+// object is never removed keeps its locations forever. On clusters
+// where a cloud controller or autoscaler deletes the object that
+// resolves itself; where nothing does, it needs an operator to
+// remove the node.
+func TestReconcile_NotReadyNodeLocation_IsKept(t *testing.T) {
+	scheme := newScheme(t)
+	flow := newFlow(mxlv1alpha1.MxlFlowLocation{
+		NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin,
+	})
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy(), notReadyNode("n1")).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: flow.Name},
+	})
+	require.NoError(t, err)
+
+	var after mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: flow.Name}, &after))
+	assert.Equal(t, flow.Status, after.Status,
+		"absence of the Node object is the departure signal, not unreadiness")
+}

--- a/operator/internal/flow/controller_test.go
+++ b/operator/internal/flow/controller_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -14,16 +15,19 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 )
 
-// The flow reconciler is an observer stub: the agent owns MxlFlow
-// status, the operator only logs the event. The contract that needs
-// to hold is therefore narrow: do not mutate the CR, do not requeue,
-// do not crash on missing objects. A future change that quietly turns
-// the reconciler into a writer would be caught by the no-mutation
-// assertion.
+// The agent owns MxlFlow status for its own node. The operator's one
+// write is removing entries whose node has left the cluster, which no
+// agent can do for itself once its node is gone. Everything else must
+// stay untouched: a location on a live node, the spec, the requeue
+// result. The assertions below fence that narrow permission in, so a
+// change that widens the reconciler into a general status writer
+// fails here.
 
 func newScheme(t *testing.T) *runtime.Scheme {
 	t.Helper()
@@ -33,23 +37,27 @@ func newScheme(t *testing.T) *runtime.Scheme {
 	return s
 }
 
-func TestReconcile_ExistingFlow_IsObservedWithoutMutation(t *testing.T) {
-	scheme := newScheme(t)
-	flow := &mxlv1alpha1.MxlFlow{
+func newFlow(locs ...mxlv1alpha1.MxlFlowLocation) *mxlv1alpha1.MxlFlow {
+	return &mxlv1alpha1.MxlFlow{
 		ObjectMeta: metav1.ObjectMeta{Name: "11111111-2222-3333-4444-555555555555"},
-		Spec: mxlv1alpha1.MxlFlowSpec{
-			ID: "11111111-2222-3333-4444-555555555555",
-		},
-		Status: mxlv1alpha1.MxlFlowStatus{
-			Locations: []mxlv1alpha1.MxlFlowLocation{
-				{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
-			},
-		},
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: "11111111-2222-3333-4444-555555555555"},
+		Status:     mxlv1alpha1.MxlFlowStatus{Locations: locs},
 	}
+}
+
+func node(name string) *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name}}
+}
+
+func TestReconcile_LiveNodeLocations_AreNotMutated(t *testing.T) {
+	scheme := newScheme(t)
+	flow := newFlow(mxlv1alpha1.MxlFlowLocation{
+		NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin,
+	})
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
-		WithObjects(flow.DeepCopy()).
+		WithObjects(flow.DeepCopy(), node("n1")).
 		Build()
 
 	r := &Reconciler{Client: c, Scheme: scheme}
@@ -64,9 +72,65 @@ func TestReconcile_ExistingFlow_IsObservedWithoutMutation(t *testing.T) {
 		types.NamespacedName{Name: flow.Name}, &after))
 	assert.Equal(t, flow.Spec, after.Spec)
 	assert.Equal(t, flow.Status, after.Status,
-		"the operator must not write MxlFlow.status; the agent owns it. "+
-			"Any non-empty diff here is a contract violation that would "+
-			"race the agent's status updates")
+		"a location whose node is still registered belongs to that node's "+
+			"agent; writing it here would race the agent's own updates")
+}
+
+// The incident this guards: spot capacity is reclaimed, the agent
+// dies with the node, and the entry it published outlives both. On a
+// cluster that recycles nodes the list grows without bound, and every
+// stranded entry is one a consumer cannot tell apart from a quiet
+// node.
+func TestReconcile_DepartedNodeLocation_IsPruned(t *testing.T) {
+	scheme := newScheme(t)
+	flow := newFlow(
+		mxlv1alpha1.MxlFlowLocation{NodeName: "gone", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+		mxlv1alpha1.MxlFlowLocation{NodeName: "alive", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+	)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy(), node("alive")).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: flow.Name},
+	})
+	require.NoError(t, err)
+
+	var after mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: flow.Name}, &after))
+	require.Len(t, after.Status.Locations, 1,
+		"the entry for the departed node must go; nothing else can remove it")
+	assert.Equal(t, "alive", after.Status.Locations[0].NodeName)
+}
+
+// An Origin entry on a departed node is the dangerous shape: it reads
+// as a live producer to anything that does not also consult the
+// Lease.
+func TestReconcile_DepartedOriginLocation_IsPruned(t *testing.T) {
+	scheme := newScheme(t)
+	flow := newFlow(mxlv1alpha1.MxlFlowLocation{
+		NodeName: "gone", Phase: mxlv1alpha1.MxlFlowLocationOrigin,
+	})
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy()).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: flow.Name},
+	})
+	require.NoError(t, err)
+
+	var after mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: flow.Name}, &after))
+	assert.Empty(t, after.Status.Locations)
 }
 
 func TestReconcile_MissingFlow_NoError(t *testing.T) {
@@ -81,13 +145,50 @@ func TestReconcile_MissingFlow_NoError(t *testing.T) {
 	assert.Equal(t, ctrl.Result{}, res)
 }
 
-// Compile-time guarantee that the package still ships an obvious
-// Reconcile entry point. If the public Reconcile method ever moves
-// to a different receiver, every consumer of the package breaks at
-// build time; this declaration keeps that obvious in the test
-// binary too.
+func TestNodeToFlows_EnqueuesOnlyReferencingFlows(t *testing.T) {
+	scheme := newScheme(t)
+	referencing := newFlow(mxlv1alpha1.MxlFlowLocation{NodeName: "gone"})
+	unrelated := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: "99999999-2222-3333-4444-555555555555"},
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: "99999999-2222-3333-4444-555555555555"},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{{NodeName: "elsewhere"}},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(referencing, unrelated).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme}
+	got := r.nodeToFlows(context.Background(), node("gone"))
+	require.Len(t, got, 1,
+		"a Node deletion raises no event on the flows referencing it, so the "+
+			"mapping is what makes the prune happen at all")
+	assert.Equal(t, referencing.Name, got[0].Name)
+}
+
+func TestNodeToFlows_NonNodeObjectReturnsNil(t *testing.T) {
+	scheme := newScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &Reconciler{Client: c, Scheme: scheme}
+	assert.Nil(t, r.nodeToFlows(context.Background(), newFlow()))
+}
+
+// Node objects churn constantly on heartbeats and conditions. Only a
+// departure can strand a location, so everything else is filtered
+// out before it reaches the queue.
+func TestNodeDeletedOnly_AcceptsDeletesOnly(t *testing.T) {
+	p := nodeDeletedOnly()
+	assert.True(t, p.Delete(event.DeleteEvent{Object: node("n1")}))
+	assert.False(t, p.Create(event.CreateEvent{Object: node("n1")}))
+	assert.False(t, p.Update(event.UpdateEvent{ObjectOld: node("n1"), ObjectNew: node("n1")}))
+	assert.False(t, p.Generic(event.GenericEvent{Object: node("n1")}))
+}
+
 var _ = (*Reconciler)(nil).Reconcile
 
-// silence unused-import diagnostics when the test file is the only
-// importer of a package.
-var _ = client.IgnoreNotFound
+var (
+	_ = client.IgnoreNotFound
+	_ reconcile.Request
+)

--- a/test/integration/kind/cases/85-node-departure.sh
+++ b/test/integration/kind/cases/85-node-departure.sh
@@ -29,15 +29,43 @@ REJOIN_TIMEOUT_SECS="${REJOIN_TIMEOUT_SECS:-180}"
 
 # flows_on_node <node> -- names of MxlFlows carrying a location for
 # the node, one per line. MxlFlow is cluster-scoped.
+#
+# The filter that reads naturally here,
+# .items[?(@.status.locations[*].nodeName=='x')], cannot be used:
+# kubectl's jsonpath engine rejects a comparison whose left side
+# expands to more than one element ("can only compare one element at
+# a time"), and any flow with a second location does exactly that.
+# Emitting the node list per flow and matching in shell sidesteps it.
+#
+# stderr is deliberately not discarded. A jsonpath or connection
+# error must not read as "this node carries no locations".
 flows_on_node() {
+  local want="$1" name nodes
   "${KUBECTL[@]}" get mxlflow -o \
-    "jsonpath={range .items[?(@.status.locations[*].nodeName=='$1')]}{.metadata.name}{'\n'}{end}" \
-    2>/dev/null
+    'jsonpath={range .items[*]}{.metadata.name}{"|"}{range .status.locations[*]}{.nodeName}{","}{end}{"\n"}{end}' \
+  | while IFS='|' read -r name nodes; do
+      [ -n "$name" ] || continue
+      case ",${nodes}" in
+        *",${want},"*) echo "$name" ;;
+      esac
+    done
 }
 
 # location_count <node> -- how many flows still list the node.
 location_count() {
   flows_on_node "$1" | grep -c . || true
+}
+
+# mirrors_sourced_from <node> -- "<name>=<phase>" per mirror whose
+# spec.sourceNode is the node. Same range-and-match shape as above.
+mirrors_sourced_from() {
+  local want="$1" name src phase
+  "${KUBECTL[@]}" get mxlflowmirror -A -o \
+    'jsonpath={range .items[*]}{.metadata.name}{"|"}{.spec.sourceNode}{"|"}{.status.phase}{"\n"}{end}' \
+  | while IFS='|' read -r name src phase; do
+      [ -n "$name" ] || continue
+      [ "$src" = "$want" ] && echo "${name}=${phase}"
+    done
 }
 
 victim=""
@@ -113,9 +141,7 @@ log "all ${before} location(s) for ${victim} were pruned"
 # No mirror may keep claiming Ready while sourcing from the node that
 # just left. Anything still Ready there is reporting a producer that
 # cannot exist.
-stale_ready="$("${KUBECTL[@]}" get mxlflowmirror -A -o \
-  "jsonpath={range .items[?(@.spec.sourceNode=='${victim}')]}{.metadata.name}={.status.phase}{'\n'}{end}" \
-  2>/dev/null | grep -c '=Ready$' || true)"
+stale_ready="$(mirrors_sourced_from "$victim" | grep -c '=Ready$' || true)"
 [ "$stale_ready" -eq 0 ] \
   || fail "${stale_ready} mirror(s) still report Ready with sourceNode=${victim}"
 

--- a/test/integration/kind/cases/85-node-departure.sh
+++ b/test/integration/kind/cases/85-node-departure.sh
@@ -27,47 +27,6 @@ need "$RUNTIME"
 PRUNE_TIMEOUT_SECS="${PRUNE_TIMEOUT_SECS:-90}"
 REJOIN_TIMEOUT_SECS="${REJOIN_TIMEOUT_SECS:-180}"
 
-# flows_on_node <node> -- names of MxlFlows carrying a location for
-# the node, one per line. MxlFlow is cluster-scoped.
-#
-# The filter that reads naturally here,
-# .items[?(@.status.locations[*].nodeName=='x')], cannot be used:
-# kubectl's jsonpath engine rejects a comparison whose left side
-# expands to more than one element ("can only compare one element at
-# a time"), and any flow with a second location does exactly that.
-# Emitting the node list per flow and matching in shell sidesteps it.
-#
-# stderr is deliberately not discarded. A jsonpath or connection
-# error must not read as "this node carries no locations".
-flows_on_node() {
-  local want="$1" name nodes
-  "${KUBECTL[@]}" get mxlflow -o \
-    'jsonpath={range .items[*]}{.metadata.name}{"|"}{range .status.locations[*]}{.nodeName}{","}{end}{"\n"}{end}' \
-  | while IFS='|' read -r name nodes; do
-      [ -n "$name" ] || continue
-      case ",${nodes}" in
-        *",${want},"*) echo "$name" ;;
-      esac
-    done
-}
-
-# location_count <node> -- how many flows still list the node.
-location_count() {
-  flows_on_node "$1" | grep -c . || true
-}
-
-# mirrors_sourced_from <node> -- "<name>=<phase>" per mirror whose
-# spec.sourceNode is the node. Same range-and-match shape as above.
-mirrors_sourced_from() {
-  local want="$1" name src phase
-  "${KUBECTL[@]}" get mxlflowmirror -A -o \
-    'jsonpath={range .items[*]}{.metadata.name}{"|"}{.spec.sourceNode}{"|"}{.status.phase}{"\n"}{end}' \
-  | while IFS='|' read -r name src phase; do
-      [ -n "$name" ] || continue
-      [ "$src" = "$want" ] && echo "${name}=${phase}"
-    done
-}
-
 victim=""
 restore_done=0
 

--- a/test/integration/kind/cases/85-node-departure.sh
+++ b/test/integration/kind/cases/85-node-departure.sh
@@ -75,7 +75,6 @@ restore_node() {
   [ -n "$victim" ] || return 0
   [ "$restore_done" -eq 0 ] || return 0
   restore_done=1
-  log "restoring ${victim}"
   "$RUNTIME" start "$victim" >/dev/null 2>&1 || true
   local deadline
   deadline=$(( $(date +%s) + REJOIN_TIMEOUT_SECS ))
@@ -83,7 +82,7 @@ restore_node() {
     if "${KUBECTL[@]}" get node "$victim" \
         -o 'jsonpath={.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null \
         | grep -qx True; then
-      log "${victim} rejoined and is Ready"
+      echo "  ${victim} rejoined and is Ready"
       "${KUBECTL[@]}" -n "$NAMESPACE" rollout status ds/mxl-k8s-gateway \
         --timeout="${ROLLOUT_TIMEOUT_SECS}s" >/dev/null 2>&1 || true
       "${KUBECTL[@]}" -n "$NAMESPACE" rollout status ds/mxl-k8s-agent \
@@ -99,7 +98,6 @@ restore_node() {
 # missing worker would sabotage any case that runs after this one.
 trap restore_node EXIT
 
-log "selecting a worker that carries at least one MxlFlow location"
 for node in $("${KUBECTL[@]}" get nodes \
     -l '!node-role.kubernetes.io/control-plane' \
     -o 'jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}'); do
@@ -111,18 +109,16 @@ done
 [ -n "$victim" ] || fail "no worker node carries an MxlFlow location; nothing to observe"
 
 before="$(location_count "$victim")"
-log "victim=${victim} carries ${before} flow location(s)"
+echo "  victim=${victim} locations=${before}"
 
 if ! "$RUNTIME" inspect "$victim" >/dev/null 2>&1; then
   fail "no ${RUNTIME} container named ${victim}; is this a KIND cluster?"
 fi
 
-log "stopping ${victim} and deleting its Node object"
 "$RUNTIME" stop "$victim" >/dev/null || fail "could not stop container ${victim}"
 "${KUBECTL[@]}" delete node "$victim" --wait=true >/dev/null \
   || fail "could not delete Node ${victim}"
 
-log "waiting for the operator to prune its locations"
 deadline=$(( $(date +%s) + PRUNE_TIMEOUT_SECS ))
 remaining=-1
 while [ "$(date +%s)" -lt "$deadline" ]; do
@@ -136,7 +132,7 @@ if [ "$remaining" -ne 0 ]; then
   flows_on_node "$victim" >&2
   fail "after ${PRUNE_TIMEOUT_SECS}s, ${remaining} flow(s) still list departed node ${victim}"
 fi
-log "all ${before} location(s) for ${victim} were pruned"
+echo "  ${victim} stopped, Node deleted, ${before} location(s) pruned"
 
 # No mirror may keep claiming Ready while sourcing from the node that
 # just left. Anything still Ready there is reporting a producer that
@@ -144,10 +140,10 @@ log "all ${before} location(s) for ${victim} were pruned"
 stale_ready="$(mirrors_sourced_from "$victim" | grep -c '=Ready$' || true)"
 [ "$stale_ready" -eq 0 ] \
   || fail "${stale_ready} mirror(s) still report Ready with sourceNode=${victim}"
+echo "  no mirror reports Ready with sourceNode=${victim}"
 
 restore_node
 
-log "verifying the rejoined node can carry locations again"
 deadline=$(( $(date +%s) + REJOIN_TIMEOUT_SECS ))
 while [ "$(date +%s)" -lt "$deadline" ]; do
   "${KUBECTL[@]}" get node "$victim" >/dev/null 2>&1 && break
@@ -156,4 +152,3 @@ done
 "${KUBECTL[@]}" get node "$victim" >/dev/null 2>&1 \
   || fail "${victim} never came back; later cases would run a worker short"
 
-log "PASS: ${victim} left, its locations were pruned, and it rejoined"

--- a/test/integration/kind/cases/85-node-departure.sh
+++ b/test/integration/kind/cases/85-node-departure.sh
@@ -1,0 +1,133 @@
+#!/usr/bin/env bash
+# 85-node-departure.sh -- a node leaves the cluster and rejoins.
+#
+# Node removal is the one lifecycle event no agent can report for
+# itself: the agent dies with the node, so whatever it published on
+# MxlFlow.status.locations outlives it. On a cluster that recycles
+# capacity (spot instances, autoscaler consolidation) those entries
+# accumulate, and an Origin among them reads as a live producer to
+# anything that does not also consult the Lease.
+#
+# The case drives a real departure and a real rejoin. A KIND node is
+# a container, so stopping it and deleting the Node object reproduces
+# reclamation exactly as the API server sees it, and starting the
+# container again lets the kubelet re-register under the same name --
+# a full leave/join cycle without recreating the cluster.
+#
+# bash 3.2 compatible: no associative arrays, no mapfile.
+
+set -uo pipefail
+
+# shellcheck source=../lib.sh
+. "${KIND_TEST_LIB:?KIND_TEST_LIB not set}"
+
+RUNTIME="${CONTAINER_RUNTIME:-docker}"
+need "$RUNTIME"
+
+PRUNE_TIMEOUT_SECS="${PRUNE_TIMEOUT_SECS:-90}"
+REJOIN_TIMEOUT_SECS="${REJOIN_TIMEOUT_SECS:-180}"
+
+# flows_on_node <node> -- names of MxlFlows carrying a location for
+# the node, one per line. MxlFlow is cluster-scoped.
+flows_on_node() {
+  "${KUBECTL[@]}" get mxlflow -o \
+    "jsonpath={range .items[?(@.status.locations[*].nodeName=='$1')]}{.metadata.name}{'\n'}{end}" \
+    2>/dev/null
+}
+
+# location_count <node> -- how many flows still list the node.
+location_count() {
+  flows_on_node "$1" | grep -c . || true
+}
+
+victim=""
+restore_done=0
+
+restore_node() {
+  [ -n "$victim" ] || return 0
+  [ "$restore_done" -eq 0 ] || return 0
+  restore_done=1
+  log "restoring ${victim}"
+  "$RUNTIME" start "$victim" >/dev/null 2>&1 || true
+  local deadline
+  deadline=$(( $(date +%s) + REJOIN_TIMEOUT_SECS ))
+  while [ "$(date +%s)" -lt "$deadline" ]; do
+    if "${KUBECTL[@]}" get node "$victim" \
+        -o 'jsonpath={.status.conditions[?(@.type=="Ready")].status}' 2>/dev/null \
+        | grep -qx True; then
+      log "${victim} rejoined and is Ready"
+      "${KUBECTL[@]}" -n "$NAMESPACE" rollout status ds/mxl-k8s-gateway \
+        --timeout="${ROLLOUT_TIMEOUT_SECS}s" >/dev/null 2>&1 || true
+      "${KUBECTL[@]}" -n "$NAMESPACE" rollout status ds/mxl-k8s-agent \
+        --timeout="${ROLLOUT_TIMEOUT_SECS}s" >/dev/null 2>&1 || true
+      return 0
+    fi
+    sleep 3
+  done
+  echo "WARN: ${victim} did not rejoin within ${REJOIN_TIMEOUT_SECS}s" >&2
+}
+
+# Always put the node back, including on a mid-case failure: a
+# missing worker would sabotage any case that runs after this one.
+trap restore_node EXIT
+
+log "selecting a worker that carries at least one MxlFlow location"
+for node in $("${KUBECTL[@]}" get nodes \
+    -l '!node-role.kubernetes.io/control-plane' \
+    -o 'jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}'); do
+  if [ "$(location_count "$node")" -gt 0 ]; then
+    victim="$node"
+    break
+  fi
+done
+[ -n "$victim" ] || fail "no worker node carries an MxlFlow location; nothing to observe"
+
+before="$(location_count "$victim")"
+log "victim=${victim} carries ${before} flow location(s)"
+
+if ! "$RUNTIME" inspect "$victim" >/dev/null 2>&1; then
+  fail "no ${RUNTIME} container named ${victim}; is this a KIND cluster?"
+fi
+
+log "stopping ${victim} and deleting its Node object"
+"$RUNTIME" stop "$victim" >/dev/null || fail "could not stop container ${victim}"
+"${KUBECTL[@]}" delete node "$victim" --wait=true >/dev/null \
+  || fail "could not delete Node ${victim}"
+
+log "waiting for the operator to prune its locations"
+deadline=$(( $(date +%s) + PRUNE_TIMEOUT_SECS ))
+remaining=-1
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  remaining="$(location_count "$victim")"
+  [ "$remaining" -eq 0 ] && break
+  sleep 3
+done
+
+if [ "$remaining" -ne 0 ]; then
+  echo "flows still listing ${victim}:" >&2
+  flows_on_node "$victim" >&2
+  fail "after ${PRUNE_TIMEOUT_SECS}s, ${remaining} flow(s) still list departed node ${victim}"
+fi
+log "all ${before} location(s) for ${victim} were pruned"
+
+# No mirror may keep claiming Ready while sourcing from the node that
+# just left. Anything still Ready there is reporting a producer that
+# cannot exist.
+stale_ready="$("${KUBECTL[@]}" get mxlflowmirror -A -o \
+  "jsonpath={range .items[?(@.spec.sourceNode=='${victim}')]}{.metadata.name}={.status.phase}{'\n'}{end}" \
+  2>/dev/null | grep -c '=Ready$' || true)"
+[ "$stale_ready" -eq 0 ] \
+  || fail "${stale_ready} mirror(s) still report Ready with sourceNode=${victim}"
+
+restore_node
+
+log "verifying the rejoined node can carry locations again"
+deadline=$(( $(date +%s) + REJOIN_TIMEOUT_SECS ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  "${KUBECTL[@]}" get node "$victim" >/dev/null 2>&1 && break
+  sleep 3
+done
+"${KUBECTL[@]}" get node "$victim" >/dev/null 2>&1 \
+  || fail "${victim} never came back; later cases would run a worker short"
+
+log "PASS: ${victim} left, its locations were pruned, and it rejoined"

--- a/test/integration/kind/cases/86-node-drain.sh
+++ b/test/integration/kind/cases/86-node-drain.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# 86-node-drain.sh -- cordon and drain are not departure.
+#
+# The control plane treats one node signal as terminal: the Node
+# object being gone. Cordon and drain both leave it in place, and the
+# distinction is load-bearing.
+#
+# Cordon only blocks new scheduling. DaemonSet pods tolerate
+# node.kubernetes.io/unschedulable, so the agent keeps publishing and
+# the gateway keeps serving; nothing about the flow changes.
+#
+# Drain evicts the workload but skips DaemonSets, which is why
+# --ignore-daemonsets exists. The agent survives to notice its flow
+# directory vanish and demote its own location to Stale. The entry
+# stays on the flow, because the node is still there -- that is what
+# separates a drained node from a departed one, whose entry the
+# operator removes outright.
+#
+# bash 3.2 compatible: no associative arrays, no mapfile.
+
+set -uo pipefail
+
+# shellcheck source=../lib.sh
+. "${KIND_TEST_LIB:?KIND_TEST_LIB not set}"
+
+DRAIN_TIMEOUT_SECS="${DRAIN_TIMEOUT_SECS:-120}"
+SETTLE_TIMEOUT_SECS="${SETTLE_TIMEOUT_SECS:-120}"
+
+victim=""
+uncordon_done=0
+
+uncordon_node() {
+  [ -n "$victim" ] || return 0
+  [ "$uncordon_done" -eq 0 ] || return 0
+  uncordon_done=1
+  "${KUBECTL[@]}" uncordon "$victim" >/dev/null 2>&1 || true
+}
+
+# Always make the node schedulable again: the demo's podAntiAffinity
+# needs both workers, so a cordon left behind would strand a pod
+# Pending for every case that follows.
+trap uncordon_node EXIT
+
+for node in $("${KUBECTL[@]}" get nodes \
+    -l '!node-role.kubernetes.io/control-plane' \
+    -o 'jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}'); do
+  if [ "$(location_count "$node")" -gt 0 ]; then
+    victim="$node"
+    break
+  fi
+done
+[ -n "$victim" ] || fail "no worker node carries an MxlFlow location; nothing to observe"
+
+before_count="$(location_count "$victim")"
+echo "  victim=${victim} locations=${before_count}"
+
+agent_before="$(daemonset_pod_on agent "$victim")"
+gateway_before="$(daemonset_pod_on gateway "$victim")"
+[ -n "$agent_before" ] || fail "no running agent pod on ${victim} to begin with"
+[ -n "$gateway_before" ] || fail "no running gateway pod on ${victim} to begin with"
+
+# --- cordon ------------------------------------------------------
+"${KUBECTL[@]}" cordon "$victim" >/dev/null || fail "could not cordon ${victim}"
+sleep 5
+
+after_cordon="$(location_count "$victim")"
+[ "$after_cordon" -eq "$before_count" ] \
+  || fail "cordon changed the location count for ${victim}: ${before_count} -> ${after_cordon}"
+[ -n "$(daemonset_pod_on agent "$victim")" ] \
+  || fail "agent pod left ${victim} on cordon; DaemonSets tolerate unschedulable"
+echo "  cordoned: ${after_cordon} location(s) intact, agent and gateway still running"
+
+# --- drain -------------------------------------------------------
+"${KUBECTL[@]}" drain "$victim" \
+  --ignore-daemonsets --delete-emptydir-data --force \
+  --timeout="${DRAIN_TIMEOUT_SECS}s" >/dev/null 2>&1 \
+  || fail "drain of ${victim} did not complete within ${DRAIN_TIMEOUT_SECS}s"
+
+# Drain must not have taken the agent or the gateway with it: without
+# them the node could not report its own state, which is precisely
+# the condition that makes a departure unrecoverable.
+[ -n "$(daemonset_pod_on agent "$victim")" ] \
+  || fail "agent pod gone from ${victim} after drain --ignore-daemonsets"
+[ -n "$(daemonset_pod_on gateway "$victim")" ] \
+  || fail "gateway pod gone from ${victim} after drain --ignore-daemonsets"
+
+# The entry must survive: the node is still registered, so the
+# operator's departed-node prune has no business touching it. Only
+# its phase moves, and only the agent moves it.
+deadline=$(( $(date +%s) + SETTLE_TIMEOUT_SECS ))
+non_stale=-1
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  non_stale="$(location_phases "$victim" | grep -cv '^Stale$' || true)"
+  [ "$non_stale" -eq 0 ] && break
+  sleep 3
+done
+
+remaining="$(location_count "$victim")"
+[ "$remaining" -eq "$before_count" ] \
+  || fail "drain removed location entries for ${victim} (${before_count} -> ${remaining}); a drained node is not a departed one"
+
+if [ "$non_stale" -ne 0 ]; then
+  echo "phases still recorded for ${victim}:" >&2
+  location_phases "$victim" >&2
+  fail "after ${SETTLE_TIMEOUT_SECS}s, ${non_stale} location(s) on drained ${victim} are still not Stale"
+fi
+echo "  drained: ${remaining} location(s) retained and demoted to Stale, DaemonSets kept"
+
+# --- uncordon ----------------------------------------------------
+uncordon_node
+echo "  ${victim} uncordoned"

--- a/test/integration/kind/lib.sh
+++ b/test/integration/kind/lib.sh
@@ -126,3 +126,73 @@ collect_diagnostics() {
         > "$KIND_DIAG_DIR/${pod}.log"       2>&1 || true
   done
 }
+
+# --- MxlFlow location helpers -------------------------------------
+#
+# The filter that reads naturally for these, e.g.
+# .items[?(@.status.locations[*].nodeName=='x')], cannot be used:
+# kubectl's jsonpath engine rejects a comparison whose left side
+# expands to more than one element ("can only compare one element at
+# a time"), and any flow with a second location does exactly that.
+# Each helper emits one line per object and matches in shell instead.
+#
+# None of them discard stderr: a jsonpath or connection error must
+# not read as "this node carries nothing".
+
+# flows_on_node <node> -- names of MxlFlows carrying a location for
+# the node, one per line. MxlFlow is cluster-scoped.
+flows_on_node() {
+  local want="$1" name nodes
+  "${KUBECTL[@]}" get mxlflow -o \
+    'jsonpath={range .items[*]}{.metadata.name}{"|"}{range .status.locations[*]}{.nodeName}{","}{end}{"\n"}{end}' \
+  | while IFS='|' read -r name nodes; do
+      [ -n "$name" ] || continue
+      case ",${nodes}" in
+        *",${want},"*) echo "$name" ;;
+      esac
+    done
+}
+
+# location_count <node> -- how many flows list the node.
+location_count() {
+  flows_on_node "$1" | grep -c . || true
+}
+
+# location_phases <node> -- the phase each flow records for the node,
+# one per line. Empty when the node is listed by no flow.
+location_phases() {
+  local want="$1" name pairs pair
+  "${KUBECTL[@]}" get mxlflow -o \
+    'jsonpath={range .items[*]}{.metadata.name}{"|"}{range .status.locations[*]}{.nodeName}{"="}{.phase}{","}{end}{"\n"}{end}' \
+  | while IFS='|' read -r name pairs; do
+      [ -n "$name" ] || continue
+      IFS=','
+      for pair in $pairs; do
+        case "$pair" in
+          "${want}="*) echo "${pair#*=}" ;;
+        esac
+      done
+      unset IFS
+    done
+}
+
+# mirrors_sourced_from <node> -- "<name>=<phase>" per MxlFlowMirror
+# whose spec.sourceNode is the node.
+mirrors_sourced_from() {
+  local want="$1" name src phase
+  "${KUBECTL[@]}" get mxlflowmirror -A -o \
+    'jsonpath={range .items[*]}{.metadata.name}{"|"}{.spec.sourceNode}{"|"}{.status.phase}{"\n"}{end}' \
+  | while IFS='|' read -r name src phase; do
+      [ -n "$name" ] || continue
+      [ "$src" = "$want" ] && echo "${name}=${phase}"
+    done
+}
+
+# daemonset_pod_on <ds-label-value> <node> -- name of the running
+# DaemonSet pod for the component on the node, empty when none.
+daemonset_pod_on() {
+  "${KUBECTL[@]}" -n "$NAMESPACE" get pods \
+    --field-selector "spec.nodeName=$2,status.phase=Running" -o \
+    'jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}' \
+  | grep "^mxl-k8s-$1-" | head -1
+}


### PR DESCRIPTION
Two status-accuracy defects found while verifying the mirror-deadlock
fixes on a dev cluster running Karpenter spot capacity. Both make a
broken flow look healthy to anything reading status.

MxlFlow.status.locations never loses an entry for a node that left.
An agent publishes and demotes the entry for its own node, which
covers every transition except its own node disappearing. One flow on
dev had accumulated nine locations, most naming nodes reclaimed hours
earlier, and two of those entries were still phase Origin. An Origin
on a departed node reads as a live producer to any reader that does
not separately consult the origin Lease, which makes the Lease
freshness check the only thing standing between a consumer and a node
that does not exist. The MxlFlow reconciler was an observer with no
writes; it now prunes entries whose node is absent and wakes on Node
deletion, because removing a node raises no event on the flows that
reference it. Entries for live nodes are left to the agent that owns
them.

A target that never receives a grain reports Ready forever. Reconcile
sets Phase=Ready when the fabric side opens, before any grain
arrives, and the flusher stayed silent while lastCommitAt was nil, so
only a mirror that had flowed and then stalled could ever reach
Degraded. Four mirrors on dev sat Ready with no TargetProgress
condition and no lastGrainAt while sourcing from nodes that had been
reclaimed. That is indistinguishable from a healthy mirror, and it
masked an incomplete rollout as a successful one.

Operator RBAC gains get/list/watch on nodes, which the absence check
and the Node watch require. config/rbac/role.yaml is regenerated from
the markers rather than hand-edited.

The KIND suite gains a node departure and rejoin case. A KIND node is
a container, so stopping it and deleting the Node object reproduces
reclamation as the API server sees it, and restarting the container
lets the kubelet re-register under the same name. The restore runs
from an EXIT trap so a mid-case failure does not leave the suite a
worker short.

fix(gateway): demote a target that never receives a grain