### PR TITLE
fix(gateway): escalate and recover a target that cannot open

### DIFF
--- a/api/v1alpha1/mxlflowmirror_types.go
+++ b/api/v1alpha1/mxlflowmirror_types.go
@@ -18,11 +18,14 @@ const (
 	// MxlFlowMirrorReady means the handshake is complete and grain
 	// activity has been observed within the freshness window.
 	MxlFlowMirrorReady MxlFlowMirrorPhase = "Ready"
-	// MxlFlowMirrorDegraded means the handshake is complete but no
-	// grain progress has been observed for longer than the target
-	// gateway's freshness window. The mirror may recover without
-	// operator intervention; inspect status.conditions for the
-	// reason.
+	// MxlFlowMirrorDegraded means the mirror is not moving grains and
+	// has been in that state long enough that it is no longer coming
+	// up: either the handshake completed and no grain progress has
+	// been observed for longer than the target gateway's freshness
+	// window, or the target side has failed to open across enough
+	// consecutive attempts to rule out a transient failure. The mirror
+	// may recover without operator intervention; inspect
+	// status.conditions for the reason.
 	MxlFlowMirrorDegraded MxlFlowMirrorPhase = "Degraded"
 	// MxlFlowMirrorFailed means the mirror failed permanently.
 	// Inspect status.conditions for the cause.
@@ -108,9 +111,21 @@ type MxlFlowMirrorStatus struct {
 
 	// AttemptCount is the number of consecutive failed AddTarget
 	// attempts since the last successful reconcile. Reset to zero
-	// when the source gateway succeeds.
+	// when the source gateway succeeds. Source-side only; the target
+	// side counts its own open failures in TargetAttemptCount.
 	// +optional
 	AttemptCount int32 `json:"attemptCount,omitempty"`
+
+	// TargetAttemptCount is the number of consecutive failed attempts
+	// the target gateway has made to open the local writer and the
+	// libmxl-fabrics target endpoint. Reset to zero when the target
+	// side opens.
+	//
+	// Kept separate from AttemptCount because the two gateways apply
+	// status under different field managers: a single counter would
+	// have each side's server-side apply reset the other's value.
+	// +optional
+	TargetAttemptCount int32 `json:"targetAttemptCount,omitempty"`
 }
 
 // +kubebuilder:object:root=true

--- a/charts/mxl-k8s/crds/mxl.qvest-digital.com_mxlflowmirrors.yaml
+++ b/charts/mxl-k8s/crds/mxl.qvest-digital.com_mxlflowmirrors.yaml
@@ -132,7 +132,8 @@ spec:
                 description: |-
                   AttemptCount is the number of consecutive failed AddTarget
                   attempts since the last successful reconcile. Reset to zero
-                  when the source gateway succeeds.
+                  when the source gateway succeeds. Source-side only; the target
+                  side counts its own open failures in TargetAttemptCount.
                 format: int32
                 type: integer
               conditions:
@@ -234,6 +235,18 @@ spec:
                 - Degraded
                 - Failed
                 type: string
+              targetAttemptCount:
+                description: |-
+                  TargetAttemptCount is the number of consecutive failed attempts
+                  the target gateway has made to open the local writer and the
+                  libmxl-fabrics target endpoint. Reset to zero when the target
+                  side opens.
+
+                  Kept separate from AttemptCount because the two gateways apply
+                  status under different field managers: a single counter would
+                  have each side's server-side apply reset the other's value.
+                format: int32
+                type: integer
               targetInfo:
                 description: |-
                   TargetInfo is the libmxl-fabrics target descriptor produced by

--- a/config/crd/mxl.qvest-digital.com_mxlflowmirrors.yaml
+++ b/config/crd/mxl.qvest-digital.com_mxlflowmirrors.yaml
@@ -132,7 +132,8 @@ spec:
                 description: |-
                   AttemptCount is the number of consecutive failed AddTarget
                   attempts since the last successful reconcile. Reset to zero
-                  when the source gateway succeeds.
+                  when the source gateway succeeds. Source-side only; the target
+                  side counts its own open failures in TargetAttemptCount.
                 format: int32
                 type: integer
               conditions:
@@ -234,6 +235,18 @@ spec:
                 - Degraded
                 - Failed
                 type: string
+              targetAttemptCount:
+                description: |-
+                  TargetAttemptCount is the number of consecutive failed attempts
+                  the target gateway has made to open the local writer and the
+                  libmxl-fabrics target endpoint. Reset to zero when the target
+                  side opens.
+
+                  Kept separate from AttemptCount because the two gateways apply
+                  status under different field managers: a single counter would
+                  have each side's server-side apply reset the other's value.
+                format: int32
+                type: integer
               targetInfo:
                 description: |-
                   TargetInfo is the libmxl-fabrics target descriptor produced by

--- a/docs/RDMA.md
+++ b/docs/RDMA.md
@@ -453,7 +453,7 @@ those nodes belong in their own variant.
 
 | Symptom | Likely cause |
 | --- | --- |
-| `MxlFlowMirror` stuck in `Materializing` | Gateway can't `fi_getinfo` the provider on the local NIC. Check `/dev/infiniband` is mounted and the host module is loaded. |
+| `MxlFlowMirror` `Degraded` with `TargetProgress=False/OpenTargetFailed` | Gateway can't `fi_getinfo` the provider on the local NIC. Check `/dev/infiniband` is mounted and the host module is loaded. `status.targetAttemptCount` carries the length of the failure run. |
 | Mirror fails with `no usable fabric interface` | Every candidate was excluded. The error names the first exclusion and its reason; check the fabric flags against `kubectl get mxlnodecapabilities <node> -o yaml`. |
 | A node advertises `deviceCount: 0` for a provider whose hardware is installed | libmxl-fabrics did not enumerate a usable device. Check the host module and `/dev/infiniband` first, then whether the fabric flags exclude the interface it would have used. |
 | Every mirror sits on tcp after an upgrade | Nodes whose gateway has not rolled yet report no `Probed` condition. Check `kubectl get mxlnodecapabilities` for the ones still on the old shape. |

--- a/docs/architecture/02-components.md
+++ b/docs/architecture/02-components.md
@@ -74,15 +74,27 @@ fabric side *without* closing the `mxl.Writer`, so consumer pods'
 
 ![Gateway: TargetReconciler state, including recovery](./diagrams/02-gateway-lifecycle.drawio.svg)
 
-Two transitions in particular are easy to miss:
+Three transitions in particular are easy to miss:
 
 - **Pod restart** lands in `Materializing` again, not `Ready` -- the
   in-memory `targetEntry` map is empty after restart, the fast-path
   declines, and the slow path reopens the writer. This also rotates
   `TargetInfo`, which the source side picks up through its
   `Watches(MxlFlowMirror)`.
+- **A target that will not open** counts consecutive failures in
+  `status.targetAttemptCount` and leaves `Materializing` for
+  `Degraded` past `maxTargetOpenAttempts`
+  ([`target.go:516`](../../gateway/internal/mirror/target.go)):
+  `Materializing` is the state a consumer waits through, so a mirror
+  parked there reads as one about to go `Ready`. When the failure came
+  from the local writer, that threshold also reclaims the flow
+  directory -- a gateway restart part-way through materialising a
+  target leaves a grain ring shorter than the flow header declares,
+  and libmxl fails every later open of that path. Only a directory
+  this node is not the flow's `Origin` for is removed; an `Origin`
+  location means a local producer has taken it over.
 - **Fatal `ReadGrain`** triggers `recoverFromFatalError`
-  ([`target.go:375`](../../gateway/internal/mirror/target.go)),
+  ([`target.go:924`](../../gateway/internal/mirror/target.go)),
   which closes only the fabric triple
   (`Regions`/`Target`/`Info`). The `mxl.Writer` is intentionally
   retained -- the on-disk flow definition and any consumer

--- a/gateway/cmd/mxl-fabrics-gateway/main.go
+++ b/gateway/cmd/mxl-fabrics-gateway/main.go
@@ -112,6 +112,7 @@ func run(args []string) error {
 		BindAddress:   cfg.BindAddress,
 		Selector:      selector,
 		Handles:       handles,
+		DomainPath:    cfg.DomainPath,
 		DegradedAfter: cfg.DegradedAfter,
 	}).SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup target reconciler: %w", err)

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -67,6 +69,34 @@ const defaultStuckHandshakeAfter = 20 * time.Second
 // the cap counts *consecutive* failed rebuilds, not lifetime ones.
 const maxStuckRebuilds uint32 = 3
 
