### PR TITLE
fix(shim): hook __xstat so pre-2.33 glibc consumers raise intent

### DIFF
--- a/shim/README.md
+++ b/shim/README.md
@@ -72,6 +72,15 @@ and `lstat(2)`. libmxl probes the flow_def.json with `access` and
 left the very first `mxlCreateFlowReader` call returning
 `FLOW_NOT_FOUND` without the shim being consulted.
 
+The stat pair is exported twice. glibc from 2.33 on has plain `stat`
+and `lstat` symbols; before that `<sys/stat.h>` rewrites the call to
+`__xstat(_STAT_VER, ...)`, so a consumer built against an older
+glibc reaches `__xstat` / `__lxstat` and never the plain names. Both
+spellings are hooked, along with the `_64` variants a consumer
+compiled with `_FILE_OFFSET_BITS=64` uses. A consumer linked
+against a pre-2.33 glibc depends on this: without it its directory
+probe returns `ENOENT` unseen and no intent is ever raised.
+
 Calls that don't return `ENOENT`, and calls whose target path
 doesn't match `.../*.mxl-flow/flow_def.json`, fall straight through
 to glibc. Direct syscalls (e.g. `syscall(SYS_openat, ...)` from Go)

--- a/shim/libmxl-intent.c
+++ b/shim/libmxl-intent.c
@@ -72,15 +72,9 @@ static int sys_access(const char *pathname, int mode)
 	return (int)syscall(SYS_faccessat, AT_FDCWD, pathname, mode, 0);
 }
 
-static int sys_stat(const char *pathname, struct stat *buf)
+static int sys_statat(const char *pathname, struct stat *buf, int flags)
 {
-	return (int)syscall(SYS_newfstatat, AT_FDCWD, pathname, buf, 0);
-}
-
-static int sys_lstat(const char *pathname, struct stat *buf)
-{
-	return (int)syscall(SYS_newfstatat, AT_FDCWD, pathname, buf,
-			    AT_SYMLINK_NOFOLLOW);
+	return (int)syscall(SYS_newfstatat, AT_FDCWD, pathname, buf, flags);
 }
 
 /* Return true when path is absolute and contains a non-empty
@@ -406,14 +400,12 @@ int access(const char *pathname, int mode)
 	return sys_access(pathname, mode);
 }
 
-/* libmxl also stat()s the flow_def.json during reader setup. Same
- * rationale as the access hook. On glibc < 2.33 the consumer
- * binary reaches stat via inline __xstat and our `stat` symbol is
- * never called; the hook still exists for glibc 2.33+ consumers
- * that link to plain `stat`. */
-int stat(const char *pathname, struct stat *buf)
+/* Shared body of the stat-family hooks: probe, and on ENOENT for a
+ * flow path ask the agent and probe once more. flags is the
+ * AT_SYMLINK_NOFOLLOW of the lstat variants. */
+static int stat_hook(const char *pathname, struct stat *buf, int flags)
 {
-	int rc = sys_stat(pathname, buf);
+	int rc = sys_statat(pathname, buf, flags);
 	if (rc == 0 || errno != ENOENT) return rc;
 
 	if (!is_flow_path(pathname)) {
@@ -426,23 +418,58 @@ int stat(const char *pathname, struct stat *buf)
 		return -1;
 	}
 
-	return sys_stat(pathname, buf);
+	return sys_statat(pathname, buf, flags);
+}
+
+/* libmxl also stat()s the flow_def.json during reader setup. Same
+ * rationale as the access hook. Consumers built against glibc 2.33+
+ * call these; older ones reach the __xstat pair below instead. */
+int stat(const char *pathname, struct stat *buf)
+{
+	return stat_hook(pathname, buf, 0);
 }
 
 int lstat(const char *pathname, struct stat *buf)
 {
-	int rc = sys_lstat(pathname, buf);
-	if (rc == 0 || errno != ENOENT) return rc;
+	return stat_hook(pathname, buf, AT_SYMLINK_NOFOLLOW);
+}
 
