### PR TITLE
fix(shim): report a producer attach only on the flow data file

### DIFF
--- a/charts/mxl-k8s/templates/rbac-operator.yaml
+++ b/charts/mxl-k8s/templates/rbac-operator.yaml
@@ -18,8 +18,13 @@ rules:
     resources: [leases]
     verbs: [get, list, watch]
   - apiGroups: [mxl.qvest-digital.com]
-    resources: [mxldomains, mxlflows, mxlnodecapabilities]
+    resources: [mxldomains, mxlnodecapabilities]
     verbs: [get, list, watch]
+  # delete collects a flow once no node holds a copy of it and no
+  # mirror needs its definition.
+  - apiGroups: [mxl.qvest-digital.com]
+    resources: [mxlflows]
+    verbs: [delete, get, list, watch]
   - apiGroups: [mxl.qvest-digital.com]
     resources: [mxldomains/status, mxlnodecapabilities/status]
     verbs: [get]

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,7 +25,6 @@ rules:
   - mxl.qvest-digital.com
   resources:
   - mxldomains
-  - mxlflows
   - mxlnodecapabilities
   verbs:
   - get
@@ -67,6 +66,15 @@ rules:
   - get
   - patch
   - update
+- apiGroups:
+  - mxl.qvest-digital.com
+  resources:
+  - mxlflows
+  verbs:
+  - delete
+  - get
+  - list
+  - watch
 - apiGroups:
   - mxl.qvest-digital.com
   resources:

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -63,6 +63,22 @@ var errAddTargetFailed = errors.New("AddTarget failed")
 // TODO(go-mxl): swap to typed sentinel when wrapper exposes one.
 const readerAgedOutMarker = "out of range (too late)"
 
+// maxReaderRebuilds bounds the number of consecutive reader reopens
+// the stall watchdog performs for one mirror. Past the cap the
+// gateway keeps the entry in place and publishes
+// ReasonReaderRebuildCapReached, so a flow whose producer is
+// genuinely gone stops costing a reopen every stall window. The
+// counter is cleared as soon as a grain transfers, so it counts
+// consecutive failed reopens rather than lifetime ones.
+const maxReaderRebuilds = 5
+
+// ReasonReaderRebuildCapReached marks a mirror whose source-side
+// reader stayed wedged across maxReaderRebuilds consecutive reopens.
+// Distinct from ReasonReaderNotAdvancing: that one is the
+// recoverable observation, this one says the gateway has stopped
+// reopening the reader.
+const ReasonReaderRebuildCapReached = "ReaderRebuildCapReached"
+
 // SourceReconciler reconciles MxlFlowMirror resources from the
 // sending side. See the package doc.
 type SourceReconciler struct {
@@ -108,9 +124,20 @@ type SourceReconciler struct {
 	// later caller could redirect.
 	opener initiatorOpener
 
+	// rebuildFn is the seam the reader-stall watchdog uses to spawn
+	// its reopen. Production leaves it nil and the flusher invokes
+	// rebuildWedgedReader directly; tests inject a recorder so they
+	// can assert the watchdog fired without driving a real libmxl
+	// reader. Mirrors the target reconciler's recoverFn.
+	rebuildFn func(key types.NamespacedName)
+
 	mu       sync.Mutex
 	sources  map[types.NamespacedName]*sourceEntry
 	attempts map[types.NamespacedName]uint32
+	// rebuilds counts consecutive reader reopens per mirror. It
+	// outlives the sourceEntry the watchdog tears down, which is the
+	// point: the budget has to survive the reopen it is bounding.
+	rebuilds map[types.NamespacedName]uint32
 }
 
 // sourceEntry holds the live libmxl + fabrics handles and the
@@ -167,6 +194,11 @@ type sourceEntry struct {
 	// published into r.sources under r.mu -- safe to read from
 	// Reconcile without its own synchronization, same as infoStr.
 	openedAt time.Time
+
+	// rebuilding is set by the reader-stall watchdog before it hands
+	// the entry to the reopen goroutine, so a second flusher tick
+	// cannot spawn a competing rebuild for the same entry.
+	rebuilding atomic.Bool
 
 	// cancel stops the per-flow transfer goroutine; done is closed
 	// when the goroutine returns.
@@ -1067,6 +1099,47 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 		case <-t.C:
 		}
 		state := observedState(entry, r.readerStallAfter())
+
+		// A reader whose head never moves is the one wedge neither
+		// side of the mirror resolves on its own. The target's
+		// stuck-handshake watchdog is gated on status.lastSentAt
+		// postdating its own fabric open, and a reader that has
+		// transferred nothing never advances lastSentAt, so the
+		// target reads the mirror as an idle producer and declines to
+		// rebuild. Reporting the wedge and waiting for the other side
+		// leaves the mirror Degraded indefinitely; reopening the
+		// reader here is what ends it.
+		if state.reason == mxlv1alpha1.ReasonReaderNotAdvancing {
+			switch {
+			case r.readerRebuildsExhausted(key):
+				state.reason = ReasonReaderRebuildCapReached
+				state.message = fmt.Sprintf(
+					"reader head stuck at %d across %d reopens",
+					entry.lastHead.Load(), maxReaderRebuilds)
+			case entry.rebuilding.CompareAndSwap(false, true):
+				attempt := r.bumpReaderRebuilds(key)
+				if err := r.publishSourceProgress(ctx, key, state); err != nil {
+					ctrl.Log.WithName("source-flush").Error(err, "publish",
+						"mirror", key, "reason", state.reason)
+				}
+				ctrl.Log.WithName("source-flush").Info(
+					"reader head stuck; reopening reader",
+					"mirror", key, "attempt", attempt)
+				// Returning first is what makes the reopen safe:
+				// closeSourceHandles waits on flusherDone, and this
+				// goroutine is the one that closes it.
+				go r.dispatchReaderRebuild(key)
+				return
+			default:
+				// A reopen is already in flight for this entry.
+				continue
+			}
+		}
+		if state.status == metav1.ConditionTrue &&
+			state.reason == mxlv1alpha1.ReasonRecovered {
+			r.clearReaderRebuilds(key)
+		}
+
 		if !first && sourceStateEqual(state, last) {
 			continue
 		}
@@ -1077,6 +1150,61 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 		}
 		last = state
 		first = false