+// maxTargetOpenAttempts is the number of consecutive openTarget
+// failures after which the mirror stops reading as Materializing.
+// Materializing is a transient state a consumer waits through, so a
+// mirror parked there is indistinguishable from one a moment away
+// from Ready: no phase change to alert on and no counter to
+// threshold. From this attempt on the target side publishes
+// Phase=Degraded, and a failure that came from the local writer also
+// gets the flow directory reclaimed (see reclaimUnusableFlowDir).
+const maxTargetOpenAttempts uint32 = 3
+
+// flowDirSuffix is the directory-name suffix libmxl gives a per-flow
+// directory under a domain (FLOW_DIRECTORY_NAME_SUFFIX). go-mxl keeps
+// its own copy unexported, so the gateway carries one; the agent
+// module holds the same constant as flowpublisher.FlowDirSuffix.
+const flowDirSuffix = ".mxl-flow"
+
+// grainDirName is the subdirectory of a flow directory holding the
+// grain segment files (GRAIN_DIRECTORY_NAME). Only ever read, and
+// only to report how much of the ring was present when a directory
+// is reclaimed.
+const grainDirName = "grains"
+
+// errOpenWriterFailed wraps a NewWriter failure so the Reconcile
+// failure path can tell "the local flow file could not be opened"
+// apart from "the libmxl-fabrics side could not be set up". Only the
+// former is answerable by reclaiming the flow directory.
+var errOpenWriterFailed = errors.New("open local writer")
+
 // ReasonStuckHandshakeCapReached marks a target-side mirror whose
 // libmxl-fabrics handshake never produced a grain commit across
 // maxStuckRebuilds consecutive watchdog-driven rebuilds. Distinct
