### PR TITLE
ci: cut the release train's serialisation and stale-pin risk

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -113,6 +113,25 @@ jobs:
             echo "release_tag=${release_tag}"
           } >> "$GITHUB_OUTPUT"
 
+  # A chart release PR bumps only the chart's own version; the image
+  # pins come from whatever values.yaml holds on main when it merges.
+  # Cutting the chart before a component's post-release/chart-pins
+  # bump has landed therefore packages a stale image, and nothing
+  # about the PR looks wrong while it happens. This turns that
+  # ordering rule into a gate.
+  pins:
+    runs-on: ubuntu-24.04
+    needs: meta
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Release tags are the comparison basis; the default shallow
+          # fetch carries none of them.
+          fetch-depth: 0
+
+      - name: Chart pins are not behind released images
+        run: ./hack/check-chart-pins.sh
+
   lint:
     runs-on: ubuntu-24.04
     needs: meta

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -65,6 +65,7 @@ jobs:
       demo_tools: ${{ steps.f.outputs.demo_tools }}
       workflow:   ${{ steps.f.outputs.workflow }}
       kind:       ${{ steps.f.outputs.kind }}
+      code:       ${{ steps.f.outputs.code }}
     steps:
       - uses: actions/checkout@v7
       - uses: dorny/paths-filter@v4
@@ -77,6 +78,14 @@ jobs:
             shim:       ['docker/shim.Dockerfile', 'shim/**']
             demo_tools: ['docker/demo-tools.Dockerfile']
             workflow:   ['.github/workflows/images.yml']
+            # True when the diff touches anything that is not
+            # markdown. The negation cannot be folded into the
+            # per-image filters above: dorny/paths-filter honours
+            # '!' only under predicate-quantifier 'every', and those
+            # filters are unions that 'every' could never satisfy.
+            # Standing alone it works under the default quantifier:
+            # true iff some changed file is not a .md.
+            code:       ['!**/*.md']
             kind:
               - 'hack/kind-*'
               - 'docker/**'
@@ -138,6 +147,11 @@ jobs:
       CHANGED_SHIM:       ${{ needs.changes.outputs.shim       || 'true' }}
       CHANGED_DEMO_TOOLS: ${{ needs.changes.outputs.demo_tools || 'true' }}
       CHANGED_WORKFLOW:   ${{ needs.changes.outputs.workflow   || 'false' }}
+      # Deliberately undefaulted: empty when the changes job is
+      # skipped (workflow_call / workflow_dispatch). The gate below
+      # fires only on an explicit 'false', so a release publish is
+      # never held back by it.
+      CHANGED_CODE:       ${{ needs.changes.outputs.code }}
     steps:
       - id: m
         run: |
@@ -167,6 +181,16 @@ jobs:
           )
           if [ "$CHANGED_WORKFLOW" = "true" ]; then
             for k in "${!wanted[@]}"; do wanted[$k]=true; done
+          fi
+
+          # A markdown-only diff cannot change an image. The per-image
+          # filters glob whole module directories, so release-please
+          # writing <component>/CHANGELOG.md matches them; without this
+          # every release PR rebuilds and republishes its component's
+          # image, and images-summary being a required check puts that
+          # build on the critical path to merging a changelog entry.
+          if [ "$CHANGED_CODE" = "false" ]; then
+            for k in "${!wanted[@]}"; do wanted[$k]=false; done
           fi
 
           push=false

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -41,6 +41,20 @@ jobs:
       api_released:      ${{ steps.rp.outputs['api--release_created'] }}
       api_tag:           ${{ steps.rp.outputs['api--tag_name'] }}
     steps:
+      - uses: actions/checkout@v7
+
+      # Runs before release-please so the same invocation recreates
+      # whatever it closes. release-please rewrites a component's
+      # branch when that component's pending release changes, not
+      # when main moves under it, so a release PR whose neighbouring
+      # manifest keys have since moved is stuck: workflow_dispatch
+      # regenerates stale contents, not a stale base, and "Update
+      # branch" refuses on conflict.
+      - name: Close release PRs that conflict with main
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: ./hack/reap-conflicted-release-prs.sh
+
       - id: rp
         uses: googleapis/release-please-action@v5
         with:

