### PR TITLE
build(shim): fail the build above the supported glibc floor

### DIFF
--- a/docker/shim.Dockerfile
+++ b/docker/shim.Dockerfile
@@ -5,12 +5,17 @@
 # emptyDir shared with the main container.
 # Build context: repo root.
 
+# binutils carries the objdump the Makefile's glibc floor check runs. It
+# arrives with gcc today, named here because the check fails the build without
+# it rather than skipping quietly.
 FROM docker.io/library/debian:trixie-slim AS builder
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends gcc libc6-dev make && \
+    apt-get install -y --no-install-recommends gcc libc6-dev make binutils && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /src
 COPY shim/libmxl-intent.c shim/Makefile ./
+# make runs the floor check, so a build whose glibc symbols outrun the oldest
+# supported consumer fails here rather than at that consumer's pod start.
 RUN make
 
 FROM docker.io/library/debian:trixie-slim

--- a/shim/Makefile
+++ b/shim/Makefile
@@ -3,11 +3,37 @@ CFLAGS  ?= -O2 -Wall -Wextra -fPIC
 LDFLAGS ?= -shared
 LDLIBS  ?=
 
-.PHONY: all clean
-all: libmxl-intent.so
+# The shim is LD_PRELOADed into consumer images this build never sees, so the
+# build glibc is the floor of the supported consumer set rather than a local
+# detail. The oldest target is EL8; a .so versioned above its 2.28 fails to
+# load there, and the loader blames the consumer ("version GLIBC_x.y not found
+# required by libmxl-intent.so") rather than the shim, so the check belongs
+# here where the artefact is produced.
+GLIBC_FLOOR ?= 2.28
+
+.PHONY: all check clean
+all: libmxl-intent.so check
 
 libmxl-intent.so: libmxl-intent.c
 	$(CC) $(CFLAGS) $(LDFLAGS) -o $@ $< $(LDLIBS)
+
+# Fails when any versioned glibc symbol the .so requires is newer than the
+# floor. Reaching libc through direct syscalls rather than dlsym is what keeps
+# it low; a dlsym reintroduction lands at 2.34, where libdl merged into libc.
+check: libmxl-intent.so
+	@max=$$(objdump -T $< | grep -oE 'GLIBC_[0-9.]+' | sed 's/GLIBC_//' \
+		| sort -uV | tail -1); \
+	if [ -z "$$max" ]; then \
+		echo "$<: no versioned glibc symbols found, check objdump" >&2; \
+		exit 1; \
+	fi; \
+	if [ "$$(printf '%s\n%s\n' "$$max" "$(GLIBC_FLOOR)" | sort -V | tail -1)" \
+		!= "$(GLIBC_FLOOR)" ]; then \
+		echo "$<: requires GLIBC_$$max, above the $(GLIBC_FLOOR) floor;" \
+			"consumers on older glibc cannot load it" >&2; \
+		exit 1; \
+	fi; \
+	echo "$<: highest required glibc symbol $$max, floor $(GLIBC_FLOOR)"
 
 clean:
 	rm -f libmxl-intent.so

--- a/shim/README.md
+++ b/shim/README.md
@@ -16,6 +16,16 @@ Produces `libmxl-intent.so`. With the runtime image
 image ships the compiled `.so` at
 `/opt/mxl-intent/libmxl-intent.so`.
 
+`make` also runs `make check`, which fails when the `.so` requires a
+versioned glibc symbol newer than `GLIBC_FLOOR` (2.28, the EL8
+version). The shim is preloaded into consumer images the build never
+sees, so the build glibc is the floor of the supported consumer set:
+a `.so` above it does not load, and the loader reports the failure
+against the consumer rather than the shim. What keeps the requirement
+low is reaching libc through direct syscalls instead of `dlsym`,
+which lands at 2.34 where libdl merged into libc. Override the floor
+with `make GLIBC_FLOOR=2.17` to target something older.
+
 ## Use
 
 In a consumer pod:


### PR DESCRIPTION
The shim ships as a prebuilt `.so` that consumer pods `LD_PRELOAD` from their
own images, so the build glibc is the floor of the supported consumer set, not
a local build detail. A `.so` versioned above that floor does not load, and the
loader blames the consumer:

```
/lib64/libc.so.6: version `GLIBC_2.34' not found
    (required by /opt/mxl-intent/libmxl-intent.so)
```

Nothing asserted the floor. Staying under it has been a property of the source
happening to reach libc through direct syscalls rather than `dlsym` - and
`dlsym` lands at 2.34, where libdl merged into libc. A reintroduction would
pass CI and first show up as a consumer pod that no longer starts, with the
error pointing at the consumer image.

`make` now runs `make check`, which reads the versioned glibc symbols out of
the built `.so` and fails when the highest is newer than `GLIBC_FLOOR`
(default 2.28, the EL8 version). Current build for reference:

```
libmxl-intent.so: highest required glibc symbol 2.4, floor 2.28
```

The comparison is a version sort, so `2.14` ranks above `2.4` rather than
below it. Exercised both directions, including that trap:

| max | floor | result |
| --- | --- | --- |
| 2.4 | 2.28 | pass |
| 2.14 | 2.4 | fail |
| 2.4 | 2.14 | pass |
| 2.34 | 2.28 | fail |
| 2.28 | 2.28 | pass |
| 2.2.5 | 2.28 | pass |

`binutils` is named explicitly in the builder image because the check needs
`objdump`. It arrives with `gcc` today, but an unnamed dependency would make
the check skip rather than fail if that ever changed.

The floor is overridable (`make GLIBC_FLOOR=2.17`) so targeting something older
does not mean editing the Makefile.