+	}
+}
+
+// bumpReaderRebuilds records one more consecutive reopen for key and
+// returns the new count.
+func (r *SourceReconciler) bumpReaderRebuilds(key types.NamespacedName) uint32 {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.rebuilds == nil {
+		r.rebuilds = make(map[types.NamespacedName]uint32)
+	}
+	r.rebuilds[key]++
+	return r.rebuilds[key]
+}
+
+// readerRebuildsExhausted reports whether key has used its reopen
+// budget.
+func (r *SourceReconciler) readerRebuildsExhausted(key types.NamespacedName) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.rebuilds[key] >= maxReaderRebuilds
+}
+
+// clearReaderRebuilds returns key's full reopen budget. Called once
+// grains flow again, so a mirror that wedges later is not judged on
+// a stall it already recovered from.
+func (r *SourceReconciler) clearReaderRebuilds(key types.NamespacedName) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.rebuilds, key)
+}
+
+func (r *SourceReconciler) dispatchReaderRebuild(key types.NamespacedName) {
+	if r.rebuildFn != nil {
+		r.rebuildFn(key)
+		return
+	}
+	r.rebuildWedgedReader(context.Background(), key)
+}
+
+// rebuildWedgedReader drops the wedged reader and initiator and runs
+// one reconcile to open fresh ones.
+//
+// Reconcile does the reopen rather than this function: it already
+// owns provider resolution, the AddTarget attempt counter and the
+// flusher handoff, and a second open path here would be a copy of
+// all three that could drift. Driving it directly instead of waiting
+// for a watch keeps the recovery self-contained -- the events that
+// would otherwise wake the reconciler (origin Lease renewals, MxlFlow
+// status writes) all stop precisely when the producer is in trouble.
+func (r *SourceReconciler) rebuildWedgedReader(ctx context.Context, key types.NamespacedName) {
+	r.closeEntry(key)
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err != nil {
+		ctrl.Log.WithName("source-flush").Error(err, "reopen source reader",
+			"mirror", key)
 	}
 }
 