-	if (!is_flow_path(pathname)) {
-		errno = ENOENT;
-		return -1;
-	}
+/* glibc before 2.33 exports no plain stat / lstat at all: <sys/stat.h>
+ * turns the call into __xstat(_STAT_VER, ...), so the two hooks above
+ * are dead code for such a consumer and the probe reaches the kernel
+ * unseen. A libmxl-common linked against such a glibc imports
+ * __xstat and __lxstat, and libmxl probes the flow directory before
+ * it opens flow_def.json, so without these the reader reports
+ * FLOW_NOT_FOUND before any hooked call is made and no intent is ever
+ * raised.
+ *
+ * The version argument selects the struct stat layout. Only
+ * _STAT_VER_KERNEL is in use on the 64-bit architectures
+ * libmxl-fabrics supports, and it is the same layout sys_statat
+ * already fills from the kernel, so it is not consulted. The _64
+ * variants exist because a consumer compiled with
+ * _FILE_OFFSET_BITS=64 reaches those symbol names instead; struct
+ * stat64 and struct stat share a layout there. */
+int __xstat(int ver, const char *pathname, struct stat *buf)
+{
+	(void)ver;
+	return stat_hook(pathname, buf, 0);
+}
 
-	if (request_materialization(pathname) != 0) {
-		errno = ENOENT;
-		return -1;
-	}
+int __lxstat(int ver, const char *pathname, struct stat *buf)
+{
+	(void)ver;
+	return stat_hook(pathname, buf, AT_SYMLINK_NOFOLLOW);
+}
 
-	return sys_lstat(pathname, buf);
+int __xstat64(int ver, const char *pathname, struct stat64 *buf)
+{
+	(void)ver;
+	return stat_hook(pathname, (struct stat *)buf, 0);
+}
+
+int __lxstat64(int ver, const char *pathname, struct stat64 *buf)
+{
+	(void)ver;
+	return stat_hook(pathname, (struct stat *)buf, AT_SYMLINK_NOFOLLOW);
 }


### PR DESCRIPTION
A consumer built against glibc older than 2.33 never reaches the shim's `stat`
and `lstat` hooks. `<sys/stat.h>` rewrites the call to `__xstat(_STAT_VER, ...)`
on those versions, so the plain symbols the shim exports are dead code and the
probe reaches the kernel unseen.

A `libmxl-common.so.1` linked against such a glibc imports that pair:

```
libmxl.so.1          open
libmxl-common.so.1   __lxstat  __xstat  fopen  open  openat  realpath
libmxl-fabrics.so    __xstat   fopen
```

against a shim exporting `access lstat open openat stat`. libmxl probes the
flow directory before it opens `flow_def.json`, so the reader reports
`FLOW_NOT_FOUND` before any hooked call is made. The observable effect is a
consumer with the shim correctly mapped into its processes and a reachable
agent socket, yet zero intent requests logged and no `MxlFlowMirror` ever
created, however many flows it is configured to read. Consumers on current
glibc are unaffected, which is why this surfaces only where the consumer image
predates 2.33.

Both spellings are hooked now, plus the `_64` variants a consumer compiled with
`_FILE_OFFSET_BITS=64` reaches instead. The version argument is not consulted:
only `_STAT_VER_KERNEL` is in use on the 64-bit architectures libmxl-fabrics
supports, and it is the layout the existing `newfstatat` call already fills.

The shared probe-retry body moves into `stat_hook` so the six entry points
cannot drift, and `sys_stat` / `sys_lstat` collapse into `sys_statat`, which
differed only in the flag.

## Verification

Run against a consumer binary importing the same `__xstat` / `__lxstat` pair as
`libmxl-common`, probing a non-existent flow path and counting intent requests
reaching the node agent:

| shim | intent requests |
| --- | --- |
| published `v1.0.0-rc.16` | 0 |
| this build | 1 |

The build carries no glibc reference above `GLIBC_2.4`.

Not addressed here: `libmxl-common` also imports `fopen` and `realpath`, which
the shim does not hook. A `flow_def.json` read through `fopen` would bypass the
`open` hook, since glibc's internal call does not go through the PLT. Left out
because the evidence points at the stat probe and a speculative hook would be
unverified.

Note for reviewers: the unmerged `shim-glibc228` branch addresses the adjacent
question of how the `.so` is built. This change is orthogonal - which symbols
the shim exports, not how it is compiled - but both touch the same file and
will want sequencing.