### PR TITLE
ci: gate pull request titles on the release vocabulary

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,56 @@
+name: pr-title
+
+# A squash merge takes its subject from the pull request title, and
+# release-please decides from that subject whether a component releases and at
+# which version. A title it cannot parse releases nothing and reports nothing.
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  conventional-title:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v7
+
+      # The types are release-please's own: one outside changelog-sections
+      # reaches no changelog section.
+      - name: Read the types from the release-please config
+        id: vocabulary
+        run: |
+          set -euo pipefail
+          {
+            echo 'types<<VOCABULARY'
+            jq -r '.["changelog-sections"][].type' .github/release-please-config.json
+            echo 'VOCABULARY'
+          } >> "$GITHUB_OUTPUT"
+
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          types: ${{ steps.vocabulary.outputs.types }}
+          # A scope names the module changed and routes nothing: release-please
+          # attributes a commit to a package by the paths it touches.
+          requireScope: false
+          subjectPattern: ^(?![A-Z]).+[^.]$
+          subjectPatternError: >-
+            "{subject}" starts upper case or ends in a period.
+          # Squashing a single-commit pull request falls back to that commit's
+          # subject while squash_merge_commit_title is COMMIT_OR_PR_TITLE, and
+          # repository settings are not version controlled.
+          validateSingleCommit: true
+
+      # The title becomes the subject line, which wraps at 72.
+      - name: Check the subject length
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          if [ "${#TITLE}" -gt 72 ]; then
+            echo "::error::The title is ${#TITLE} characters, the limit is 72."
+            exit 1
+          fi


### PR DESCRIPTION
A merge squashes, so the pull request title becomes the commit subject on
main. release-please reads that subject to decide whether a component releases and at
which version; a subject it cannot parse releases nothing and reports
nothing.

`.github/workflows/pr-title.yml` validates the title against the types in
`changelog-sections`, read from `.github/release-please-config.json` at
check time rather than duplicated into the workflow. Scopes stay
unconstrained: a scope names the area changed, while release-please
attributes a commit by the paths it touches. The subject pattern rejects
sentence case and a trailing period, and a second step holds the whole
title to 72 characters.

`validateSingleCommit` covers the fallback path. While
`squash_merge_commit_title` is `COMMIT_OR_PR_TITLE`, GitHub squashes a
single-commit pull request under that commit's subject and not under the
title, and repository settings are not version controlled.

The merge settings of this repository are squash only, with
`squash_merge_commit_title=PR_TITLE` and
`squash_merge_commit_message=PR_BODY`.