@@ -1196,6 +1324,9 @@ func (r *SourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	if r.attempts == nil {
 		r.attempts = make(map[types.NamespacedName]uint32)
+	}
+	if r.rebuilds == nil {
+		r.rebuilds = make(map[types.NamespacedName]uint32)
 	}
 	if r.APIReader == nil {
 		r.APIReader = mgr.GetAPIReader()

--- a/gateway/internal/mirror/source_stall_test.go
+++ b/gateway/internal/mirror/source_stall_test.go
@@ -201,3 +201,143 @@ func TestReconcile_PreservesLastSentAtAcrossReopen(t *testing.T) {
 		"the next publish must still carry lastSentAt so SSA does not strip it")
 	assert.True(t, state.lastSentAt.Equal(sentAt.Time))
 }
+
+func TestRunFlusher_ReopensWedgedReader(t *testing.T) {
+	// The wedge neither side resolves alone: the target's watchdog is
+	// gated on status.lastSentAt postdating its own fabric open, and a
+	// reader that has transferred nothing never advances lastSentAt,
+	// so the target treats the mirror as an idle producer. Publishing
+	// ReaderNotAdvancing and waiting leaves it Degraded forever.
+	scheme := newSourceTestScheme(t)
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", "flow-1", "info-1")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	rebuilt := make(chan types.NamespacedName, 4)
+	r := &SourceReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: "node-a",
+		sources:  map[types.NamespacedName]*sourceEntry{},
+		attempts: map[types.NamespacedName]uint32{},
+		rebuilds: map[types.NamespacedName]uint32{},
+		rebuildFn: func(key types.NamespacedName) {
+			rebuilt <- key
+		},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	entry := stalledEntry(42, ptrTime(time.Now().Add(-time.Minute)), 0)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+
+	select {
+	case got := <-rebuilt:
+		assert.Equal(t, key, got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("a wedged reader must be reopened, not just reported")
+	}
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the flusher must return before the reopen tears the entry down")
+	}
+
+	assert.Equal(t, uint32(1), r.rebuilds[key],
+		"the reopen must consume exactly one unit of budget")
+
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &got))
+	require.Len(t, got.Status.Conditions, 1)
+	assert.Equal(t, mxlv1alpha1.ReasonReaderNotAdvancing, got.Status.Conditions[0].Reason,
+		"the wedge stays visible on status while the reopen runs")
+}
+
+func TestRunFlusher_StopsReopeningAtCap(t *testing.T) {
+	// A flow whose producer is genuinely gone would otherwise cost a
+	// reopen every stall window for as long as the mirror exists.
+	scheme := newSourceTestScheme(t)
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", "flow-1", "info-1")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	r := &SourceReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: "node-a",
+		sources:  map[types.NamespacedName]*sourceEntry{},
+		attempts: map[types.NamespacedName]uint32{},
+		rebuilds: map[types.NamespacedName]uint32{key: maxReaderRebuilds},
+		rebuildFn: func(types.NamespacedName) {
+			t.Error("no reopen may be spawned once the budget is spent")
+		},
+	}
+
+	entry := stalledEntry(42, ptrTime(time.Now().Add(-time.Minute)), 0)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		var got mxlv1alpha1.MxlFlowMirror
+		if err := c.Get(context.Background(), key, &got); err != nil {
+			return false
+		}
+		return len(got.Status.Conditions) == 1 &&
+			got.Status.Conditions[0].Reason == ReasonReaderRebuildCapReached
+	}, 5*time.Second, 10*time.Millisecond)
+
+	cancel()
+	<-done
+}
+
+func TestRunFlusher_ClearsRebuildBudgetOnProgress(t *testing.T) {
+	// The cap counts consecutive failed reopens. A mirror that
+	// recovered and wedges again later must get a full budget rather
+	// than inherit the spent one.
+	scheme := newSourceTestScheme(t)
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", "flow-1", "info-1")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	r := &SourceReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: "node-a",
+		sources:  map[types.NamespacedName]*sourceEntry{},
+		attempts: map[types.NamespacedName]uint32{},
+		rebuilds: map[types.NamespacedName]uint32{key: 3},
+	}
+
+	entry := stalledEntry(42, ptrTime(time.Now()), 5)
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		_, still := r.rebuilds[key]
+		return !still
+	}, 5*time.Second, 10*time.Millisecond)
+
+	cancel()
+	<-done
+}
+
+func ptrTime(t time.Time) *time.Time { return &t }

--- a/operator/cmd/mxl-operator/main.go
+++ b/operator/cmd/mxl-operator/main.go
@@ -66,7 +66,11 @@ func main() {
 		setup func(ctrl.Manager) error
 	}{
 		{"MxlDomain", (&domain.Reconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()}).SetupWithManager},
