### PR TITLE
fix(ci): drop the component name from the root release package

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -21,7 +21,6 @@
     },
     ".": {
       "release-type": "simple",
-      "component": "mxl-k8s",
       "include-component-in-tag": false,
       "exclude-paths": [
         ".github",


### PR DESCRIPTION
Merging #214 produced no `v1.0.0-rc.14` tag and no GitHub release;
`publish-images` and `package-chart` skipped on a `release_created` that
was never true. Run
[30627888209](https://github.com/qvest-digital/mxl-k8s/actions/runs/30627888209)
logged the reason twice:

```
PR component: undefined does not match configured component: api
PR component: undefined does not match configured component: mxl-k8s
```

## Why

`BaseStrategy.buildRelease` resolves a merged release pull request
against the package it belongs to. When the body carries exactly one
entry and that entry carries no component label, it takes the
standalone-pull-request path:

```ts
if (pullRequestBody.releaseData.length === 1 &&
    !pullRequestBody.releaseData[0].component) {
  const branchComponent = await this.getBranchComponent();
  if (this.normalizeComponent(branchName.component) !==
      this.normalizeComponent(branchComponent)) {
    this.logger.warn(`PR component: ... does not match ...`);
    return;                       // <- no release built
  }
```

#214 hit every one of those conditions. Only the root package had
commits, so the body held one entry; the root package renders its entry
as `<details><summary>1.0.0-rc.14</summary>` with no component, because
`getComponent()` returns `''` under `include-component-in-tag: false`.

The comparison is then between the head branch and the config.
`BranchName.parse("release-please--branches--main")` yields no
component, while `getBranchComponent()` is
`this.component || getDefaultComponent()` -- it reads the raw
`component` key and is *not* gated on `include-component-in-tag`. So
`"" !== "mxl-k8s"`, and the release was discarded.

Removing the key makes `getBranchComponent()` fall through to
`getDefaultComponent()`, which is `''` for a `simple` strategy with no
`package-name`. `"" === ""` holds, `releaseData[0].version` supplies
`1.0.0-rc.14`, and `new TagName(version, includeComponentInTag ?
component : undefined, ...)` still yields `v1.0.0-rc.14`.

The key was doing nothing else: with `include-component-in-tag: false`
the tag never carried it, and the changelog entry renders unlabelled.
It also made the candidate branch name disagree with the grouped branch
the merge plugin writes; those now agree.

## Recovery, no manual tagging

#214 still carries `autorelease: pending`, so the next release-please
pass finds it as a merged-but-unreleased pull request and cuts
`v1.0.0-rc.14` from it. This pull request touches only `.github/`,
which is in the root package's `exclude-paths`, so it opens no
competing release of its own.

## Multi-package case

Unchanged. When both packages release, the body holds two entries and
the `else` branch matches by `getComponent()`: `''` for the root entry
(rendered unlabelled) and `api` for the api entry.