--- a/hack/check-chart-pins.sh
+++ b/hack/check-chart-pins.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# check-chart-pins.sh -- fail when the chart pins a module image
+# older than that module's newest release tag.
+#
+# The chart carries no pins of its own on a release PR: it bumps its
+# own version and inherits whatever values.yaml holds on main at
+# merge time. A chart release cut before a component's pin bump has
+# landed therefore packages a stale image, and the PR looks entirely
+# healthy while doing it -- mergeable, green, and wrong.
+#
+# Reads the tag pinned per component out of values.yaml and compares
+# it with the newest <component>/v* tag in the repository.
+#
+# bash 3.2 compatible: no associative arrays, no mapfile.
+
+set -uo pipefail
+
+VALUES="${VALUES:-charts/mxl-k8s/values.yaml}"
+COMPONENTS="${COMPONENTS:-operator agent gateway}"
+
+[ -f "$VALUES" ] || { echo "no such file: $VALUES" >&2; exit 2; }
+
+# pinned_tag <component> -- the image tag values.yaml pins for the
+# component, read from the renovate-annotated line so a stray tag:
+# elsewhere in the file cannot be mistaken for it.
+pinned_tag() {
+  grep -E "tag: \"v[0-9][^\"]*\".*depName=ghcr\.io/qvest-digital/mxl-k8s/$1( |$)" "$VALUES" \
+    | head -1 | sed -E 's/.*tag: "(v[^"]+)".*/\1/'
+}
+
+# released_tag <component> -- newest <component>/vX tag, by version.
+released_tag() {
+  git tag --list "$1/v*" | sed "s#^$1/##" | sort -V | tail -1
+}
+
+rc=0
+for c in $COMPONENTS; do
+  pinned="$(pinned_tag "$c")"
+  released="$(released_tag "$c")"
+
+  if [ -z "$pinned" ]; then
+    echo "FAIL ${c}: no pinned tag found in ${VALUES}" >&2
+    rc=1
+    continue
+  fi
+  if [ -z "$released" ]; then
+    echo "skip ${c}: no release tag yet"
+    continue
+  fi
+
+  if [ "$pinned" = "$released" ]; then
+    echo "ok   ${c}: ${pinned}"
+    continue
+  fi
+
+  # Newer-than-released is not a failure: a pin bump merges before
+  # the chart release that carries it, so main legitimately sits
+  # ahead of the chart's own last release.
+  newest="$(printf '%s\n%s\n' "$pinned" "$released" | sort -V | tail -1)"
+  if [ "$newest" = "$pinned" ]; then
+    echo "ok   ${c}: ${pinned} (ahead of released ${released})"
+  else
+    echo "FAIL ${c}: chart pins ${pinned} but ${released} is released" >&2
+    rc=1
+  fi
+done
+
+if [ "$rc" -ne 0 ]; then
+  echo >&2
+  echo "The chart would package an image older than the newest release." >&2
+  echo "Let the post-release/chart-pins bump merge first, then re-run." >&2
+fi
+exit "$rc"