-		{"MxlFlow", (&flow.Reconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()}).SetupWithManager},
+		{"MxlFlow", (&flow.Reconciler{
+			Client: mgr.GetClient(),
+			Scheme: mgr.GetScheme(),
+			Lease:  &leasecheck.Checker{Client: mgr.GetClient()},
+		}).SetupWithManager},
 		{"MxlFlowMirror", (&mirror.Reconciler{Client: mgr.GetClient(), Scheme: mgr.GetScheme()}).SetupWithManager},
 		{"MxlReceiver", (&receiver.Reconciler{
 			Client:    mgr.GetClient(),

--- a/operator/internal/flow/collect_test.go
+++ b/operator/internal/flow/collect_test.go
@@ -1,0 +1,230 @@
+package flow
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// A flow the agent demoted to Stale describes nothing: no node holds a
+// copy, so resolveSourceNode cannot answer from it and no consumer can
+// be routed to it. Nothing removed those before, so the flow list grew
+// for the life of the cluster.
+
+type fakeLease struct {
+	fresh    map[string]bool
+	deadline time.Time
+	err      error
+}
+
+func (f *fakeLease) IsFresh(_ context.Context, flowID, nodeName string) (bool, time.Time, error) {
+	if f.err != nil {
+		return false, time.Time{}, f.err
+	}
+	return f.fresh[flowID+"/"+nodeName], f.deadline, nil
+}
+
+func staleFlow(locs ...mxlv1alpha1.MxlFlowLocation) *mxlv1alpha1.MxlFlow {
+	return newFlow(locs...)
+}
+
+func mirrorFor(flowID string) *mxlv1alpha1.MxlFlowMirror {
+	return &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{Name: "m1", Namespace: "ns1"},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID: flowID, SourceNode: "n1", TargetNode: "n2",
+		},
+	}
+}
+
+func TestCollect_DeletesFlowWithNoCopyAndNoMirror(t *testing.T) {
+	scheme := newScheme(t)
+	flow := staleFlow(
+		mxlv1alpha1.MxlFlowLocation{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationStale},
+		mxlv1alpha1.MxlFlowLocation{NodeName: "n2", Phase: mxlv1alpha1.MxlFlowLocationStale},
+	)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy(), node("n1"), node("n2")).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme, Lease: &fakeLease{}, GracePeriod: time.Hour}
+	key := types.NamespacedName{Name: flow.Name}
+	req := ctrl.Request{NamespacedName: key}
+
+	// First sighting only starts the clock: a producer rolling over
+	// looks exactly like this between releasing and republishing.
+	res, err := r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	assert.Positive(t, res.RequeueAfter, "the grace period has to be waited out")
+	require.NoError(t, c.Get(context.Background(), key, &mxlv1alpha1.MxlFlow{}),
+		"the flow must survive its first collectable sighting")
+
+	// Reaching back past the grace period stands in for waiting it out.
+	r.mu.Lock()
+	r.firstCollectable[flow.Name] = time.Now().Add(-2 * time.Hour)
+	r.mu.Unlock()
+
+	_, err = r.Reconcile(context.Background(), req)
+	require.NoError(t, err)
+	err = c.Get(context.Background(), key, &mxlv1alpha1.MxlFlow{})
+	assert.True(t, apierrors.IsNotFound(err), "want the flow collected, got %v", err)
+}
+
+func TestCollect_KeepsFlowWithLiveOrigin(t *testing.T) {
+	scheme := newScheme(t)
+	flow := staleFlow(
+		mxlv1alpha1.MxlFlowLocation{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+		mxlv1alpha1.MxlFlowLocation{NodeName: "n2", Phase: mxlv1alpha1.MxlFlowLocationStale},
+	)
+	deadline := time.Now().Add(30 * time.Second)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy(), node("n1"), node("n2")).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme, GracePeriod: time.Nanosecond, Lease: &fakeLease{
+		fresh:    map[string]bool{flow.Spec.ID + "/n1": true},
+		deadline: deadline,
+	}}
+
+	res, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: flow.Name}})
+	require.NoError(t, err)
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: flow.Name}, &mxlv1alpha1.MxlFlow{}))
+	assert.Positive(t, res.RequeueAfter,
+		"a flow held alive by a Lease has to be re-examined when it lapses")
+}
+
+func TestCollect_KeepsFlowWithStaleOriginButLiveMirror(t *testing.T) {
+	// The target gateway reads spec.definition to open its writer, so
+	// deleting a mirrored flow would break the consumer the mirror
+	// exists for, producer or no producer.
+	scheme := newScheme(t)
+	flow := staleFlow(
+		mxlv1alpha1.MxlFlowLocation{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationStale},
+	)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy(), node("n1"), mirrorFor(flow.Spec.ID)).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme, Lease: &fakeLease{}, GracePeriod: time.Nanosecond}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: flow.Name}})
+	require.NoError(t, err)
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: flow.Name}, &mxlv1alpha1.MxlFlow{}))
+}
+
+func TestCollect_KeepsFlowWithReadyLocation(t *testing.T) {
+	scheme := newScheme(t)
+	flow := staleFlow(
+		mxlv1alpha1.MxlFlowLocation{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationStale},
+		mxlv1alpha1.MxlFlowLocation{NodeName: "n2", Phase: mxlv1alpha1.MxlFlowLocationReady},
+	)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy(), node("n1"), node("n2")).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme, Lease: &fakeLease{}, GracePeriod: time.Nanosecond}
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: types.NamespacedName{Name: flow.Name}})
+	require.NoError(t, err)
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: flow.Name}, &mxlv1alpha1.MxlFlow{}))
+}
+
+func TestCollect_ClockRestartsWhenTheFlowComesBack(t *testing.T) {
+	// A producer that returns inside the grace period must not be
+	// judged on the window it was away for.
+	scheme := newScheme(t)
+	flow := staleFlow(
+		mxlv1alpha1.MxlFlowLocation{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationStale},
+	)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy(), node("n1")).
+		Build()
+
+	lease := &fakeLease{}
+	r := &Reconciler{Client: c, Scheme: scheme, Lease: lease, GracePeriod: time.Hour}
+	key := types.NamespacedName{Name: flow.Name}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	r.mu.Lock()
+	_, marked := r.firstCollectable[flow.Name]
+	r.mu.Unlock()
+	require.True(t, marked)
+
+	var live mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), key, &live))
+	live.Status.Locations = []mxlv1alpha1.MxlFlowLocation{{
+		NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin,
+	}}
+	require.NoError(t, c.Status().Update(context.Background(), &live))
+	lease.fresh = map[string]bool{flow.Spec.ID + "/n1": true}
+	lease.deadline = time.Now().Add(30 * time.Second)
+
+	_, err = r.Reconcile(context.Background(), ctrl.Request{NamespacedName: key})
+	require.NoError(t, err)
+	r.mu.Lock()
+	_, stillMarked := r.firstCollectable[flow.Name]
+	r.mu.Unlock()
+	assert.False(t, stillMarked, "a flow that came back must lose its collectable mark")
+}
+
+func TestMirrorToFlow(t *testing.T) {
+	got := mirrorToFlow(context.Background(), mirrorFor("flow-1"))
+	require.Len(t, got, 1)
+	assert.Equal(t, "flow-1", got[0].Name)
+	assert.Empty(t, mirrorToFlow(context.Background(), node("n1")))
+}
+
+func TestCollect_StaleReadDoesNotDeleteARepublishedFlow(t *testing.T) {
+	// The grace period is decided against a read of the flow; an agent
+	// republishing between that read and the delete must keep its
+	// flow.
+	scheme := newScheme(t)
+	flow := staleFlow(
+		mxlv1alpha1.MxlFlowLocation{NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationStale},
+	)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(flow.DeepCopy(), node("n1")).
+		Build()
+
+	r := &Reconciler{Client: c, Scheme: scheme, Lease: &fakeLease{}, GracePeriod: time.Hour}
+	key := types.NamespacedName{Name: flow.Name}
+
+	var read mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), key, &read))
+	r.mu.Lock()
+	r.firstCollectable = map[string]time.Time{flow.Name: time.Now().Add(-2 * time.Hour)}
+	r.mu.Unlock()
+
+	// Republish under the collector's feet.
+	var live mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(), key, &live))
+	live.Status.Locations = []mxlv1alpha1.MxlFlowLocation{{
+		NodeName: "n1", Phase: mxlv1alpha1.MxlFlowLocationOrigin,
+	}}
+	require.NoError(t, c.Status().Update(context.Background(), &live))
+
+	_, err := r.collect(context.Background(), &read)
+	require.Error(t, err, "a delete against a superseded version must not succeed")
+	require.NoError(t, c.Get(context.Background(), key, &mxlv1alpha1.MxlFlow{}))
+}

