### PR TITLE
fix(gateway): select the fabric interface before setup

### DIFF
--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/gateway
 go 1.26.0
 
 require (
-	github.com/qvest-digital/go-mxl v1.0.0-rc.12
+	github.com/qvest-digital/go-mxl v1.0.0-rc.13
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.7 // x-release-please-version
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -86,8 +86,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/qvest-digital/go-mxl v1.0.0-rc.12 h1:DtkhrgtXCw504MhuAvROQsy9KndKevWQpG0BujCzZcQ=
-github.com/qvest-digital/go-mxl v1.0.0-rc.12/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.0.0-rc.13 h1:nkZHf6+O9Tfrw2Ciwncewyv6lxqXhPtUcT4r5YBJLUE=
+github.com/qvest-digital/go-mxl v1.0.0-rc.13/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/gateway/internal/mirror/common.go
+++ b/gateway/internal/mirror/common.go
@@ -69,3 +69,50 @@ func providerForSetup(m *mxlv1alpha1.MxlFlowMirror) (fabrics.Provider, error) {
 	}
 	return mapProvider(m.Spec.Provider), nil
 }
+
+// errNoInterface reports that no local fabric interface can carry a
+// transfer for the requested provider.
+var errNoInterface = errors.New("no usable fabric interface")
+
+// resolveInterface asks libmxl-fabrics what this host offers and
+// returns the entry a setup should be given.
+//
+// A setup handed a config with no address leaves interface resolution
+// to fi_getinfo, which answers ENODATA on a fabric that needs a
+// concrete source address, and the setup fails with nothing naming the
+// cause. Enumerating first is how libmxl-fabrics expects the question
+// to be answered: the entry it returns carries the provider's own
+// address and capabilities, including the maxMessageSize a caller
+// cannot otherwise learn.
+//
+// bindAddress narrows the search to one address when set, and is left
+// out of the query otherwise so every address of the provider is
+// considered. Service is not taken from the entry: the endpoint's port
+// is the caller's to choose, and an empty one means ephemeral.
+func resolveInterface(fi interfaceLister, provider fabrics.Provider, bindAddress string) (fabrics.InterfaceConfig, error) {
+	query := &fabrics.InterfaceConfig{Provider: provider}
+	if bindAddress != "" {
+		query.Address.Node = bindAddress
+	}
+
+	ifaces, err := fi.Interfaces(query)
+	if err != nil {
+		return fabrics.InterfaceConfig{}, fmt.Errorf("query fabric interfaces: %w", err)
+	}
+
+	// Remote write is the only transfer mode libmxl-fabrics implements,
+	// and a setup that cannot do it is refused further down anyway.
+	iface, ok := fabrics.SelectInterface(ifaces, fabrics.InterfaceCapRemoteWrite)
+	if !ok {
+		return fabrics.InterfaceConfig{}, fmt.Errorf("%w for provider %s on %q: %d candidate(s)",
+			errNoInterface, provider, bindAddress, len(ifaces))
+	}
+	iface.Address.Service = ""
+	return iface, nil
+}
+
+// interfaceLister is the slice of fabrics.Instance resolveInterface
+// needs, so tests can drive it without a libmxl-fabrics instance.
+type interfaceLister interface {
+	Interfaces(query *fabrics.InterfaceConfig) ([]fabrics.InterfaceConfig, error)
+}

