### PR TITLE
deps(api): bump api module to v1.0.0-rc.6

### DIFF
--- a/agent/go.mod
+++ b/agent/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/agent
 go 1.26.0
 
 require (
-	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.5
+	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.6
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0
 	golang.org/x/sys v0.47.0

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/qvest-digital/go-mxl v1.0.0-rc.10
-	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.5
+	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.6
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0
 	k8s.io/api v0.36.3

--- a/operator/go.mod
+++ b/operator/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/operator
 go 1.26.0
 
 require (
-	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.5
+	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.6
 	github.com/stretchr/testify v1.11.1
 	k8s.io/api v0.36.3
 	k8s.io/apimachinery v0.36.3


### PR DESCRIPTION
Aligns the api require of agent, operator, and gateway with the version recorded in .github/release-please-manifest.json. Opened by the bump-go-consumers job in release-please.yml.