--- a/operator/internal/flow/controller.go
+++ b/operator/internal/flow/controller.go
@@ -3,6 +3,8 @@ package flow
 import (
 	"context"
 	"fmt"
+	"sync"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -35,10 +37,45 @@ import (
 type Reconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
+
+	// Lease gates the Origin locations this reconciler trusts when
+	// deciding whether a flow still has a producer. Nil treats any
+	// Origin location as live, which keeps the collector off flows it
+	// cannot judge.
+	Lease LeaseChecker
+
+	// GracePeriod is how long a flow has to stay collectable before
+	// it is deleted. Zero means defaultGracePeriod.
+	GracePeriod time.Duration
+
+	mu sync.Mutex
+	// firstCollectable records when each flow was first observed with
+	// no producer and no mirror. Held in memory rather than on the
+	// object so the collector adds no field to the API and no write to
+	// a flow it may yet leave alone; an operator restart costs one
+	// extra grace period before the flow is collected, which a garbage
+	// collector can afford.
+	firstCollectable map[string]time.Time
 }
 
-// +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflows,verbs=get;list;watch
+// LeaseChecker reports whether the agent on nodeName still holds a
+// renewed origin Lease for flowID. Matches the receiver package's
+// interface of the same name so both consume one leasecheck.Checker.
+type LeaseChecker interface {
+	IsFresh(ctx context.Context, flowID, nodeName string) (fresh bool, deadline time.Time, err error)
+}
+
+// defaultGracePeriod is how long a flow must look collectable before
+// it is deleted. It has to outlast a producer rolling over: between
+// the old pod releasing its flow and the new one publishing again the
+// flow has no Origin, and deleting it in that window would take the
+// definition away from a consumer that is about to need it.
+const defaultGracePeriod = 5 * time.Minute
+
+// +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflows,verbs=get;list;watch;delete
 // +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflows/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflowmirrors,verbs=get;list;watch
+// +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch
 // +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 
 // Reconcile drops every status.locations entry whose node is absent
@@ -57,7 +94,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 	if len(departed) == 0 {
 		l.V(1).Info("observed MxlFlow", "id", obj.Spec.ID, "locations", len(obj.Status.Locations))
-		return ctrl.Result{}, nil
+		return r.collect(ctx, &obj)
 	}
 
 	// An agent rewrites its own entry on its own schedule, so this
@@ -90,6 +127,139 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	l.Info("pruned MxlFlow locations for departed nodes",
 		"id", obj.Spec.ID, "nodes", departedNames(departed))
 	return ctrl.Result{}, nil
+}
+
+// collect deletes an MxlFlow that no longer describes anything: no
+// node holds a copy the control plane can route a consumer to, and no
+// mirror needs its definition.
+//
+// Nothing else removes these. The agent demotes its own location to
+// Stale when the directory goes away but leaves the object, and the
+// prune above only drops entries for nodes that left the cluster, so
+// on a cluster whose producers come and go the flow list grows
+// without bound. Every one of those entries is a name resolveSourceNode
+// walks and an OriginFresh condition the operator keeps evaluating.
+//
+// Deleting is safe because the object is derived state: an agent that
+// still has the flow on disk republishes it from flow_def.json on its
+// next pass, so a flow collected while its producer was mid-restart
+// comes back with the same name and spec.
+func (r *Reconciler) collect(ctx context.Context, flow *mxlv1alpha1.MxlFlow) (ctrl.Result, error) {
+	live, deadline, err := r.hasLiveCopy(ctx, flow)
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !live {
+		var mirrors mxlv1alpha1.MxlFlowMirrorList
+		if err := r.List(ctx, &mirrors); err != nil {
+			return ctrl.Result{}, fmt.Errorf("list MxlFlowMirrors: %w", err)
+		}
+		for i := range mirrors.Items {
+			if mirrors.Items[i].Spec.FlowID == flow.Spec.ID {
+				live = true
+				break
+			}
+		}
+	}
+
+	if live {
+		r.forget(flow.Name)
+		// A Lease falling out of its window raises no event, so a flow
+		// held alive only by one has to be looked at again by the
+		// clock. Mirrors and their deletions arrive on the watch.
+		if !deadline.IsZero() {
+			if wait := time.Until(deadline); wait > 0 {
+				return ctrl.Result{RequeueAfter: wait}, nil
+			}
+			return ctrl.Result{Requeue: true}, nil
+		}
+		return ctrl.Result{}, nil
+	}
+
+	grace := r.GracePeriod
+	if grace <= 0 {
+		grace = defaultGracePeriod
+	}
+	if since := time.Since(r.markCollectable(flow.Name)); since < grace {
+		return ctrl.Result{RequeueAfter: grace - since}, nil
+	}
+
+	// Preconditioned on the version the decision was made against: an
+	// agent republishing the flow between the read above and here
+	// makes the delete fail rather than drop a flow that just came
+	// back. The conflict returns the object to the queue.
+	err = r.Delete(ctx, flow, client.Preconditions{
+		UID:             &flow.UID,
+		ResourceVersion: &flow.ResourceVersion,
+	})
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			r.forget(flow.Name)
+			return ctrl.Result{}, nil
+		}
+		return ctrl.Result{}, fmt.Errorf("delete MxlFlow %s: %w", flow.Name, err)
+	}
+	r.forget(flow.Name)
+	log.FromContext(ctx).Info("collected MxlFlow with no copy and no mirror",
+		"id", flow.Spec.ID)
+	return ctrl.Result{}, nil
+}
+
+// hasLiveCopy reports whether any node still holds a copy of the flow
+// a consumer could be routed to: an Origin whose Lease is being
+// renewed, or a materialized mirror the target gateway has published.
+// A Stale location is neither. The returned deadline is the moment the
+// sustaining Lease lapses, and is zero when the answer does not rest
+// on one.
+func (r *Reconciler) hasLiveCopy(ctx context.Context, flow *mxlv1alpha1.MxlFlow) (bool, time.Time, error) {
+	var soonest time.Time
+	live := false
+	for _, loc := range flow.Status.Locations {
+		switch loc.Phase {
+		case mxlv1alpha1.MxlFlowLocationReady, mxlv1alpha1.MxlFlowLocationMirroring:
+			return true, time.Time{}, nil
+		case mxlv1alpha1.MxlFlowLocationOrigin:
+			if r.Lease == nil {
+				return true, time.Time{}, nil
+			}
+			fresh, deadline, err := r.Lease.IsFresh(ctx, flow.Spec.ID, loc.NodeName)
+			if err != nil {
+				return false, time.Time{}, fmt.Errorf("check origin lease for %s on %s: %w",
+					flow.Spec.ID, loc.NodeName, err)
+			}
+			if !fresh {
+				continue
+			}
+			live = true
+			if soonest.IsZero() || deadline.After(soonest) {
+				soonest = deadline
+			}
+		}
+	}
+	return live, soonest, nil
+}
+
+// markCollectable records the first time name was seen collectable and
+// returns that instant, so the grace period measures how long the flow
+// has been unreferenced rather than how old it is.
+func (r *Reconciler) markCollectable(name string) time.Time {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.firstCollectable == nil {
+		r.firstCollectable = make(map[string]time.Time)
+	}
+	if at, ok := r.firstCollectable[name]; ok {
+		return at
+	}
+	now := time.Now()
+	r.firstCollectable[name] = now
+	return now
+}
+
+func (r *Reconciler) forget(name string) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	delete(r.firstCollectable, name)
 }
 
 // departedNodes returns the node names in locs that have no Node