--- a/gateway/internal/mirror/interface_resolve_test.go
+++ b/gateway/internal/mirror/interface_resolve_test.go
@@ -1,0 +1,129 @@
+package mirror
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+)
+
+// A setup handed a config with no address leaves interface resolution
+// to fi_getinfo, which answers ENODATA on a fabric that needs a
+// concrete source address. Enumerating first is what supplies one,
+// along with the capabilities and message size the provider reports.
+
+type fakeLister struct {
+	got  *fabrics.InterfaceConfig
+	out  []fabrics.InterfaceConfig
+	err  error
+	call int
+}
+
+func (f *fakeLister) Interfaces(q *fabrics.InterfaceConfig) ([]fabrics.InterfaceConfig, error) {
+	f.call++
+	f.got = q
+	return f.out, f.err
+}
+
+func TestResolveInterfaceCarriesTheProviderAddressAndCaps(t *testing.T) {
+	l := &fakeLister{out: []fabrics.InterfaceConfig{{
+		Provider: fabrics.ProviderVerbs,
+		Caps: fabrics.InterfaceCaps{
+			Flags:          fabrics.InterfaceCapRemoteWrite,
+			MaxMessageSize: 1 << 20,
+		},
+		Address: fabrics.EndpointAddress{Node: "10.20.53.13"},
+	}}}
+
+	got, err := resolveInterface(l, fabrics.ProviderVerbs, "")
+	require.NoError(t, err)
+	assert.Equal(t, "10.20.53.13", got.Address.Node,
+		"the address the setup binds to has to come from the provider")
+	assert.Equal(t, uint64(1<<20), got.Caps.MaxMessageSize,
+		"maxMessageSize is only knowable from enumeration")
+	assert.Equal(t, fabrics.InterfaceCapRemoteWrite, got.Caps.Flags)
+	assert.Equal(t, fabrics.ProviderVerbs, got.Provider)
+}
+
+func TestResolveInterfaceLeavesServiceUnset(t *testing.T) {
+	// The port belongs to the endpoint being opened, not to the
+	// interface; an empty one means ephemeral.
+	l := &fakeLister{out: []fabrics.InterfaceConfig{{
+		Provider: fabrics.ProviderTCP,
+		Caps:     fabrics.InterfaceCaps{Flags: fabrics.InterfaceCapRemoteWrite},
+		Address:  fabrics.EndpointAddress{Node: "10.0.0.1", Service: "47001"},
+	}}}
+
+	got, err := resolveInterface(l, fabrics.ProviderTCP, "")
+	require.NoError(t, err)
+	assert.Empty(t, got.Address.Service)
+}
+
+func TestResolveInterfaceQueriesByProviderOnly(t *testing.T) {
+	l := &fakeLister{out: []fabrics.InterfaceConfig{{
+		Provider: fabrics.ProviderVerbs,
+		Caps:     fabrics.InterfaceCaps{Flags: fabrics.InterfaceCapRemoteWrite},
+	}}}
+
+	_, err := resolveInterface(l, fabrics.ProviderVerbs, "")
+	require.NoError(t, err)
+	require.NotNil(t, l.got)
+	assert.Equal(t, fabrics.ProviderVerbs, l.got.Provider)
+	assert.Empty(t, l.got.Address.Node,
+		"an unset bind address must not narrow the search")
+}
+
+func TestResolveInterfaceNarrowsToTheBindAddress(t *testing.T) {
+	l := &fakeLister{out: []fabrics.InterfaceConfig{{
+		Provider: fabrics.ProviderVerbs,
+		Caps:     fabrics.InterfaceCaps{Flags: fabrics.InterfaceCapRemoteWrite},
+		Address:  fabrics.EndpointAddress{Node: "10.20.53.13"},
+	}}}
+
+	_, err := resolveInterface(l, fabrics.ProviderVerbs, "10.20.53.13")
+	require.NoError(t, err)
+	require.NotNil(t, l.got)
+	assert.Equal(t, "10.20.53.13", l.got.Address.Node)
+}
+
+func TestResolveInterfacePrefersTheFasterProvider(t *testing.T) {
+	l := &fakeLister{out: []fabrics.InterfaceConfig{
+		{Provider: fabrics.ProviderTCP, Caps: fabrics.InterfaceCaps{Flags: fabrics.InterfaceCapRemoteWrite}},
+		{Provider: fabrics.ProviderVerbs, Caps: fabrics.InterfaceCaps{Flags: fabrics.InterfaceCapRemoteWrite}},
+	}}
+
+	got, err := resolveInterface(l, fabrics.ProviderAny, "")
+	require.NoError(t, err)
+	assert.Equal(t, fabrics.ProviderVerbs, got.Provider)
+}
+
+func TestResolveInterfaceRejectsWhenNothingCanTransfer(t *testing.T) {
+	// An interface that cannot do remote write is refused by the setup
+	// path anyway; failing here names the reason.
+	l := &fakeLister{out: []fabrics.InterfaceConfig{{
+		Provider: fabrics.ProviderVerbs,
+		Caps:     fabrics.InterfaceCaps{Flags: fabrics.InterfaceCapSendReceive},
+	}}}
+
+	_, err := resolveInterface(l, fabrics.ProviderVerbs, "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoInterface)
+}
+
+func TestResolveInterfaceEmptyEnumeration(t *testing.T) {
+	l := &fakeLister{}
+	_, err := resolveInterface(l, fabrics.ProviderVerbs, "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, errNoInterface)
+}
+
+func TestResolveInterfacePropagatesQueryFailure(t *testing.T) {
+	sentinel := errors.New("boom")
+	l := &fakeLister{err: sentinel}
+	_, err := resolveInterface(l, fabrics.ProviderVerbs, "")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, sentinel)
+}

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -568,12 +568,15 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 		_ = reader.Close()
 		return nil, fmt.Errorf("NewInitiator: %w", err)
 	}
