### PR TITLE
ci: make the chart pin gate correct and reportable

### DIFF
--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -1,21 +1,14 @@
 name: chart
 
 on:
+  # No paths filter here on purpose. Filtering at the workflow level
+  # means a diff that touches no chart path starts no run at all, so
+  # chart-summary never reports and a branch rule that requires it
+  # waits forever. The filter lives in the changes job instead, the
+  # same shape ci.yml and images.yml use.
   pull_request:
-    paths:
-      - 'charts/mxl-k8s/**'
-      - 'config/crd/**'
-      - '.github/workflows/chart.yml'
-      # The pins job runs this script; without it here a change to the
-      # gate itself never reaches the gate.
-      - 'hack/check-chart-pins.sh'
   push:
     branches: [main]
-    paths:
-      - 'charts/mxl-k8s/**'
-      - 'config/crd/**'
-      - '.github/workflows/chart.yml'
-      - 'hack/check-chart-pins.sh'
   # release-please.yml calls this workflow as a reusable workflow
   # when a charts/mxl-k8s release tag has just been cut, gated on
   # the per-component release_created output. Pre-PAT a
@@ -70,8 +63,53 @@ env:
   YQ_VERSION: v4.53.3
 
 jobs:
+  # Decides whether this diff concerns the chart at all. Gating meta on
+  # the result is enough to cascade: pins, lint and render all need it,
+  # and a skipped dependency skips them too.
+  changes:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    outputs:
+      chart: ${{ steps.decide.outputs.chart }}
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: dorny/paths-filter@v4
+        id: f
+        if: github.event_name == 'pull_request' || github.event_name == 'push'
+        with:
+          filters: |
+            chart:
+              - 'charts/mxl-k8s/**'
+              - 'config/crd/**'
+              - '.github/workflows/chart.yml'
+              # The pins job runs this script; without it here a change
+              # to the gate itself never reaches the gate.
+              - 'hack/check-chart-pins.sh'
+
+      - id: decide
+        env:
+          FILTERED: ${{ steps.f.outputs.chart }}
+          INPUT_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -eu
+          # A release_tag input means release-please.yml called this
+          # workflow to package a tag it just cut, so the chart jobs must
+          # run whatever the diff looks like. On workflow_call
+          # github.event_name is the *caller's* event (push), not
+          # "workflow_call", so the input is the only reliable signal.
+          # workflow_dispatch with an empty tag is a manual dev build and
+          # has no diff to filter against either.
+          if [ -n "${INPUT_RELEASE_TAG:-}" ] || [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
+            echo "chart=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "chart=${FILTERED:-false}" >> "$GITHUB_OUTPUT"
+          fi
+
   meta:
     runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.chart == 'true'
     outputs:
       publish: ${{ steps.m.outputs.publish }}
       version: ${{ steps.m.outputs.version }}
@@ -312,4 +350,27 @@ jobs:
               | gh release edit "${RELEASE_TAG}" --notes-file -
           else
             cat /tmp/bundled.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # One stable check name for branch protection, alongside ci-summary
+  # and images-summary. Runs on every pull request and every push to
+  # main, including those where the chart jobs skipped, so a required
+  # rule on this name always gets a report. Requiring pins directly
+  # instead would block any diff that never starts the chart jobs.
+  chart-summary:
+    needs: [changes, meta, pins, lint, render, package-push]
+    if: ${{ !cancelled() }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 2
+    steps:
+      - name: Verify upstream jobs
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          set -eu
+          echo "$NEEDS" | jq -r 'to_entries[] | "\(.key): \(.value.result)"'
+          bad=$(echo "$NEEDS" | jq '[.[] | select(.result == "failure" or .result == "cancelled")] | length')
+          if [ "$bad" -ne 0 ]; then
+            echo "::error::$bad required job(s) failed or were cancelled"
+            exit 1
           fi

--- a/.github/workflows/chart.yml
+++ b/.github/workflows/chart.yml
@@ -6,12 +6,16 @@ on:
       - 'charts/mxl-k8s/**'
       - 'config/crd/**'
       - '.github/workflows/chart.yml'
+      # The pins job runs this script; without it here a change to the
+      # gate itself never reaches the gate.
+      - 'hack/check-chart-pins.sh'
   push:
     branches: [main]
     paths:
       - 'charts/mxl-k8s/**'
       - 'config/crd/**'
       - '.github/workflows/chart.yml'
+      - 'hack/check-chart-pins.sh'
   # release-please.yml calls this workflow as a reusable workflow
   # when a charts/mxl-k8s release tag has just been cut, gated on
   # the per-component release_created output. Pre-PAT a

--- a/hack/check-chart-pins.sh
+++ b/hack/check-chart-pins.sh
@@ -28,9 +28,20 @@ pinned_tag() {
     | head -1 | sed -E 's/.*tag: "(v[^"]+)".*/\1/'
 }
 
+# newest_version -- reads versions on stdin, prints the highest.
+#
+# sort -V orders v1.0.0-rc.1 above v1.0.0, which inverts every
+# comparison below the moment a component graduates to a stable
+# release. Mapping the prerelease separator to ~ restores semver
+# order: sort -V places ~ below an empty suffix, so v1.0.0~rc.1
+# sorts under v1.0.0.
+newest_version() {
+  sed 's/-/~/' | sort -V | tail -1 | sed 's/~/-/'
+}
+
 # released_tag <component> -- newest <component>/vX tag, by version.
 released_tag() {
-  git tag --list "$1/v*" | sed "s#^$1/##" | sort -V | tail -1
+  git tag --list "$1/v*" | sed "s#^$1/##" | newest_version
 }
 
 rc=0
@@ -56,7 +67,7 @@ for c in $COMPONENTS; do
   # Newer-than-released is not a failure: a pin bump merges before
   # the chart release that carries it, so main legitimately sits
   # ahead of the chart's own last release.
-  newest="$(printf '%s\n%s\n' "$pinned" "$released" | sort -V | tail -1)"
+  newest="$(printf '%s\n%s\n' "$pinned" "$released" | newest_version)"
   if [ "$newest" = "$pinned" ]; then
     echo "ok   ${c}: ${pinned} (ahead of released ${released})"
   else


### PR DESCRIPTION
Three related fixes to the chart pin gate added in #202. The first is the defect; the other two are what it took to make the gate actually enforceable.

## 1. `sort -V` inverts prerelease against stable

`sort -V` places `v1.0.0-rc.1` **above** `v1.0.0`. The gate compares versions twice with it, so both comparisons invert the moment a component graduates:

| chart pin | newest tag | gate said | reality |
| --- | --- | --- | --- |
| `v1.0.0-rc.10` | `v1.0.0` | `ok` | stale pin, shipped unnoticed |
| `v1.0.0` | `v1.0.0` (+ older rc) | `FAIL` | pin is correct |

In the first row `released_tag` resolves to `v1.0.0-rc.10` rather than `v1.0.0`, matches the pin, and reports `ok` -- exactly the class of bug the gate exists to catch. Mapping the prerelease separator to `~` before sorting restores semver order, since `sort -V` places `~` below an empty suffix.

Verified by running both scripts against identical state, with a local `gateway/v1.0.0` tag standing in for a graduation (created and deleted locally, never pushed):

```
--- OLD script (origin/main) ---
ok   gateway: v1.0.0-rc.10          <- stale pin passes
old exit=0

--- NEW script (this branch) ---
FAIL gateway: chart pins v1.0.0-rc.10 but v1.0.0 is released
new exit=1
```

Unmodified `main` state still passes, and that run also exercises the double-digit case on real tags (`rc.10` correctly beats `rc.9`, untouched by the `~` mapping).

## 2. The gate never ran on itself

`hack/check-chart-pins.sh` was absent from chart.yml's path filters, so a change to the gate never reached the gate. This PR was the demonstration: its first two commits produced no `pins` run at all.

## 3. `pins` could not serve as a required check

`pins` is in the branch ruleset's required checks, but chart.yml was filtered at the workflow level. A diff touching no chart path starts no run, so `pins` never reports and the PR sits `BLOCKED` indefinitely. This PR sat in exactly that state.

That is the trap `CLAUDE.md` already documents:

> Do not add individual conditional jobs to the required-checks list -- a skipped check on an unrelated diff would block the PR.

The filter moves into a `changes` job and `meta` is gated on its result; `pins`, `lint` and `render` need `meta`, so a skipped `meta` skips them. A new `chart-summary` runs on every pull request and every push to main and fails iff an upstream failed or was cancelled, matching `ci-summary` and `images-summary`.

The release path keys on the `release_tag` input, not the event name. Under `workflow_call` `github.event_name` is the *caller's* event (`push`), so keying on it would filter a release publish against an unrelated diff. Truth table as shipped:

```
event=pull_request       tag=<none>                       filtered=false  -> chart=false
event=pull_request       tag=<none>                       filtered=true   -> chart=true
event=push               tag=<none>                       filtered=true   -> chart=true
event=push               tag=charts/mxl-k8s/v1.0.0-rc.13  filtered=false  -> chart=true   <- release publish
event=workflow_dispatch  tag=<none>                       filtered=<none> -> chart=true
```

## Required-checks change needed on merge

The ruleset currently requires `ci-summary`, `images-summary` and `pins`. Replace `pins` with `chart-summary`. Leaving `pins` required keeps the deadlock for any diff that does not touch a chart path.

fix(ci): order prerelease versions below their stable release