@@ -139,6 +309,10 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.nodeToFlows),
 			builder.WithPredicates(nodeDeletedOnly()),
 		).
+		Watches(
+			&mxlv1alpha1.MxlFlowMirror{},
+			handler.EnqueueRequestsFromMapFunc(mirrorToFlow),
+		).
 		Named("mxlflow").
 		Complete(r)
 }
@@ -169,6 +343,20 @@ func (r *Reconciler) nodeToFlows(ctx context.Context, obj client.Object) []recon
 		}
 	}
 	return out
+}
+
+// mirrorToFlow enqueues the MxlFlow a mirror references. The
+// collector treats a mirror as a reason to keep the flow, so the
+// mirror going away is the event that can make the flow collectable,
+// and it raises nothing on the flow itself.
+func mirrorToFlow(_ context.Context, obj client.Object) []reconcile.Request {
+	mirror, ok := obj.(*mxlv1alpha1.MxlFlowMirror)
+	if !ok || mirror.Spec.FlowID == "" {
+		return nil
+	}
+	return []reconcile.Request{{
+		NamespacedName: types.NamespacedName{Name: mirror.Spec.FlowID},
+	}}
 }
 
 // nodeDeletedOnly limits the Node watch to deletions. Node objects

--- a/shim/libmxl-intent.c
+++ b/shim/libmxl-intent.c
@@ -30,13 +30,15 @@
  * Outside the narrow flow_def.json path the hooks fall straight
  * through to the kernel.
  *