--- a/hack/reap-conflicted-release-prs.sh
+++ b/hack/reap-conflicted-release-prs.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+# reap-conflicted-release-prs.sh -- close release PRs that can no
+# longer merge, so release-please recreates them from current main.
+#
+# release-please rewrites a component's release branch when that
+# component's pending release changes, not when main moves under it.
+# A branch therefore keeps the release-please-manifest.json snapshot
+# it was cut from, and every component shares that one file: once a
+# sibling release lands, the stale neighbouring keys collide with
+# main. Whether a given PR survives comes down to whether its key is
+# adjacent to one that moved, which is an accident of alphabetical
+# order in a JSON file.
+#
+# Neither recovery the tooling offers helps. A workflow_dispatch of
+# release-please regenerates a release PR whose contents are stale,
+# not one whose base has moved, and GitHub's "Update branch" refuses
+# on conflict. Closing is what works: release-please sees no open PR
+# for the component and cuts a fresh one against current main.
+#
+# Runs before the release-please step so the same run recreates what
+# it closes. Only PRs release-please itself labels are considered,
+# and only on an unambiguous CONFLICTING -- never on UNKNOWN, which
+# is what GitHub reports while it recomputes mergeability after a
+# push.
+#
+# bash 3.2 compatible: no associative arrays, no mapfile.
+
+set -uo pipefail
+
+LABEL="${LABEL:-autorelease: pending}"
+DRY_RUN="${DRY_RUN:-false}"
+
+command -v gh >/dev/null 2>&1 || { echo "gh not on PATH" >&2; exit 1; }
+
+numbers="$(gh pr list --state open --label "$LABEL" \
+  --json number --jq '.[].number' 2>/dev/null)"
+
+if [ -z "$numbers" ]; then
+  echo "no open PRs labelled '${LABEL}'"
+  exit 0
+fi
+
+reaped=0
+for n in $numbers; do
+  # Queried per PR rather than in the list call: mergeable is
+  # computed lazily, and asking for it one at a time gives GitHub the
+  # chance to have settled on a real answer.
+  state="$(gh pr view "$n" --json mergeable --jq .mergeable 2>/dev/null)"
+  title="$(gh pr view "$n" --json title --jq .title 2>/dev/null)"
+
+  case "$state" in
+    CONFLICTING)
+      echo "reaping #${n} (${state}): ${title}"
+      if [ "$DRY_RUN" = "true" ]; then
+        echo "  DRY_RUN set, leaving it open"
+        continue
+      fi
+      gh pr comment "$n" --body \
+        "Closed automatically: this release PR conflicts with main and release-please does not rebase a branch whose base has moved. A replacement is cut from current main in the same workflow run; the release it carries is unchanged." \
+        >/dev/null 2>&1 || true
+      if gh pr close "$n" --delete-branch >/dev/null 2>&1; then
+        reaped=$((reaped + 1))
+      else
+        echo "  could not close #${n}; leaving it for a human" >&2
+      fi
+      ;;
+    MERGEABLE)
+      echo "ok      #${n}: ${title}"
+      ;;
+    *)
+      # UNKNOWN, or an empty response. Doing nothing is correct: a
+      # PR closed on a transient unknown would churn the release for
+      # no reason.
+      echo "skip    #${n} (mergeable=${state:-?}): ${title}"
+      ;;
+  esac
+done
+
+echo "reaped ${reaped} conflicted release PR(s)"


### PR DESCRIPTION
Three independent sources of friction, each observed while driving a
full five-component release through by hand. None of them change how
components are versioned or tagged.

## Release PRs rebuilt their own component's image

The per-image filters glob whole module directories, so release-please
writing `<component>/CHANGELOG.md` matched them. Every component
release PR therefore rebuilt and republished an image whose source had
not changed, and because `images-summary` is a required check that
build sat on the critical path to merging a changelog entry. For
gateway that is the cgo build.

The negation cannot be folded into those filters: `dorny/paths-filter`
honours `!` only under `predicate-quantifier: 'every'`, and they are
unions that `every` could never satisfy. A standalone `code` filter of
`['!**/*.md']` works under the default quantifier -- true iff some
changed file is not markdown -- and gates the image set in `meta`.
Release publishes are unaffected: the value is empty when the `changes`
job is skipped, and the gate fires only on an explicit `false`.

## A conflicted release PR had no recovery

release-please rewrites a component's branch when that component's
pending release changes, not when main moves under it. The branch
keeps the `release-please-manifest.json` snapshot it was cut from, and
all six components share that file, so once a sibling release lands the
stale neighbouring keys collide. Whether a given PR survives comes down
to whether its key is adjacent to one that moved.

Neither documented recovery helps. A `workflow_dispatch` of
release-please regenerates a release PR whose *contents* are stale, not
one whose *base* has moved, and GitHub's "Update branch" refuses on
conflict. Closing is what works, because release-please then cuts a
fresh PR against current main.

`reap-conflicted-release-prs.sh` runs before the release-please step so
the same invocation recreates what it closes. It only considers PRs
release-please labels itself, and acts only on an unambiguous
`CONFLICTING` -- never on `UNKNOWN`, which is what GitHub reports while
recomputing mergeability after a push.

## The chart could package an image older than its release

A chart release PR bumps only the chart's own version; the image pins
come from whatever `values.yaml` holds on main when it merges. Cutting
it before a component's `post-release/chart-pins` bump has landed
packages a stale image, and nothing about the PR looks wrong while it
happens -- it is mergeable and green.

`check-chart-pins.sh` compares each pinned tag against the newest
release tag for that component and fails when one lags. A pin ahead of
the released tag is not a failure: that is the normal state between a
pin bump merging and the chart release that carries it.

Verified both directions against the repository: passes on current
main, and fails with a clear message when a pin is rolled back.

## One thing this PR cannot do on its own

The new `pins` job lives in `chart.yml`, which is not part of the
`ci-summary` / `images-summary` fan-in that the branch ruleset
requires. It will report but not block until `pins` is added to the
ruleset's required status checks, which is a repository-settings
change.