+	iface, err := resolveInterface(fabInst, provider, o.BindAddress)
+	if err != nil {
+		_ = initiator.Close()
+		_ = reader.Close()
+		return nil, err
+	}
 	if err := initiator.Setup(fabrics.InitiatorConfig{
-		Interface: fabrics.InterfaceConfig{
-			Provider: provider,
-			Address:  fabrics.EndpointAddress{Node: o.BindAddress},
-		},
-		Reader: reader,
+		Interface: iface,
+		Reader:    reader,
 	}); err != nil {
 		_ = initiator.Close()
 		_ = reader.Close()

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -442,12 +442,14 @@ func (r *TargetReconciler) openFabricSide(writer *mxl.Writer, provider fabrics.P
 	if err != nil {
 		return nil, nil, "", fmt.Errorf("NewTarget: %w", err)
 	}
+	iface, err := resolveInterface(fabInst, provider, r.BindAddress)
+	if err != nil {
+		_ = target.Close()
+		return nil, nil, "", err
+	}
 	info, err := target.Setup(fabrics.TargetConfig{
-		Interface: fabrics.InterfaceConfig{
-			Provider: provider,
-			Address:  fabrics.EndpointAddress{Node: r.BindAddress},
-		},
-		Writer: writer,
+		Interface: iface,
+		Writer:    writer,
 	})
 	if err != nil {
 		_ = target.Close()


### PR DESCRIPTION
Every verbs target setup on a bare-metal cluster failed after moving to
libmxl upstream main:

```
fi_getinfo: provider verbs returned -61 (No data available)
Failed to set up target: Failed to get source interface information
-> TargetProgress=OpenTargetFailed "Target.Setup: mxl: unknown error"
```

The gateway passed an interface config carrying a provider and the
configured bind address, which is empty by default, and left the rest to
`fi_getinfo`. That works only while the library can resolve an interface
from the provider alone. It stopped being able to, and the failure was
invisible from the outside: the unconstrained capability probe kept
reporting verbs, so the node advertised a provider no mirror could
actually use, while a tcp cluster on the same release stayed healthy.

`mxlFabricsGetInterfaces` is how libmxl-fabrics expects that question to
be answered, and the entries it returns are shaped to be passed straight
back into a setup -- provider, capabilities and address as one unit.
This is the pattern `tools/mxl-fabrics-demo` moved to in
`Refactor demo to use mxlFabricsGetInterfaces for automatic interface
selection`.

Three things follow from taking the entry rather than building one:

- the address is concrete, so the query resolves
- `caps.maxMessageSize` is populated, which has no other source and
  which the library warns about on every setup that leaves it unset
- the flags are the provider's own, rather than the remote-write
  default the binding supplies when a caller sets none

`--bind-address` now narrows the search when set instead of being the
whole answer. A gateway that names no address gets the best interface
its provider offers, ordered EFA, verbs, TCP, SHM -- the order the demo
applies -- rather than nothing. Where the provider is already concrete,
which is every mirror the operator or agent stamps, the order only
decides between addresses of that one provider.

Needs go-mxl 1.0.0-rc.13 for the enumeration wrapper.