- * The hooks also report the reverse case. A successful open of a
- * path under <uuid>.mxl-flow with write intent and without O_CREAT
- * means a local producer attached to a flow that already existed,
- * which libmxl reaches via openFlow(..., READ_WRITE) and which
- * raises no filesystem event the agent can watch. The shim sends
+ * The hooks also report the reverse case. A successful open of
+ * <uuid>.mxl-flow/data with write intent and without O_CREAT means
+ * a local producer attached to a flow that already existed, which
+ * libmxl reaches via openFlow(..., READ_WRITE) and which raises no
+ * filesystem event the agent can watch. The shim sends
  * `{"path":"<absolute path>","event":"attached"}\n` and does not
  * wait for the reply, so the producer's open is never delayed.
+ * Only that one file discriminates: a FlowReader opens it read-only
+ * but takes the access file in the same directory O_RDWR.
  */
 
 #define _GNU_SOURCE
@@ -58,6 +60,7 @@
 #define DEFAULT_SOCK_PATH "/run/mxl/agent.sock"
 #define SOCK_ENV "MXL_INTENT_SOCK"
 #define FLOW_SUFFIX ".mxl-flow"
+#define FLOW_DATA_NAME "data"
 
 static int sys_openat(int dirfd, const char *pathname, int flags, mode_t mode)
 {
@@ -106,6 +109,36 @@ static bool is_flow_path(const char *path)
 		}
 	}
 	return false;
