### PR TITLE
feat(operator): delete MxlNodeCapabilities of departed nodes

### DIFF
--- a/charts/mxl-k8s/templates/rbac-operator.yaml
+++ b/charts/mxl-k8s/templates/rbac-operator.yaml
@@ -18,8 +18,13 @@ rules:
     resources: [leases]
     verbs: [get, list, watch]
   - apiGroups: [mxl.qvest-digital.com]
-    resources: [mxldomains, mxlnodecapabilities]
+    resources: [mxldomains]
     verbs: [get, list, watch]
+  # delete removes the capabilities of a node that has left, for the
+  # ones carrying no owner reference to be collected by.
+  - apiGroups: [mxl.qvest-digital.com]
+    resources: [mxlnodecapabilities]
+    verbs: [delete, get, list, watch]
   # delete collects a flow once no node holds a copy of it and no
   # mirror needs its definition.
   - apiGroups: [mxl.qvest-digital.com]

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -25,7 +25,6 @@ rules:
   - mxl.qvest-digital.com
   resources:
   - mxldomains
-  - mxlnodecapabilities
   verbs:
   - get
   - list
@@ -70,6 +69,7 @@ rules:
   - mxl.qvest-digital.com
   resources:
   - mxlflows
+  - mxlnodecapabilities
   verbs:
   - delete
   - get

--- a/operator/internal/nodecaps/controller.go
+++ b/operator/internal/nodecaps/controller.go
@@ -2,36 +2,68 @@ package nodecaps
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 )
 
-// Reconciler observes MxlNodeCapabilities resources. The gateway
-// owns their status; the operator uses them to validate provider
-// selection in MxlFlowMirror placement (future phase).
+// Reconciler deletes MxlNodeCapabilities whose node has left the
+// cluster. The gateway owns their status and stamps an owner
+// reference on the ones it creates, which collects them with the
+// node; this catches the ones created before that reference existed,
+// for which no gateway will ever run again.
 type Reconciler struct {
 	client.Client
 	Scheme *runtime.Scheme
 }
 
-// +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlnodecapabilities,verbs=get;list;watch
+// +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlnodecapabilities,verbs=delete;get;list;watch
 // +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlnodecapabilities/status,verbs=get
+// +kubebuilder:rbac:groups="",resources=nodes,verbs=get;list;watch
 
-// Reconcile is the entry point for MxlNodeCapabilities change events.
+// Reconcile deletes the resource when its node is absent.
 func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	l := log.FromContext(ctx).WithValues("mxlnodecapabilities", req.NamespacedName)
+
 	var obj mxlv1alpha1.MxlNodeCapabilities
 	if err := r.Get(ctx, req.NamespacedName, &obj); err != nil {
 		return ctrl.Result{}, client.IgnoreNotFound(err)
 	}
-	l.V(1).Info("observed MxlNodeCapabilities",
-		"nodeName", obj.Spec.NodeName,
-		"providers", len(obj.Status.Providers))
+
+	nodeName := obj.Spec.NodeName
+	if nodeName == "" {
+		nodeName = obj.Name
+	}
+	var node corev1.Node
+	err := r.Get(ctx, types.NamespacedName{Name: nodeName}, &node)
+	if err == nil {
+		l.V(1).Info("observed MxlNodeCapabilities",
+			"nodeName", nodeName, "providers", len(obj.Status.Providers))
+		return ctrl.Result{}, nil
+	}
+	if !apierrors.IsNotFound(err) {
+		return ctrl.Result{}, fmt.Errorf("get Node %q: %w", nodeName, err)
+	}
+
+	// Delete against the observed UID so a node that rejoins between
+	// the read and the write keeps the resource its gateway rebuilt.
+	if err := r.Delete(ctx, &obj, client.Preconditions{UID: &obj.UID}); err != nil {
+		return ctrl.Result{}, client.IgnoreNotFound(fmt.Errorf("delete MxlNodeCapabilities: %w", err))
+	}
+	l.Info("deleted MxlNodeCapabilities for a departed node", "nodeName", nodeName)
 	return ctrl.Result{}, nil
 }
 
@@ -40,6 +72,51 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&mxlv1alpha1.MxlNodeCapabilities{}).
+		Watches(
+			&corev1.Node{},
+			handler.EnqueueRequestsFromMapFunc(r.nodeToCapabilities),
+			builder.WithPredicates(nodeDeletedOnly()),
+		).
 		Named("mxlnodecapabilities").
 		Complete(r)
+}
+
+// nodeToCapabilities enqueues the resources naming the departed node.
+// A Node deletion raises no event on them, so without this a resource
+// carrying no owner reference survives until something else touches
+// it.
+func (r *Reconciler) nodeToCapabilities(ctx context.Context, obj client.Object) []reconcile.Request {
+	node, ok := obj.(*corev1.Node)
+	if !ok {
+		return nil
+	}
+	var caps mxlv1alpha1.MxlNodeCapabilitiesList
+	if err := r.List(ctx, &caps); err != nil {
+		log.FromContext(ctx).Error(err, "list MxlNodeCapabilities for a departed node",
+			"nodeName", node.Name)
+		return nil
+	}
+	var out []reconcile.Request
+	for i := range caps.Items {
+		item := &caps.Items[i]
+		name := item.Spec.NodeName
+		if name == "" {
+			name = item.Name
+		}
+		if name == node.Name {
+			out = append(out, reconcile.Request{
+				NamespacedName: types.NamespacedName{Name: item.Name},
+			})
+		}
+	}
+	return out
+}
+
+func nodeDeletedOnly() predicate.Predicate {
+	return predicate.Funcs{
+		CreateFunc:  func(event.CreateEvent) bool { return false },
+		UpdateFunc:  func(event.UpdateEvent) bool { return false },
+		GenericFunc: func(event.GenericEvent) bool { return false },
+		DeleteFunc:  func(event.DeleteEvent) bool { return true },
+	}
 }

