### PR TITLE
fix(gateway): surface a source reader whose head stops advancing

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -52,6 +52,11 @@ const (
 	// grains.
 	ReasonReaderAgedOut = "ReaderAgedOut"
 
+	// ReasonReaderNotAdvancing marks a mirror whose source-side flow
+	// reader has never transferred a grain and whose head index has
+	// not moved since the reader opened.
+	ReasonReaderNotAdvancing = "ReaderNotAdvancing"
+
 	// ReasonProviderUnresolved marks a mirror the gateway refused to
 	// set up because spec.provider is still auto. libmxl-fabrics no
 	// longer resolves auto itself (v1.1.0-beta-1 dropped it), so the

--- a/gateway/cmd/mxl-fabrics-gateway/main.go
+++ b/gateway/cmd/mxl-fabrics-gateway/main.go
@@ -112,11 +112,12 @@ func run(args []string) error {
 		return fmt.Errorf("setup target reconciler: %w", err)
 	}
 	if err := (&mirror.SourceReconciler{
-		Client:      mgr.GetClient(),
-		Scheme:      mgr.GetScheme(),
-		NodeName:    cfg.NodeName,
-		BindAddress: cfg.BindAddress,
-		Handles:     handles,
+		Client:           mgr.GetClient(),
+		Scheme:           mgr.GetScheme(),
+		NodeName:         cfg.NodeName,
+		BindAddress:      cfg.BindAddress,
+		Handles:          handles,
+		ReaderStallAfter: cfg.ReaderStallAfter,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup source reconciler: %w", err)
 	}

--- a/gateway/internal/config/config.go
+++ b/gateway/internal/config/config.go
@@ -57,6 +57,11 @@ type Config struct {
 	// MxlFlowMirror freshness expectation.
 	DegradedAfter time.Duration
 
+	// ReaderStallAfter is how long the source-side reconciler lets a
+	// reader report an unchanged head index, having never transferred
+	// a grain, before SourceProgress reports ReaderNotAdvancing.
+	ReaderStallAfter time.Duration
+
 	// KubeAPIQPS is the sustained request rate the Kubernetes API
 	// client allows before throttling. The per-mirror status flushers
 	// publish roughly one PATCH per second per flowing mirror, so the
@@ -98,6 +103,8 @@ func FromFlags(fs *flag.FlagSet, args []string) (*Config, error) {
 		"How often to refresh MxlNodeCapabilities status.")
 	fs.DurationVar(&c.DegradedAfter, "degraded-after", 10*time.Second,
 		"Grain-commit inactivity after which the target gateway demotes a mirror to Degraded.")
+	fs.DurationVar(&c.ReaderStallAfter, "reader-stall-after", 20*time.Second,
+		"Head-index inactivity after which the source gateway reports a reader that has never transferred a grain as not advancing.")
 	fs.Float64Var(&c.KubeAPIQPS, "kube-api-qps", 50,
 		"Sustained Kubernetes API request rate allowed before client-side throttling.")
 	fs.IntVar(&c.KubeAPIBurst, "kube-api-burst", 100,

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -94,6 +94,12 @@ type SourceReconciler struct {
 	// when the observed state has transitioned. Defaults to 1s.
 	FlushInterval time.Duration
 
+	// ReaderStallAfter is how long a reader may report an unchanged
+	// head index, having never transferred a grain, before
+	// SourceProgress reports ReaderNotAdvancing. Defaults to
+	// defaultReaderStallAfter.
+	ReaderStallAfter time.Duration
+
 	// opener is the seam onto the cgo-dependent libmxl-fabrics
 	// Initiator setup path. SetupWithManager binds it to a
 	// libmxlOpener built from Handles + NodeName + BindAddress;
@@ -133,6 +139,13 @@ type sourceEntry struct {
 	// Used by the flusher to publish SourceProgress with reason
 	// ReaderAgedOut on the transition.
 	agedOutAt atomic.Pointer[time.Time]
+
+	// lastHead is the most recent head index the transfer loop probed
+	// off the FlowReader; headAdvancedAt is when that value last
+	// changed. The flusher reads both to tell a wedged reader from one
+	// still waiting on its first grain.
+	lastHead       atomic.Uint64
+	headAdvancedAt atomic.Pointer[time.Time]
 
 	// addTargetAttempts mirrors r.attempts for this key into the
 	// flusher's view. lastError records the most recent reconcile
@@ -351,6 +364,14 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if originAt != nil {
 		t := *originAt
 		entry.lastObservedOriginAt.Store(&t)
+	}
+	// Carry the published lastSentAt onto the fresh entry: a rebuilt
+	// entry has no transfers of its own, and an omitted field is one
+	// SSA releases and the apiserver strips, erasing the timestamp the
+	// target's stuck-handshake watchdog discriminates on.
+	if mirror.Status.LastSentAt != nil {
+		t := mirror.Status.LastSentAt.Time
+		entry.lastSentAt.Store(&t)
 	}
 
 	r.mu.Lock()
@@ -640,12 +661,18 @@ const (
 	mirrorResyncLag int64 = 2
 )
 
+// defaultReaderStallAfter is the head-index inactivity window behind
+// ReasonReaderNotAdvancing. Matches defaultStuckHandshakeAfter so both
+// sides of a mirror describe a wedge over the same period.
+const defaultReaderStallAfter = 20 * time.Second
+
 // progressTracker is the subset of sourceEntry the transfer loop
 // updates. Defined as an interface so tests can inject a stub
 // without constructing a full sourceEntry.
 type progressTracker interface {
 	recordTransfer(idx uint64, at time.Time)
 	recordAgedOut(at time.Time)
+	recordHead(head uint64, at time.Time)
 }
 
 func (e *sourceEntry) recordTransfer(idx uint64, at time.Time) {
@@ -657,6 +684,18 @@ func (e *sourceEntry) recordTransfer(idx uint64, at time.Time) {
 func (e *sourceEntry) recordAgedOut(at time.Time) {
 	t := at
 	e.agedOutAt.Store(&t)
+}
+
+// recordHead stamps headAdvancedAt only on a changed head, so the
+// timestamp measures how long the reader has stood still rather than
+// how long ago the loop last polled it.
+func (e *sourceEntry) recordHead(head uint64, at time.Time) {
+	if e.headAdvancedAt.Load() != nil && e.lastHead.Load() == head {
+		return
+	}
+	e.lastHead.Store(head)
+	t := at
+	e.headAdvancedAt.Store(&t)
 }
 
 // runTransferLoop pumps grains that appear on the source flow into
@@ -692,6 +731,9 @@ func runTransferLoop(
 		return
 	}
 	lastSent := int64(head0)
+	if tracker != nil {
+		tracker.recordHead(head0, time.Now())
+	}
 
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -707,6 +749,9 @@ func runTransferLoop(
 		if err != nil {
 			l.Error(err, "Runtime")
 			continue
+		}
+		if tracker != nil {
+			tracker.recordHead(head, time.Now())
 		}
 
 		// A mirror can only transfer grains the producer still holds in
@@ -1021,7 +1066,7 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 			return
 		case <-t.C:
 		}
-		state := observedState(entry)
+		state := observedState(entry, r.readerStallAfter())
 		if !first && sourceStateEqual(state, last) {
 			continue
 		}
@@ -1033,6 +1078,15 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 		last = state
 		first = false
 	}
+}
+
+// readerStallAfter returns the configured reader-stall window,
+// falling back to defaultReaderStallAfter when unset.
+func (r *SourceReconciler) readerStallAfter() time.Duration {
+	if r.ReaderStallAfter > 0 {
+		return r.ReaderStallAfter
+	}
+	return defaultReaderStallAfter
 }
 
 // sourceStateEqual reports whether two sourceProgressState values
@@ -1061,7 +1115,7 @@ func sourceStateEqual(a, b sourceProgressState) bool {
 // propagated into every state so the target-side watchdog gets a
 // freshness signal regardless of which condition is currently being
 // published.
-func observedState(entry *sourceEntry) sourceProgressState {
+func observedState(entry *sourceEntry, stallAfter time.Duration) sourceProgressState {
 	var sent *time.Time
 	if p := entry.lastSentAt.Load(); p != nil {
 		t := *p
@@ -1094,6 +1148,19 @@ func observedState(entry *sourceEntry) sourceProgressState {
 			status:     metav1.ConditionTrue,
 			reason:     mxlv1alpha1.ReasonRecovered,
 			message:    "grain progress observed",
+			lastSentAt: sent,
+		}
+	}
+	// Nothing transferred and the head has not moved: the loop's inner
+	// range never runs, so it emits no error and no aged-out skip, and
+	// the target reads the mirror as an idle producer and declines to
+	// recover. Reporting True here describes that wedge as healthy.
+	if at := entry.headAdvancedAt.Load(); at != nil && time.Since(*at) > stallAfter {
+		return sourceProgressState{
+			status: metav1.ConditionFalse,
+			reason: mxlv1alpha1.ReasonReaderNotAdvancing,
+			message: fmt.Sprintf("reader head stuck at %d for over %s",
+				entry.lastHead.Load(), stallAfter),
 			lastSentAt: sent,
 		}
 	}

--- a/gateway/internal/mirror/source_stall_test.go
+++ b/gateway/internal/mirror/source_stall_test.go
@@ -1,0 +1,203 @@
+package mirror
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+func stalledEntry(head uint64, headAt *time.Time, transfers uint64) *sourceEntry {
+	e := &sourceEntry{}
+	e.lastHead.Store(head)
+	if headAt != nil {
+		t := *headAt
+		e.headAdvancedAt.Store(&t)
+	}
+	for i := uint64(0); i < transfers; i++ {
+		e.recordTransfer(i, time.Now())
+	}
+	return e
+}
+
+func TestObservedState_ReaderNotAdvancing(t *testing.T) {
+	// A source whose reader head never moves transfers nothing, and
+	// the transfer loop's inner range never runs, so it emits neither
+	// an error nor an aged-out skip. Reporting SourceProgress=True
+	// there describes a wedged mirror as healthy.
+	const window = 20 * time.Second
+	stale := time.Now().Add(-window - time.Second)
+	fresh := time.Now()
+
+	tests := []struct {
+		name       string
+		entry      *sourceEntry
+		wantStatus metav1.ConditionStatus
+		wantReason string
+	}{
+		{
+			name:       "never probed",
+			entry:      stalledEntry(0, nil, 0),
+			wantStatus: metav1.ConditionTrue,
+			wantReason: mxlv1alpha1.ReasonHandshakeComplete,
+		},
+		{
+			name:       "head advanced within window",
+			entry:      stalledEntry(42, &fresh, 0),
+			wantStatus: metav1.ConditionTrue,
+			wantReason: mxlv1alpha1.ReasonHandshakeComplete,
+		},
+		{
+			name:       "head frozen past window without transfers",
+			entry:      stalledEntry(42, &stale, 0),
+			wantStatus: metav1.ConditionFalse,
+			wantReason: mxlv1alpha1.ReasonReaderNotAdvancing,
+		},
+		{
+			name:       "head frozen past window after transfers",
+			entry:      stalledEntry(42, &stale, 3),
+			wantStatus: metav1.ConditionTrue,
+			wantReason: mxlv1alpha1.ReasonRecovered,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := observedState(tc.entry, window)
+			assert.Equal(t, tc.wantStatus, got.status)
+			assert.Equal(t, tc.wantReason, got.reason)
+		})
+	}
+}
+
+func TestRecordHead_StampsOnlyOnChange(t *testing.T) {
+	// headAdvancedAt has to measure how long the reader has stood
+	// still, not how long ago it was last polled: the loop probes
+	// every ProgressInterval regardless of whether the head moved.
+	e := &sourceEntry{}
+	t0 := time.Now()
+
+	e.recordHead(100, t0)
+	first := e.headAdvancedAt.Load()
+	require.NotNil(t, first)
+	require.Equal(t, uint64(100), e.lastHead.Load())
+
+	e.recordHead(100, t0.Add(time.Minute))
+	assert.True(t, e.headAdvancedAt.Load().Equal(*first),
+		"an unchanged head must not refresh the stall clock")
+
+	e.recordHead(101, t0.Add(2*time.Minute))
+	assert.True(t, e.headAdvancedAt.Load().After(*first),
+		"a changed head must refresh the stall clock")
+	assert.Equal(t, uint64(101), e.lastHead.Load())
+}
+
+func TestRunTransferLoop_RecordsProbedHead(t *testing.T) {
+	// The flusher can only see a frozen reader if the loop reports
+	// every head it probes, including the initial attach probe.
+	tracker := &recordingTracker{}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	probes := make(chan uint64, 4)
+	probes <- 7
+	probes <- 7
+	probes <- 7
+	close(probes)
+
+	go runTransferLoop(ctx, done, "flow-1",
+		func() (uint64, error) {
+			if h, ok := <-probes; ok {
+				return h, nil
+			}
+			cancel()
+			return 7, nil
+		},
+		func(uint64) (bool, error) { return true, nil },
+		func() error { return nil },
+		time.Millisecond, tracker)
+
+	<-done
+	heads := tracker.headSnapshot()
+	require.NotEmpty(t, heads)
+	for _, h := range heads {
+		assert.Equal(t, uint64(7), h)
+	}
+	transfers, _ := tracker.snapshot()
+	assert.Empty(t, transfers,
+		"a head that never advances leaves nothing to transfer")
+}
+
+func TestReconcile_PreservesLastSentAtAcrossReopen(t *testing.T) {
+	// publishSourceProgress omits lastSentAt when the entry carries
+	// none, and SSA releases an omitted field, so the apiserver
+	// strips the published value. A reopened entry starts with zero
+	// transfers, so without seeding, a reopen erases the timestamp
+	// the target-side stuck-handshake watchdog discriminates on.
+	scheme := newSourceTestScheme(t)
+	flowID := "flow-1"
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", flowID, "info-1")
+	sentAt := metav1.NewTime(time.Now().Add(-time.Minute).Truncate(time.Second))
+	mirror.Status.LastSentAt = &sentAt
+
+	opened := metav1.NewTime(time.Now().Add(-2 * time.Minute))
+	flow := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: flowID},
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: flowID},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{{
+				NodeName:     "node-a",
+				Phase:        mxlv1alpha1.MxlFlowLocationOrigin,
+				LastObserved: &opened,
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}, &mxlv1alpha1.MxlFlow{}).
+		WithObjects(mirror, flow).
+		Build()
+
+	opener := &fakeOpener{
+		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+			return &sourceEntry{infoStr: "info-1"}, nil
+		},
+	}
+	r := &SourceReconciler{
+		Client:        c,
+		Scheme:        scheme,
+		NodeName:      "node-a",
+		opener:        opener,
+		FlushInterval: time.Hour,
+		sources:       map[types.NamespacedName]*sourceEntry{},
+		attempts:      map[types.NamespacedName]uint32{},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+	t.Cleanup(func() { r.closeEntry(key) })
+
+	r.mu.Lock()
+	entry := r.sources[key]
+	r.mu.Unlock()
+	require.NotNil(t, entry)
+
+	got := entry.lastSentAt.Load()
+	require.NotNil(t, got, "a rebuilt entry must inherit the published lastSentAt")
+	assert.True(t, got.Equal(sentAt.Time))
+
+	state := observedState(entry, defaultReaderStallAfter)
+	require.NotNil(t, state.lastSentAt,
+		"the next publish must still carry lastSentAt so SSA does not strip it")
+	assert.True(t, state.lastSentAt.Equal(sentAt.Time))
+}

--- a/gateway/internal/mirror/source_test.go
+++ b/gateway/internal/mirror/source_test.go
@@ -300,6 +300,7 @@ type recordingTracker struct {
 	mu        sync.Mutex
 	transfers []uint64
 	agedOuts  int
+	heads     []uint64
 }
 
 func (rt *recordingTracker) recordTransfer(idx uint64, _ time.Time) {
@@ -312,6 +313,20 @@ func (rt *recordingTracker) recordAgedOut(_ time.Time) {
 	rt.mu.Lock()
 	rt.agedOuts++
 	rt.mu.Unlock()
+}
+
+func (rt *recordingTracker) recordHead(head uint64, _ time.Time) {
+	rt.mu.Lock()
+	rt.heads = append(rt.heads, head)
+	rt.mu.Unlock()
+}
+
+func (rt *recordingTracker) headSnapshot() []uint64 {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	out := make([]uint64, len(rt.heads))
+	copy(out, rt.heads)
+	return out
 }
 
 func (rt *recordingTracker) snapshot() ([]uint64, int) {


### PR DESCRIPTION
A source entry that has never transferred a grain published
SourceProgress=True/HandshakeComplete regardless of whether its
FlowReader was making any progress. When the reader's head index stops
moving, the transfer loop's inner range never runs, so it emits neither
an error nor an aged-out skip, and the mirror reports a healthy source
while moving nothing. The target side reads that state as an idle
producer and declines to recover, so the wedge is silent on both sides.

The transfer loop now reports every probed head to the entry, and the
flusher publishes ReasonReaderNotAdvancing once a reader with zero
transfers has held the same head past ReaderStallAfter. The branch sits
after the progress check, so a mirror that has ever sent a grain keeps
reporting Recovered and an idle producer is not misreported as a fault.
ReaderStallAfter defaults to 20s, matching defaultStuckHandshakeAfter,
and is exposed as --reader-stall-after alongside --degraded-after.

Reopening a source entry also dropped status.lastSentAt: the rebuilt
entry carries no transfers, publishSourceProgress omits the field, and
server-side apply releases an omitted field for the apiserver to strip.
That erases the timestamp the target-side stuck-handshake watchdog
discriminates on, so a reopen disarms the target's only recovery path.
The fresh entry now inherits the published value, which is older than
the target's own fabricOpenedAt and so cannot trip the watchdog itself.

Verification: both behaviours are covered by unit tests that fail
against the unfixed code. Reverting the ReaderNotAdvancing branch fails
TestObservedState_ReaderNotAdvancing/head_frozen_past_window_without_transfers;
reverting the seed fails TestReconcile_PreservesLastSentAtAcrossReopen
on "a rebuilt entry must inherit the published lastSentAt". The full
gateway suite runs green in the go-mxl-builder image, and the KIND
suite passes all 15 cases on a clean cluster.

No KIND case covers the stall. Staging it needs a reader open on a flow
whose producer is alive but unreadable; deleting the writer instead
makes the operator tear the mirror down before the window elapses,
which is the behaviour 80-origin-lease-expiry already asserts.

feat(api): add ReaderNotAdvancing condition reason