### PR TITLE
ci: spare update bots the subject length limit

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -45,8 +45,11 @@ jobs:
           # repository settings are not version controlled.
           validateSingleCommit: true
 
-      # The title becomes the subject line, which wraps at 72.
+      # The title becomes the subject line, which wraps at 72. An update bot
+      # writes the dependency, both versions and the directory into its title
+      # and has no shorter form to fall back to.
       - name: Check the subject length
+        if: github.event.pull_request.user.type != 'Bot'
         env:
           TITLE: ${{ github.event.pull_request.title }}
         run: |


### PR DESCRIPTION
The scope allowlist is not the issue here: this workflow leaves scopes
unconstrained, so `chore(deps)`, `fix(deps)`, `deps(actions)` and every other
shape Dependabot or Renovate writes already validate. The length step is what
fails them.

Dependabot builds a title as `<type>(<scope>): bump <dependency> from <old> to
<new> in /<directory>`, taking the type from the repository's recent subjects
and scoping it `deps` or `deps-dev`. That form passes 72 characters as soon as
the dependency has a path-like name, and the bot has no shorter form to fall
back to. Renovate is usually shorter but not reliably so.

The step now skips a pull request whose author is a bot
(`github.event.pull_request.user.type != 'Bot'`). The conventional-commit check
still runs on those titles, which is the part that keeps a merge from landing a
subject release-please cannot read. The 72-character rule remains what it was
for an authored subject.