### PR TITLE
deps(gateway): move onto go-mxl 1.0.0-rc.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.10
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.12
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -270,7 +270,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.10
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.12
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7

--- a/docker/demo-tools.Dockerfile
+++ b/docker/demo-tools.Dockerfile
@@ -12,7 +12,7 @@
 #   docker build -f docker/demo-tools.Dockerfile -t local/mxl-demo-tools:dev .
 
 # renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
-ARG GO_MXL_TAG=1.0.0-rc.9
+ARG GO_MXL_TAG=1.0.0-rc.12
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 ARG GO_MXL_TAG

--- a/docker/gateway.Dockerfile
+++ b/docker/gateway.Dockerfile
@@ -5,7 +5,7 @@
 # Build context: repo root.
 
 # renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
-ARG GO_MXL_TAG=1.0.0-rc.10
+ARG GO_MXL_TAG=1.0.0-rc.12
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 WORKDIR /workspace

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/gateway
 go 1.26.0
 
 require (
-	github.com/qvest-digital/go-mxl v1.0.0-rc.11
+	github.com/qvest-digital/go-mxl v1.0.0-rc.12
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.7 // x-release-please-version
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -86,8 +86,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/qvest-digital/go-mxl v1.0.0-rc.11 h1:Vr/yA0AF7DOcUFmh5S3dRZqvRBiBhlXyj7ocLrPAH2M=
-github.com/qvest-digital/go-mxl v1.0.0-rc.11/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.0.0-rc.12 h1:DtkhrgtXCw504MhuAvROQsy9KndKevWQpG0BujCzZcQ=
+github.com/qvest-digital/go-mxl v1.0.0-rc.12/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=


### PR DESCRIPTION
Builder image, runtime image and the Go module move together: the
gateway mmaps the same flow files libmxl writes, so a gateway built
against one libmxl and a producer built against another disagree on the
on-disk layout.

go-mxl 1.0.0-rc.12 carries libmxl from upstream main. Two things in that
range reach this repository.

A fabrics setup that requests no transfer capability is now rejected
where it used to be defaulted to remote write. `Target.Setup` and
`Initiator.Setup` here both leave `InterfaceConfig.Caps` unset, so
without the default go-mxl now applies, every mirror setup would fail.
Nothing in this diff has to carry the flag.

`mxlFabricsProviderFromString` accepts `"any"` from this libmxl on.
`providerForSetup` refuses the auto sentinel against this repository's
own CRD enum rather than a parse failure, so the guard is unaffected.

The core libmxl C API is unchanged across the range.