@@ -101,6 +131,13 @@ type TargetReconciler struct {
 
 	// Handles owns the long-lived mxl + fabrics instances.
 	Handles *instance.Handles
+
+	// DomainPath is the MXL domain directory this gateway operates on,
+	// the same path Handles was opened against. Held separately from
+	// Handles because reclaimUnusableFlowDir works on the directory
+	// with the filesystem rather than through libmxl. Empty disables
+	// the reclaim.
+	DomainPath string
 
 	// FlushInterval is how often the per-mirror status flusher
 	// inspects the targetEntry trackers and publishes TargetProgress
@@ -137,8 +174,20 @@ type TargetReconciler struct {
 	// the gate that prevents double spawns.
 	recoverFn func(key types.NamespacedName)
 
+	// openTargetFn is the seam Reconcile opens the target through.
+	// Production leaves it nil and falls back to
+	// (*TargetReconciler).openTarget, which needs a real libmxl;
+	// tests inject failures so the attempt accounting and the
+	// escalation out of Materializing can be observed without one.
+	openTargetFn func(key types.NamespacedName, flowDef string, provider fabrics.Provider) (*targetEntry, error)
+
 	mu      sync.Mutex
 	targets map[types.NamespacedName]*targetEntry
+
+	// attempts counts consecutive openTarget failures per mirror.
+	// Cleared the moment a target opens, so the value is always the
+	// length of the current failure run. Guarded by mu.
+	attempts map[types.NamespacedName]uint32
 }
 
 // targetEntry holds the live libmxl handles for one target-side
@@ -346,7 +395,8 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// definition yet. Treat it like a not-yet-materialized flow:
 		// surface the reason and requeue instead of returning a bare
 		// error that leaves the mirror sitting at an empty phase.
-		r.surfaceTargetFailure(ctx, &mirror, mxlv1alpha1.ReasonFlowDefinitionEmpty,
+		r.surfaceTargetFailure(ctx, &mirror, mxlv1alpha1.MxlFlowMirrorMaterializing,
+			mxlv1alpha1.ReasonFlowDefinitionEmpty,
 			fmt.Sprintf("MxlFlow %s has empty spec.definition", mirror.Spec.FlowID))
 		return ctrl.Result{RequeueAfter: 2 * time.Second}, nil
 	}
@@ -356,21 +406,27 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		// Never forward auto into libmxl-fabrics: surface the reason on
 		// status and stop. The agent or operator patches spec.provider to
 		// a concrete value, which wakes this reconciler through its watch.
-		r.surfaceTargetFailure(ctx, &mirror, mxlv1alpha1.ReasonProviderUnresolved, err.Error())
+		r.surfaceTargetFailure(ctx, &mirror, mxlv1alpha1.MxlFlowMirrorMaterializing,
+			mxlv1alpha1.ReasonProviderUnresolved, err.Error())
 		l.Info("refusing target setup: mirror provider is unresolved", "error", err.Error())
 		return ctrl.Result{}, nil
 	}
 
-	entry, err := r.openTarget(req.NamespacedName, string(flow.Spec.Definition.Raw), provider)
+	// Seed the in-memory attempts counter from the persisted
+	// status.targetAttemptCount so a gateway pod restart does not hand
+	// a wedged mirror a fresh budget: without this a target that has
+	// been unopenable across the bounce reads as Materializing again
+	// and the escalation to Degraded restarts from zero. Matches the
+	// source side's seeding of status.attemptCount.
+	r.mu.Lock()
+	if _, ok := r.attempts[req.NamespacedName]; !ok && mirror.Status.TargetAttemptCount > 0 {
+		r.attempts[req.NamespacedName] = uint32(mirror.Status.TargetAttemptCount)
+	}
+	r.mu.Unlock()
+
+	entry, err := r.openTargetDispatch(req.NamespacedName, string(flow.Spec.Definition.Raw), provider)
 	if err != nil {
-		// openTarget wraps NewWriter + the libmxl-fabrics Target.Setup,
-		// whose errors otherwise land only in the gateway log — the mirror
-		// is left at an empty phase, so the consumer (and cluster
-		// diagnostics, which only see the CR) get no signal for why it
-		// never went Ready. Surface the cause, then let the rate-limited
-		// requeue retry.
-		r.surfaceTargetFailure(ctx, &mirror, mxlv1alpha1.ReasonOpenTargetFailed, err.Error())
-		return ctrl.Result{}, fmt.Errorf("open target: %w", err)
+		return r.handleOpenTargetFailure(ctx, &mirror, err)
 	}
 
 	r.mu.Lock()
