### PR TITLE
fix(gateway): keep a flow a local producer has taken over

### DIFF
--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/gateway
 go 1.26.0
 
 require (
-	github.com/qvest-digital/go-mxl v1.0.0-rc.10
+	github.com/qvest-digital/go-mxl v1.0.0-rc.11
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.7 // x-release-please-version
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -86,8 +86,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/qvest-digital/go-mxl v1.0.0-rc.10 h1:DxGlhRG8f07d2A6Py+wHncbYJvbYT/0CC5JUB/vBe6o=
-github.com/qvest-digital/go-mxl v1.0.0-rc.10/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.0.0-rc.11 h1:Vr/yA0AF7DOcUFmh5S3dRZqvRBiBhlXyj7ocLrPAH2M=
+github.com/qvest-digital/go-mxl v1.0.0-rc.11/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -274,7 +274,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		if !controllerutil.ContainsFinalizer(&mirror, TargetFinalizerName) {
 			return ctrl.Result{}, nil
 		}
-		r.closeEntry(req.NamespacedName)
+		r.closeEntry(req.NamespacedName, r.localFlowDisposition(ctx, mirror.Spec.FlowID))
 		controllerutil.RemoveFinalizer(&mirror, TargetFinalizerName)
 		if err := r.Update(ctx, &mirror); err != nil {
 			if apierrors.IsConflict(err) {
@@ -372,7 +372,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// Concurrent reconcile produced a stray entry; close the new
 		// one and reuse the existing.
 		r.mu.Unlock()
-		closeTargetHandles(entry)
+		closeTargetHandles(entry, keepFlow)
 		return ctrl.Result{}, nil
 	}
 	r.targets[req.NamespacedName] = entry
@@ -381,7 +381,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	if err := r.applyTargetStatus(ctx, &mirror, mxlv1alpha1.MxlFlowMirrorReady, &entry.infoStr, nil, nil); err != nil {
 		// Status update lost; close the entry so the next pass can
 		// retry cleanly.
-		r.closeEntry(req.NamespacedName)
+		r.closeEntry(req.NamespacedName, r.localFlowDisposition(ctx, mirror.Spec.FlowID))
 		return ctrl.Result{}, fmt.Errorf("update status: %w", err)
 	}
 
@@ -695,7 +695,7 @@ func commitArrivedSamples(writer *mxl.Writer, head uint64, count int) error {
 	return nil
 }
 
-func (r *TargetReconciler) closeEntry(key types.NamespacedName) {
+func (r *TargetReconciler) closeEntry(key types.NamespacedName, disp flowDisposition) {
 	r.mu.Lock()
 	entry := r.targets[key]
 	delete(r.targets, key)
@@ -703,7 +703,32 @@ func (r *TargetReconciler) closeEntry(key types.NamespacedName) {
 	if entry == nil {
 		return
 	}
-	closeTargetHandles(entry)
+	closeTargetHandles(entry, disp)
+}
+
+// localFlowDisposition decides what a teardown should do with the
+// local flow. A flow whose published Origin location names this node
+// belongs to a local producer: the mirror filled that directory until
+// the producer took it over, and offering it for deletion would take
+// the producer's flow with it.
+//
+// A lookup failure answers keepFlow. Reclaiming a mirror copy late
+// costs disk on one node until the next teardown; removing a live
+// producer's flow costs the flow.
+func (r *TargetReconciler) localFlowDisposition(ctx context.Context, flowID string) flowDisposition {
+	var flow mxlv1alpha1.MxlFlow
+	if err := r.Get(ctx, types.NamespacedName{Name: flowID}, &flow); err != nil {
+		if apierrors.IsNotFound(err) {
+			return dropFlow
+		}
+		return keepFlow
+	}
+	for _, loc := range flow.Status.Locations {
+		if loc.NodeName == r.NodeName && loc.Phase == mxlv1alpha1.MxlFlowLocationOrigin {
+			return keepFlow
+		}
+	}
+	return dropFlow
 }
 
 // dispatchRecovery routes the stuck-handshake watchdog's spawn
@@ -832,7 +857,23 @@ func (r *TargetReconciler) fetchMirror(ctx context.Context, key types.Namespaced
 	return &mirror, nil
 }
 
-func closeTargetHandles(e *targetEntry) {
+// flowDisposition says what should happen to the local flow when a
+// target entry's writer is given up.
+type flowDisposition bool
+
+const (
+	// dropFlow offers the flow for deletion. libmxl removes it when
+	// this writer turns out to be its last holder, which is what
+	// reclaims a mirror's copy once nothing needs it.
+	dropFlow flowDisposition = false
+	// keepFlow gives the writer up and leaves the flow in place. Used
+	// wherever something other than this entry owns the flow: another
+	// entry on this node, or a local producer that has taken over the
+	// flow the mirror was filling.
+	keepFlow flowDisposition = true
+)
+
+func closeTargetHandles(e *targetEntry, disp flowDisposition) {
 	if e.flusherCancel != nil {
 		e.flusherCancel()
 	}
@@ -852,7 +893,11 @@ func closeTargetHandles(e *targetEntry) {
 		_ = e.target.Close()
 	}
 	if e.writer != nil {
-		_ = e.writer.Close()
+		if disp == keepFlow {
+			_ = e.writer.Detach()
+		} else {
+			_ = e.writer.Close()
+		}
 	}
 }
 

--- a/gateway/internal/mirror/target_disposition_test.go
+++ b/gateway/internal/mirror/target_disposition_test.go
@@ -1,0 +1,82 @@
+package mirror
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// libmxl offers a flow for deletion when the writer being released is
+// its last holder, and performs that deletion by path. A mirror whose
+// flow has since been taken over by a local producer must therefore be
+// given up without offering it, or the producer loses its flow.
+
+func TestLocalFlowDisposition(t *testing.T) {
+	const node = "node-a"
+	const flowID = "11111111-2222-3333-4444-555555555555"
+
+	tests := []struct {
+		name string
+		locs []mxlv1alpha1.MxlFlowLocation
+		want flowDisposition
+	}{
+		{
+			name: "origin on this node",
+			locs: []mxlv1alpha1.MxlFlowLocation{
+				{NodeName: node, Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+			},
+			want: keepFlow,
+		},
+		{
+			name: "origin elsewhere",
+			locs: []mxlv1alpha1.MxlFlowLocation{
+				{NodeName: "node-b", Phase: mxlv1alpha1.MxlFlowLocationOrigin},
+				{NodeName: node, Phase: mxlv1alpha1.MxlFlowLocationReady},
+			},
+			want: dropFlow,
+		},
+		{
+			name: "this node only holds the mirror copy",
+			locs: []mxlv1alpha1.MxlFlowLocation{
+				{NodeName: node, Phase: mxlv1alpha1.MxlFlowLocationReady},
+			},
+			want: dropFlow,
+		},
+		{
+			name: "stale local location",
+			locs: []mxlv1alpha1.MxlFlowLocation{
+				{NodeName: node, Phase: mxlv1alpha1.MxlFlowLocationStale},
+			},
+			want: dropFlow,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			scheme := newSourceTestScheme(t)
+			flow := &mxlv1alpha1.MxlFlow{
+				ObjectMeta: metav1.ObjectMeta{Name: flowID},
+				Spec:       mxlv1alpha1.MxlFlowSpec{ID: flowID},
+				Status:     mxlv1alpha1.MxlFlowStatus{Locations: tc.locs},
+			}
+			c := fake.NewClientBuilder().WithScheme(scheme).WithObjects(flow).Build()
+			r := &TargetReconciler{Client: c, Scheme: scheme, NodeName: node}
+			assert.Equal(t, tc.want, r.localFlowDisposition(context.Background(), flowID))
+		})
+	}
+}
+
+func TestLocalFlowDisposition_MissingFlowDrops(t *testing.T) {
+	// No MxlFlow means no producer published one, so nothing on this
+	// node can be claiming the directory the mirror filled.
+	scheme := newSourceTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &TargetReconciler{Client: c, Scheme: scheme, NodeName: "node-a"}
+	assert.Equal(t, dropFlow,
+		r.localFlowDisposition(context.Background(), "11111111-2222-3333-4444-555555555555"))
+}


### PR DESCRIPTION
libmxl offers a flow for deletion when the writer being released is its
last holder. It decides that on the releasing writer's own descriptor
but performs the deletion by path, and a mirror's target-side writer
holds the same directory a producer scheduled onto the node then
creates its flow in. Tearing the mirror down removed the producer's
flow: the producer kept publishing into unlinked files and reported
nothing, while the domain lost the directory, `status.locations` for
the node went Stale with no Origin left anywhere, and consumers on that
node faulted on every open with nothing able to answer them.

Teardown now decides what to do with the local flow from the flow's
published Origin location. Naming this node means a local producer owns
the directory, so the writer is detached: given up without offering the
flow. Everywhere else the mirror's own copy is reclaimed exactly as
before. A lookup that fails answers keep, because a mirror copy left
behind costs disk on one node until the next teardown while a wrongly
deleted flow costs the flow.

The duplicate-entry and failed-status paths detach for the same reason:
in both, something other than the entry being closed holds the flow it
would otherwise offer.

Detach comes from go-mxl v1.0.0-rc.11, which holds a shared lock on the
flow's data file for the writer's lifetime and releases the writer with
that lock still held, so libmxl's exclusive-lock upgrade fails and the
delete is skipped. The upstream C API has no non-destructive release to
call instead, and the paths involved are unchanged on libmxl main.

closes #219