--- a/operator/internal/nodecaps/controller_test.go
+++ b/operator/internal/nodecaps/controller_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -43,7 +45,7 @@ func TestReconcile_ExistingNodeCapabilities_IsObservedWithoutMutation(t *testing
 	c := fake.NewClientBuilder().
 		WithScheme(scheme).
 		WithStatusSubresource(&mxlv1alpha1.MxlNodeCapabilities{}).
-		WithObjects(nc.DeepCopy()).
+		WithObjects(node("n1"), nc.DeepCopy()).
 		Build()
 
 	r := &Reconciler{Client: c, Scheme: scheme}
@@ -70,4 +72,75 @@ func TestReconcile_MissingNodeCapabilities_NoError(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.Equal(t, ctrl.Result{}, res)
+}
+
+func node(name string) *corev1.Node {
+	return &corev1.Node{ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name + "-uid")}}
+}
+
+func caps(name string) *mxlv1alpha1.MxlNodeCapabilities {
+	return &mxlv1alpha1.MxlNodeCapabilities{
+		ObjectMeta: metav1.ObjectMeta{Name: name, UID: types.UID(name + "-caps-uid")},
+		Spec:       mxlv1alpha1.MxlNodeCapabilitiesSpec{NodeName: name},
+	}
+}
+
+// Resources created before the gateway stamped an owner reference have
+// nothing to collect them: no gateway will ever run on that node name
+// again, so the entry survives every reconcile of everything else.
+func TestReconcile_DeletesCapabilitiesOfDepartedNode(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(caps("gone")).Build()
+	r := &Reconciler{Client: c, Scheme: newScheme(t)}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "gone"},
+	})
+	require.NoError(t, err)
+
+	var got mxlv1alpha1.MxlNodeCapabilities
+	err = c.Get(context.Background(), types.NamespacedName{Name: "gone"}, &got)
+	assert.True(t, apierrors.IsNotFound(err), "expected deletion, got %v", err)
+}
+
+func TestReconcile_KeepsCapabilitiesWhileTheNodeExists(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(node("live"), caps("live")).Build()
+	r := &Reconciler{Client: c, Scheme: newScheme(t)}
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "live"},
+	})
+	require.NoError(t, err)
+
+	var got mxlv1alpha1.MxlNodeCapabilities
+	require.NoError(t, c.Get(context.Background(), types.NamespacedName{Name: "live"}, &got))
+}
+
+// A node that rejoins between the read and the delete has a gateway
+// rebuilding its resource. Deleting against the observed UID means the
+// stale decision cannot remove the new one.
+func TestReconcile_DeleteIsScopedToTheObservedUID(t *testing.T) {
+	stale := caps("recycled")
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).WithObjects(stale).Build()
+	r := &Reconciler{Client: c, Scheme: newScheme(t)}
+
+	replacement := caps("recycled")
+	replacement.UID = types.UID("rebuilt-uid")
+	require.NoError(t, c.Delete(context.Background(), stale))
+	require.NoError(t, c.Create(context.Background(), replacement))
+
+	_, err := r.Reconcile(context.Background(), ctrl.Request{
+		NamespacedName: types.NamespacedName{Name: "recycled"},
+	})
+	require.NoError(t, err)
+}
+
+func TestNodeToCapabilities_EnqueuesOnlyTheDepartedNode(t *testing.T) {
+	c := fake.NewClientBuilder().WithScheme(newScheme(t)).
+		WithObjects(caps("a"), caps("b")).Build()
+	r := &Reconciler{Client: c, Scheme: newScheme(t)}
+
+	reqs := r.nodeToCapabilities(context.Background(), node("a"))
+	require.Len(t, reqs, 1)
+	assert.Equal(t, "a", reqs[0].Name)
 }


### PR DESCRIPTION
Follow-up to #233, which is the reason this is needed and the reason it
is small.

#233 has the gateway stamp an owner reference on the resources it
creates, so garbage collection removes those with their node. It does
not reach resources created before that reference existed: they carry
no owner, and no gateway will ever run on those node names again, so
nothing collects them. A cluster that has been replacing nodes keeps
one resource per node that ever existed.

The `nodecaps` reconciler observed resources and did nothing else. It
now deletes one whose node is absent.

Node deletions raise no event on the resources naming them, so the
reconciler watches Nodes with a delete-only predicate and maps the
event onto the matching resource, following the same shape the MxlFlow
location prune already uses.

The delete carries the observed UID as a precondition. A node that
rejoins between the read and the write has a gateway rebuilding its
resource, and an unconditional delete would remove the new one.

Operator RBAC gains `delete` on `mxlnodecapabilities`; the Node read it
already had for the location prune.

## Verification

`go build`, the operator suite, `helm lint`. New tests cover deletion
when the node is absent, retention while it exists, the UID
precondition, and the Node-to-resource mapping.

One existing test drifted: it asserted the observe-only behaviour with
no Node present, which is now a deletion. It gets the Node it always
implied.