+}
+
+/* Return true when path names the shared-memory segment of a flow
+ * directory, i.e. <id>.mxl-flow/data. That file is the one a write
+ * attach has to be judged on: libmxl opens it O_RDWR only for a
+ * FlowWriter, and O_RDONLY for a FlowReader. Every other entry
+ * under the directory is opened O_RDWR by readers too -- the
+ * access file carries each reader's last-read timestamp -- so a
+ * directory-level match cannot tell a producer from a consumer.
+ *
+ * The grain segments are named data.<n> under a grains/
+ * subdirectory, so requiring the last component to be exactly
+ * "data" directly below the flow directory excludes them as well.
+ * No filesystem access -- pure string inspection. */
+static bool is_flow_data_path(const char *path)
+{
+	if (!path || path[0] != '/') return false;
+
+	const char *slash = strrchr(path, '/');
+	if (!slash || strcmp(slash + 1, FLOW_DATA_NAME) != 0) return false;
+
+	/* Walk back over the parent component and require it to end in
+	 * the flow-directory suffix. */
+	size_t sfx = strlen(FLOW_SUFFIX);
+	const char *end = slash;
+	while (end > path && end[-1] == '/') end--;
+	const char *start = end;
+	while (start > path && start[-1] != '/') start--;
+	size_t complen = (size_t)(end - start);
+	return complen > sfx && memcmp(end - sfx, FLOW_SUFFIX, sfx) == 0;
 }
 
 /* Send one line-delimited JSON request to the agent. When
@@ -286,7 +319,7 @@ int openat(int dirfd, const char *pathname, int flags, ...)
 
 	int fd = sys_openat(dirfd, pathname, flags, mode);
 	if (fd >= 0) {
-		if (is_write_attach(flags) && is_flow_path(pathname)) {
+		if (is_write_attach(flags) && is_flow_data_path(pathname)) {
 			int saved = errno;
 			notify_attached(pathname);
 			errno = saved;
@@ -329,7 +362,7 @@ int open(const char *pathname, int flags, ...)
 
 	int fd = sys_openat(AT_FDCWD, pathname, flags, mode);
 	if (fd >= 0) {
-		if (is_write_attach(flags) && is_flow_path(pathname)) {
+		if (is_write_attach(flags) && is_flow_data_path(pathname)) {
 			int saved = errno;
 			notify_attached(pathname);
 			errno = saved;


### PR DESCRIPTION
Three defects that each leave a flow permanently wrong after its
producer restarts or moves.

A consumer announced itself as a producer. The shim treated write
intent on any path under `<id>.mxl-flow` as a producer attach, but
libmxl opens the flow's access file `O_RDWR` from every FlowReader to
stamp each read. Any node running a consumer therefore recorded Origin
for a flow whose only local copy was a mirror, published an origin
Lease for it and kept renewing it, so `resolveSourceNode` could answer
a materialization request with a mirror instead of the writer. Only
`<id>.mxl-flow/data` tells the two apart.

A wedged source reader was named but never reopened. A reader left on
a ring its writer has abandoned reports a head that never moves and
transfers nothing. The target's stuck-handshake watchdog rebuilds only
when `status.lastSentAt` postdates its own fabric open, and a reader
that transferred nothing never advances `lastSentAt`, so the target
classifies the mirror as an idle producer and leaves it alone.
`ReaderNotAdvancing` described that state without ending it and the
mirror stayed Degraded with both ends waiting on the other. Reopens
are capped and the budget is returned as soon as a grain transfers, so
a flow whose producer is gone settles on `ReaderRebuildCapReached`
instead of reopening a reader every stall window.

Flows nothing holds were never collected. The agent demotes its own
location to Stale when the directory goes away but leaves the MxlFlow,
and the existing prune only drops entries for nodes that left the
cluster, so the flow list grew for the life of the cluster. Collection
requires no Origin with a renewed Lease, no Ready or Mirroring
location, and no MxlFlowMirror referencing the flow, and waits out a
grace period first: a producer rolling over has no Origin between
releasing its flow and republishing it, and deleting there would take
the definition away from a consumer about to need it.

Not covered here: mirror teardown can delete a flow directory a local
producer created moments earlier, which needs a non-destructive
release that go-mxl does not expose. Filed as #219.

fix(gateway): reopen a source reader whose head stops advancing
feat(operator): collect flows no node holds and no mirror needs