@@ -382,6 +438,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 	r.targets[req.NamespacedName] = entry
+	delete(r.attempts, req.NamespacedName)
 	r.mu.Unlock()
 
 	if err := r.applyTargetStatus(ctx, &mirror, mxlv1alpha1.MxlFlowMirrorReady, &entry.infoStr, nil, nil); err != nil {
@@ -416,7 +473,7 @@ func (r *TargetReconciler) openTarget(key types.NamespacedName, flowDef string, 
 
 	writer, _, err := mxlInst.NewWriter(flowDef)
 	if err != nil {
-		return nil, fmt.Errorf("NewWriter: %w", err)
+		return nil, fmt.Errorf("%w: NewWriter: %w", errOpenWriterFailed, err)
 	}
 	target, info, s, err := r.openFabricSideDispatch(writer, provider)
 	if err != nil {
@@ -433,6 +490,107 @@ func (r *TargetReconciler) openTarget(key types.NamespacedName, flowDef string, 
 	}
 	r.startProgressLoop(entry, key)
 	return entry, nil
+}
+
+// openTargetDispatch routes the open through the test seam when set,
+// falling back to the cgo openTarget in production.
+func (r *TargetReconciler) openTargetDispatch(key types.NamespacedName, flowDef string, provider fabrics.Provider) (*targetEntry, error) {
+	if r.openTargetFn != nil {
+		return r.openTargetFn(key, flowDef, provider)
+	}
+	return r.openTarget(key, flowDef, provider)
+}
+
+// handleOpenTargetFailure records the failed open, publishes the
+// reason on status, and returns a bounded-backoff requeue.
+//
+// openTarget wraps NewWriter + the libmxl-fabrics Target.Setup, whose
+// errors otherwise land only in the gateway log: the producer, the
+// consumer and the cluster diagnostics only ever observe the CR.
+// Publishing Materializing alone is not enough either - it is the
+// state a consumer waits through, so a mirror that can never open
+// looks the same as one about to succeed. Past maxTargetOpenAttempts
+// consecutive failures the phase escalates to Degraded and, for a
+// failure that came from the local writer, the flow directory is
+// reclaimed so the retry materialises a fresh one.
+func (r *TargetReconciler) handleOpenTargetFailure(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror, openErr error) (ctrl.Result, error) {
+	key := client.ObjectKeyFromObject(mirror)
+	l := log.FromContext(ctx).WithValues("mxlflowmirror", key)
+
+	r.mu.Lock()
+	r.attempts[key]++
+	attempts := r.attempts[key]
+	r.mu.Unlock()
+
+	phase := mxlv1alpha1.MxlFlowMirrorMaterializing
+	if attempts >= maxTargetOpenAttempts {
+		phase = mxlv1alpha1.MxlFlowMirrorDegraded
+	}
+	r.surfaceTargetFailure(ctx, mirror, phase, mxlv1alpha1.ReasonOpenTargetFailed,
+		fmt.Sprintf("%s (attempt %d)", openErr.Error(), attempts))
+	l.Error(openErr, "open target", "attempt", attempts, "phase", string(phase))
+
+	// A writer that will not open is the one failure the gateway can
+	// act on: it wrote that directory as a mirror target, so a
+	// directory it can no longer open is its own torn output. Only
+	// reclaim once the failure has repeated, so a single transient
+	// error never costs a directory.
+	if attempts >= maxTargetOpenAttempts && errors.Is(openErr, errOpenWriterFailed) {
+		if reclaimed := r.reclaimUnusableFlowDir(ctx, mirror.Spec.FlowID); reclaimed {
+			// Materialising a fresh directory is the point of the
+			// reclaim; do not sit out the accumulated backoff first.
+			return ctrl.Result{RequeueAfter: 100 * time.Millisecond}, nil
+		}
+	}
+	return ctrl.Result{RequeueAfter: backoffFor(attempts)}, nil
+}
+
+// reclaimUnusableFlowDir removes the local flow directory for flowID
+// so the next openTarget materialises a complete one, and reports
+// whether it removed anything.
+//
+// A gateway restart part-way through materialising a target leaves a
+// flow directory whose grain ring is short of what its flow header
+// declares. libmxl walks to a grain segment that was never written
+// and every later open of that path fails, so retrying the open
+// against the same directory can only keep failing.
+//
+// The MxlFlow location published for this node is the gate: a flow
+// this node is Origin for belongs to a local producer, and removing
+// it would take the producer's flow with it. Only a directory this
+// gateway owns as a mirror copy is reclaimed, which is the same
+// ownership test teardown applies.
+func (r *TargetReconciler) reclaimUnusableFlowDir(ctx context.Context, flowID string) bool {
+	l := log.FromContext(ctx).WithName("target-reclaim").WithValues("flowID", flowID)
+	if r.DomainPath == "" {
+		return false
+	}
+	if r.localFlowDisposition(ctx, flowID) == keepFlow {
+		l.Info("leaving flow directory in place: not this node's mirror copy")
+		return false
+	}
+
+	dir := filepath.Join(r.DomainPath, flowID+flowDirSuffix)
+	if _, err := os.Stat(dir); err != nil {
+		if !os.IsNotExist(err) {
+			l.Error(err, "stat flow directory", "path", dir)
+		}
+		return false
+	}
+	// Report how much of the grain ring was there: the shortfall
+	// against the flow header is what distinguishes a torn directory
+	// from one that failed to open for another reason, and it is not
+	// recoverable once the directory is gone.
+	grains := -1
+	if entries, err := os.ReadDir(filepath.Join(dir, grainDirName)); err == nil {
+		grains = len(entries)
+	}
+	if err := os.RemoveAll(dir); err != nil {
+		l.Error(err, "remove flow directory", "path", dir)
+		return false
+	}
+	l.Info("reclaimed unopenable flow directory", "path", dir, "grainFiles", grains)
+	return true
 }
 
 // openFabricSide creates the fabrics.Target + TargetInfo on an
@@ -707,6 +865,7 @@ func (r *TargetReconciler) closeEntry(key types.NamespacedName, disp flowDisposi
 	r.mu.Lock()
 	entry := r.targets[key]
 	delete(r.targets, key)
+	delete(r.attempts, key)
 	r.mu.Unlock()
 	if entry == nil {
 		return
@@ -918,6 +1077,13 @@ func closeTargetHandles(e *targetEntry, disp flowDisposition) {
 // targetInfo, lastGrainAt and cond are optional; nil pointers omit
 // the corresponding key from the SSA payload so the manager does not
 // claim ownership of fields it has nothing to say about.
+//
+// targetAttemptCount is not optional: it rides on every payload
+// because SSA with a single FieldOwner releases ownership of a field
+// a later payload omits, and the apiserver then strips it. Sourcing
+// it from the live counter also keeps it honest - a write from any
+// path (flusher, recovery, teardown) reports the current failure run,
+// which is zero for as long as the target is open.
 func (r *TargetReconciler) applyTargetStatus(
 	ctx context.Context,
 	mirror *mxlv1alpha1.MxlFlowMirror,
@@ -930,9 +1096,13 @@ func (r *TargetReconciler) applyTargetStatus(
 	patch.SetGroupVersionKind(mxlv1alpha1.GroupVersion.WithKind("MxlFlowMirror"))
 	patch.SetNamespace(mirror.Namespace)
 	patch.SetName(mirror.Name)
+	r.mu.Lock()
+	attempts := r.attempts[client.ObjectKeyFromObject(mirror)]
+	r.mu.Unlock()
 	status := map[string]any{
 		"phase":              string(phase),
 		"observedGeneration": mirror.Generation,
+		"targetAttemptCount": int64(attempts),
 	}
 	if targetInfo != nil {
 		status["targetInfo"] = *targetInfo
@@ -958,19 +1128,23 @@ func (r *TargetReconciler) applyTargetStatus(
 	)
 }
 
-// surfaceTargetFailure publishes Phase=Materializing plus a
-// TargetProgress=False condition carrying the reason the target side
-// could not be established yet. Best-effort: a failed status write must
-// not mask the original error the caller returns/requeues on, so the
-// result is intentionally ignored. It exists so a target-open failure
-// shows up in MxlFlowMirror status (and `kubectl describe`) instead of
-// the mirror wedging silently at an empty phase — the producer, the
+// surfaceTargetFailure publishes phase plus a TargetProgress=False
+// condition carrying the reason the target side could not be
+// established yet. Best-effort: a failed status write must not mask
+// the original error the caller returns/requeues on, so the result is
+// intentionally ignored. It exists so a target-open failure shows up
+// in MxlFlowMirror status (and `kubectl describe`) instead of the
+// mirror wedging silently at an empty phase — the producer, the
 // consumer, and the cluster diagnostics only observe the CR, never the
 // gateway log. Only reached on the pre-Ready path (the Reconcile
 // fast-path returns earlier for a live, fresh, Ready mirror), so this
 // never demotes a healthy mirror.
-func (r *TargetReconciler) surfaceTargetFailure(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror, reason, message string) {
-	_ = r.applyTargetStatus(ctx, mirror, mxlv1alpha1.MxlFlowMirrorMaterializing, nil, nil, &metav1.Condition{
+//
+// The phase is the caller's to choose: a failure that has just started
+// is still Materializing, one that has repeated past
+// maxTargetOpenAttempts is Degraded.
+func (r *TargetReconciler) surfaceTargetFailure(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror, phase mxlv1alpha1.MxlFlowMirrorPhase, reason, message string) {
+	_ = r.applyTargetStatus(ctx, mirror, phase, nil, nil, &metav1.Condition{
 		Type:               mxlv1alpha1.ConditionTypeTargetProgress,
 		Status:             metav1.ConditionFalse,
 		Reason:             reason,
@@ -1365,6 +1539,9 @@ func (r *TargetReconciler) publishTargetProgress(ctx context.Context, key types.
 func (r *TargetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.targets == nil {
 		r.targets = make(map[types.NamespacedName]*targetEntry)
+	}
+	if r.attempts == nil {
+		r.attempts = make(map[types.NamespacedName]uint32)
 	}
 	if r.APIReader == nil {
 		r.APIReader = mgr.GetAPIReader()

--- a/gateway/internal/mirror/target_openfailure_test.go
+++ b/gateway/internal/mirror/target_openfailure_test.go
@@ -1,0 +1,280 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+const openFailureFlowID = "11111111-2222-3333-4444-555555555555"
+
+// openFailureFixture wires a target reconciler whose open always fails
+// with openErr, against a mirror and a published MxlFlow whose local
+// location carries locPhase.
+type openFailureFixture struct {
+	r      *TargetReconciler
+	key    types.NamespacedName
+	req    reconcile.Request
+	domain string
+	opens  int
+}
+
+func newOpenFailureFixture(t *testing.T, openErr error, locPhase mxlv1alpha1.MxlFlowLocationPhase) *openFailureFixture {
+	t.Helper()
+	scheme := newSourceTestScheme(t)
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	mirror := mirrorWithTargetFinalizer(key.Name, key.Namespace, "node-a", openFailureFlowID,
+		mxlv1alpha1.MxlFlowMirrorStatus{})
+	mirror.Spec.Provider = mxlv1alpha1.ProviderTCP
+	flow := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: metav1.ObjectMeta{Name: openFailureFlowID},
+		Spec: mxlv1alpha1.MxlFlowSpec{
+			ID:         openFailureFlowID,
+			Definition: runtime.RawExtension{Raw: []byte(`{"id":"` + openFailureFlowID + `"}`)},
+		},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{{NodeName: "node-a", Phase: locPhase}},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}, &mxlv1alpha1.MxlFlow{}).
+		WithObjects(mirror, flow).
+		Build()
+
+	f := &openFailureFixture{
+		key:    key,
+		req:    reconcile.Request{NamespacedName: key},
+		domain: t.TempDir(),
+	}
+	f.r = &TargetReconciler{
+		Client:     c,
+		Scheme:     scheme,
+		NodeName:   "node-a",
+		DomainPath: f.domain,
+		targets:    map[types.NamespacedName]*targetEntry{},
+		attempts:   map[types.NamespacedName]uint32{},
+		openTargetFn: func(types.NamespacedName, string, fabrics.Provider) (*targetEntry, error) {
+			f.opens++
+			return nil, openErr
+		},
+	}
+	return f
+}
+
+// writeTornFlowDir lays down a flow directory shaped like the one a
+// gateway restart leaves behind: flow_def.json and a grains/ directory
+// holding fewer segments than the ring needs.
+func writeTornFlowDir(t *testing.T, domain, flowID string, grains int) string {
+	t.Helper()
+	dir := filepath.Join(domain, flowID+flowDirSuffix)
+	require.NoError(t, os.MkdirAll(filepath.Join(dir, grainDirName), 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "flow_def.json"), []byte(`{}`), 0o644))
+	for i := range grains {
+		require.NoError(t, os.WriteFile(
+			filepath.Join(dir, grainDirName, fmt.Sprintf("grain.%d", i)), []byte("x"), 0o644))
+	}
+	return dir
+}
+
+func (f *openFailureFixture) mirror(t *testing.T) mxlv1alpha1.MxlFlowMirror {
+	t.Helper()
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, f.r.Get(context.Background(), f.key, &got))
+	return got
+}
+
+func TestTarget_OpenFailureEscalatesOutOfMaterializing(t *testing.T) {
+	// A target that cannot be opened used to sit at Materializing with
+	// no counter for as long as the failure lasted, which reads exactly
+	// like a mirror a second away from Ready: nothing to alert on and
+	// nothing to threshold. Consecutive failures must be counted and
+	// must escalate the phase once they rule out a transient fault.
+	f := newOpenFailureFixture(t, errors.New("Target.Setup: mxl: unknown error"),
+		mxlv1alpha1.MxlFlowLocationReady)
+
+	for attempt := uint32(1); attempt < maxTargetOpenAttempts; attempt++ {
+		res, err := f.r.Reconcile(context.Background(), f.req)
+		require.NoError(t, err)
+		assert.Positive(t, res.RequeueAfter,
+			"a failed open must come back as a bounded-backoff requeue")
+
+		got := f.mirror(t)
+		assert.Equal(t, mxlv1alpha1.MxlFlowMirrorMaterializing, got.Status.Phase,
+			"the first failures are still indistinguishable from a slow "+
+				"handshake, so the mirror stays Materializing")
+		assert.Equal(t, int32(attempt), got.Status.TargetAttemptCount,
+			"every failed open must advance the counter, otherwise a wedged "+
+				"mirror is indistinguishable from one that just started")
+	}
+
+	_, err := f.r.Reconcile(context.Background(), f.req)
+	require.NoError(t, err)
+
+	got := f.mirror(t)
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorDegraded, got.Status.Phase,
+		"past maxTargetOpenAttempts the mirror must leave Materializing; "+
+			"a consumer waits through Materializing forever otherwise")
+	assert.Equal(t, int32(maxTargetOpenAttempts), got.Status.TargetAttemptCount)
+	require.Len(t, got.Status.Conditions, 1)
+	assert.Equal(t, mxlv1alpha1.ReasonOpenTargetFailed, got.Status.Conditions[0].Reason)
+	assert.Equal(t, metav1.ConditionFalse, got.Status.Conditions[0].Status)
+}
+
+func TestTarget_OpenAttemptCountSeededFromStatus(t *testing.T) {
+	// The counter lives in memory, so a gateway restart would otherwise
+	// hand a mirror that has been unopenable across the bounce a fresh
+	// budget and drop it back to Materializing.
+	f := newOpenFailureFixture(t, errors.New("Target.Setup: mxl: unknown error"),
+		mxlv1alpha1.MxlFlowLocationReady)
+
+	m := f.mirror(t)
+	m.Status.TargetAttemptCount = int32(maxTargetOpenAttempts) - 1
+	require.NoError(t, f.r.Status().Update(context.Background(), &m))
+
+	_, err := f.r.Reconcile(context.Background(), f.req)
+	require.NoError(t, err)
+
+	got := f.mirror(t)
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorDegraded, got.Status.Phase,
+		"the persisted count must be restored before the escalation "+
+			"threshold is applied, or a restart resets the escalation")
+	assert.Equal(t, int32(maxTargetOpenAttempts), got.Status.TargetAttemptCount)
+}
+
+func TestTarget_WriterFailureReclaimsFlowDirAtThreshold(t *testing.T) {
+	// A gateway restart part-way through materialising a target leaves
+	// a flow directory whose grain ring is short of what its header
+	// declares. Every later open of that path fails, so retrying
+	// against the same directory can only keep failing: the directory
+	// this gateway wrote as a mirror copy has to go so the next pass
+	// materialises a complete one.
+	f := newOpenFailureFixture(t,
+		fmt.Errorf("%w: NewWriter: mxl: unknown error", errOpenWriterFailed),
+		mxlv1alpha1.MxlFlowLocationReady)
+	dir := writeTornFlowDir(t, f.domain, openFailureFlowID, 46)
+
+	for attempt := uint32(1); attempt < maxTargetOpenAttempts; attempt++ {
+		_, err := f.r.Reconcile(context.Background(), f.req)
+		require.NoError(t, err)
+		assert.DirExists(t, dir,
+			"a failure that has not yet repeated must not cost a directory")
+	}
+
+	res, err := f.r.Reconcile(context.Background(), f.req)
+	require.NoError(t, err)
+	assert.NoDirExists(t, dir,
+		"at the threshold the unopenable directory must be removed; "+
+			"leaving it makes every later NewWriter fail the same way")
+	assert.Positive(t, res.RequeueAfter)
+	assert.Less(t, res.RequeueAfter, backoffFor(maxTargetOpenAttempts),
+		"the retry that materialises a fresh directory must not sit out "+
+			"the accumulated backoff first")
+}
+
+func TestTarget_WriterFailureKeepsOriginFlowDir(t *testing.T) {
+	// A flow this node is Origin for belongs to a local producer that
+	// took the directory over from the mirror. Removing it would take
+	// the producer's flow with it, so the open keeps failing rather
+	// than the gateway destroying something it does not own.
+	f := newOpenFailureFixture(t,
+		fmt.Errorf("%w: NewWriter: mxl: unknown error", errOpenWriterFailed),
+		mxlv1alpha1.MxlFlowLocationOrigin)
+	dir := writeTornFlowDir(t, f.domain, openFailureFlowID, 46)
+
+	for range maxTargetOpenAttempts + 1 {
+		_, err := f.r.Reconcile(context.Background(), f.req)
+		require.NoError(t, err)
+	}
+
+	assert.DirExists(t, dir,
+		"an Origin location on this node makes the directory the "+
+			"producer's, not the mirror's")
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorDegraded, f.mirror(t).Status.Phase,
+		"the failure still has to escalate; only the reclaim is withheld")
+}
+
+func TestTarget_FabricFailureKeepsFlowDir(t *testing.T) {
+	// Only a writer that will not open says anything about the
+	// directory. A libmxl-fabrics setup failure is about the endpoint,
+	// and removing the flow file over it would invalidate every
+	// consumer FlowReader on the node for nothing.
+	f := newOpenFailureFixture(t, errors.New("Target.Setup: mxl: unknown error"),
+		mxlv1alpha1.MxlFlowLocationReady)
+	dir := writeTornFlowDir(t, f.domain, openFailureFlowID, 59)
+
+	for range maxTargetOpenAttempts + 1 {
+		_, err := f.r.Reconcile(context.Background(), f.req)
+		require.NoError(t, err)
+	}
+
+	assert.DirExists(t, dir,
+		"a fabric-side failure must not be answered by deleting the "+
+			"local flow directory")
+}
+
+func TestTarget_OpenSuccessClearsAttemptCount(t *testing.T) {
+	// The counter is the length of the current failure run, so a target
+	// that opens must publish zero: a stale count would keep an alert
+	// on a mirror that has recovered.
+	f := newOpenFailureFixture(t, errors.New("Target.Setup: mxl: unknown error"),
+		mxlv1alpha1.MxlFlowLocationReady)
+
+	_, err := f.r.Reconcile(context.Background(), f.req)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), f.mirror(t).Status.TargetAttemptCount)
+
+	info := "info-1"
+	f.r.openTargetFn = func(types.NamespacedName, string, fabrics.Provider) (*targetEntry, error) {
+		return &targetEntry{infoStr: info}, nil
+	}
+	// A successful Reconcile starts the per-mirror flusher; drop the
+	// entry so the goroutine is joined before goleak inspects.
+	t.Cleanup(func() { f.r.closeEntry(f.key, keepFlow) })
+	_, err = f.r.Reconcile(context.Background(), f.req)
+	require.NoError(t, err)
+
+	got := f.mirror(t)
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorReady, got.Status.Phase)
+	assert.Zero(t, got.Status.TargetAttemptCount,
+		"an open target must reset the count, otherwise the mirror keeps "+
+			"reporting a failure run that has ended")
+}
+
+func TestReclaimUnusableFlowDir_MissingDirectory(t *testing.T) {
+	// Nothing on disk means nothing to reclaim, and the caller must not
+	// treat that as a fresh start it can retry immediately.
+	scheme := newSourceTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &TargetReconciler{
+		Client:     c,
+		Scheme:     scheme,
+		NodeName:   "node-a",
+		DomainPath: t.TempDir(),
+	}
+	assert.False(t, r.reclaimUnusableFlowDir(context.Background(), openFailureFlowID))
+}
+
+func TestReclaimUnusableFlowDir_UnsetDomainPath(t *testing.T) {
+	// Without a domain path there is no directory the gateway can name,
+	// so the reclaim must decline rather than resolve a relative one.
+	scheme := newSourceTestScheme(t)
+	c := fake.NewClientBuilder().WithScheme(scheme).Build()
+	r := &TargetReconciler{Client: c, Scheme: scheme, NodeName: "node-a"}
+	assert.False(t, r.reclaimUnusableFlowDir(context.Background(), openFailureFlowID))
+}


### PR DESCRIPTION
A target-side open failure published Phase=Materializing and nothing
else, however many times it was retried. Materializing is the state a
consumer waits through, so a mirror that could never open read exactly
like one a moment away from Ready: no phase change to alert on, no
counter to threshold, and per-reconcile error logs indistinguishable
from ordinary retry noise. Consecutive failures now count in
status.targetAttemptCount and take the phase to Degraded past
maxTargetOpenAttempts, on the bounded backoff the source side already
applies to AddTarget.

The counter is separate from status.attemptCount rather than shared:
the two gateways apply status under different field managers, so one
counter would have each side's server-side apply reset the other's
value.

That threshold is also where a torn flow directory gets answered. A
gateway restart part-way through materialising a target leaves a
directory whose grain ring is shorter than its flow header declares;
libmxl fails every later open of that path, so retrying NewWriter
against the same directory can only keep failing. A writer-side
failure that has repeated now removes the directory, and the next pass
materialises a complete one. The gate is the MxlFlow location
published for this node: a flow this node is Origin for belongs to a
local producer that took the directory over, and removing it would
take the producer's flow with it.

The shortfall is not measured against a grain count derived from
flow_def.json. libmxl sizes the ring from the domain's history
duration as well as the grain rate, so deriving the expected count
here would pin a libmxl implementation detail in Go and start removing
healthy directories the moment it changed. libmxl refusing the open is
the authority instead, and the count present is logged as evidence
before the directory goes.

closes #236
closes #237

feat(api): add targetAttemptCount to MxlFlowMirror status
