### PR TITLE
fix(operator): keep the orphaned-mirror delete from being abandoned

### DIFF
--- a/operator/internal/receiver/controller.go
+++ b/operator/internal/receiver/controller.go
@@ -920,34 +920,60 @@ func (r *Reconciler) removeOwnerRef(ctx context.Context, recv *mxlv1alpha1.MxlRe
 	return nil
 }
 
-// deleteIfStillEmpty deletes mirror at key only when its
-// resourceVersion still matches rv. A concurrent ensureOwnerRef from
-// any receiver that observed the empty owner list and re-added itself
-// wins; we leave the mirror alone. Conflict is logged at V(1) and
-// swallowed; IsNotFound is also swallowed. Bare-empty owner-ref
-// deletion is required because apiserver GC only fires when an owner
-// is deleted, not when ownerReferences becomes empty via Update.
+// deleteIfStillEmpty deletes mirror at key while its owner list is
+// empty, using a resourceVersion precondition so a concurrent
+// ensureOwnerRef that re-added a receiver wins.
+//
+// The precondition alone cannot decide that: it fails on any write,
+// and the mirror's own target and source controllers write status to
+// it continuously (progress, phase, LastSentAt), so a status write
+// landing between the owner-ref Update and this Delete looks
+// identical to a re-added owner. Treating that as a re-add left the
+// mirror ownerless and undeleted, and nothing collects it -- apiserver
+// GC only fires when an owner is deleted, not when ownerReferences
+// becomes empty via Update, so the object persists for the life of
+// the cluster.
+//
+// On conflict the live object decides: an owner list that is still
+// empty means the writer was not a re-add, and the delete is retried
+// against the fresh resourceVersion. Only a non-empty list is a real
+// re-add and leaves the mirror alone. IsNotFound at any point means
+// someone else finished the job.
 func (r *Reconciler) deleteIfStillEmpty(ctx context.Context, key types.NamespacedName, rv string) error {
-	mirrorRef := &mxlv1alpha1.MxlFlowMirror{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:       key.Namespace,
-			Name:            key.Name,
-			ResourceVersion: rv,
-		},
-	}
-	err := r.Delete(ctx, mirrorRef, &client.DeleteOptions{
-		Preconditions: &metav1.Preconditions{ResourceVersion: &rv},
+	l := log.FromContext(ctx)
+	return retry.OnError(retry.DefaultRetry, apierrors.IsConflict, func() error {
+		mirrorRef := &mxlv1alpha1.MxlFlowMirror{
+			ObjectMeta: metav1.ObjectMeta{
+				Namespace:       key.Namespace,
+				Name:            key.Name,
+				ResourceVersion: rv,
+			},
+		}
+		err := r.Delete(ctx, mirrorRef, &client.DeleteOptions{
+			Preconditions: &metav1.Preconditions{ResourceVersion: &rv},
+		})
+		switch {
+		case err == nil, apierrors.IsNotFound(err):
+			return nil
+		case !apierrors.IsConflict(err):
+			return fmt.Errorf("delete orphaned mirror: %w", err)
+		}
+
+		var live mxlv1alpha1.MxlFlowMirror
+		if getErr := r.Get(ctx, key, &live); getErr != nil {
+			if apierrors.IsNotFound(getErr) {
+				return nil
+			}
+			return fmt.Errorf("re-read mirror after delete conflict: %w", getErr)
+		}
+		if len(live.OwnerReferences) > 0 {
+			l.V(1).Info("skipping mirror delete after concurrent owner add",
+				"mirror", key.String(), "owners", len(live.OwnerReferences))
+			return nil
+		}
+		rv = live.ResourceVersion
+		return err
 	})
-	switch {
-	case err == nil, apierrors.IsNotFound(err):
-		return nil
-	case apierrors.IsConflict(err):
-		log.FromContext(ctx).V(1).Info("skipping mirror delete after concurrent owner add",
-			"mirror", key.String())
-		return nil
-	default:
-		return fmt.Errorf("delete orphaned mirror: %w", err)
-	}
 }
 
 // listLiveReceiverUIDs returns the set of UIDs of every MxlReceiver

--- a/operator/internal/receiver/controller_unit_test.go
+++ b/operator/internal/receiver/controller_unit_test.go
@@ -1154,8 +1154,26 @@ func TestRemoveOwnerRef_RejectsDeleteOnConcurrentAdd(t *testing.T) {
 		WithObjects(mirror).
 		Build()
 
+	// The sibling's append has to actually land. A bare conflict is
+	// indistinguishable from any other write to the mirror, so it no
+	// longer aborts the delete on its own; the interceptor performs the
+	// add it stands in for before rejecting.
 	c := interceptor.NewClient(base, interceptor.Funcs{
-		Delete: func(ctx context.Context, _ client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+		Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			key := types.NamespacedName{Namespace: obj.GetNamespace(), Name: obj.GetName()}
+			var live mxlv1alpha1.MxlFlowMirror
+			if err := cl.Get(ctx, key, &live); err != nil {
+				return err
+			}
+			if len(live.OwnerReferences) == 0 {
+				live.OwnerReferences = []metav1.OwnerReference{{
+					APIVersion: mxlv1alpha1.GroupVersion.String(),
+					Kind:       "MxlReceiver", Name: "sibling", UID: "sibling-uid",
+				}}
+				if err := cl.Update(ctx, &live); err != nil {
+					return err
+				}
+			}
 			return apierrors.NewConflict(mxlFlowMirrorGR, obj.GetName(),
 				errors.New("simulated concurrent owner add"))
 		},
@@ -1174,11 +1192,63 @@ func TestRemoveOwnerRef_RejectsDeleteOnConcurrentAdd(t *testing.T) {
 		"the precondition aborted the Delete, so the mirror must still exist; "+
 			"otherwise a sibling receiver's just-added owner ref would have lost "+
 			"its mirror out from under it")
-	assert.Empty(t, live.OwnerReferences,
-		"the receiver's own Update inside the retry loop emptied the owner ref "+
-			"list before the guarded Delete was attempted; the conflict on Delete "+
-			"is the only thing that kept the (now-ownerless) object alive, which is "+
-			"the contract a concurrent ensureOwnerRef relies on for its append to land")
+	assert.Len(t, live.OwnerReferences, 1,
+		"the sibling's owner ref is what makes this conflict a genuine re-add, "+
+			"and an owner list that came back non-empty is the only signal that "+
+			"separates it from an unrelated write")
+}
+
+// A conflict raised by a write that is not an owner add must not be read
+// as one. The mirror's own target and source controllers write status to
+// it continuously, so such a conflict is the common case, and abandoning
+// the delete on it strands the mirror: emptying ownerReferences via
+// Update leaves nothing for apiserver GC to act on.
+func TestRemoveOwnerRef_DeletesAfterConflictFromUnrelatedWrite(t *testing.T) {
+	ctx := context.Background()
+	recv := &mxlv1alpha1.MxlReceiver{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "ns", Name: "r", UID: "recv-uid"},
+	}
+	mirror := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "ns",
+			Name:      "m",
+			OwnerReferences: []metav1.OwnerReference{
+				{APIVersion: mxlv1alpha1.GroupVersion.String(), Kind: "MxlReceiver", Name: "r", UID: "recv-uid"},
+			},
+		},
+	}
+	base := fake.NewClientBuilder().
+		WithScheme(unitScheme(t)).
+		WithObjects(mirror).
+		Build()
+
+	// One-shot conflict standing in for a status write landing between
+	// the owner-ref Update and the guarded Delete. The owner list stays
+	// empty, so the retry has to go through against the fresh version.
+	var deletes int
+	c := interceptor.NewClient(base, interceptor.Funcs{
+		Delete: func(ctx context.Context, cl client.WithWatch, obj client.Object, opts ...client.DeleteOption) error {
+			deletes++
+			if deletes == 1 {
+				return apierrors.NewConflict(mxlFlowMirrorGR, obj.GetName(),
+					errors.New("simulated status write"))
+			}
+			return cl.Delete(ctx, obj, opts...)
+		},
+	})
+	r := &Reconciler{Client: c}
+
+	require.NoError(t, r.removeOwnerRef(ctx, recv, mirror))
+	assert.Greater(t, deletes, 1,
+		"the delete must be retried against the resourceVersion the "+
+			"conflicting write produced, not abandoned")
+
+	var live mxlv1alpha1.MxlFlowMirror
+	err := base.Get(ctx, types.NamespacedName{Namespace: "ns", Name: "m"}, &live)
+	assert.True(t, apierrors.IsNotFound(err),
+		"an ownerless mirror has to end up deleted: native GC never collects a "+
+			"dependent whose owner list was emptied by an Update, so a delete "+
+			"skipped here leaks with no other collector behind it")
 }
 
 func TestEnsureOwnerRef_RetryOnConflict(t *testing.T) {


### PR DESCRIPTION
An `MxlFlowMirror` whose last owner is released can be left ownerless and never
collected.

Emptying `ownerReferences` through an Update leaves nothing for apiserver
garbage collection to act on -- the cascade fires when an owner is deleted or an
owner UID goes dangling, not when the list becomes empty. `removeOwnerRef`
therefore deletes the mirror itself, guarded by a resourceVersion precondition
so a receiver that re-added itself in the race window keeps its mirror.

The precondition cannot carry that decision alone. It fails on **any** write,
and the mirror's own target and source controllers write status to it
continuously (progress, phase, `LastSentAt`, the flusher). A status write
landing between the owner-ref Update and the guarded Delete is therefore
indistinguishable from a re-add, and reading it as one abandoned the delete:

```go
case apierrors.IsConflict(err):
    log...V(1).Info("skipping mirror delete after concurrent owner add", ...)
    return nil          // never retried
```

The mirror is then ownerless with no collector behind it, and persists for the
life of the cluster.

## Fix

The live object decides. On conflict the mirror is re-read: an owner list that
is still empty means the conflicting write was not a re-add, and the delete is
retried against the resourceVersion that write produced. A non-empty list is a
real re-add and still leaves the mirror alone. `IsNotFound` at any point means
someone else finished the job.

## Tests

`TestRemoveOwnerRef_RejectsDeleteOnConcurrentAdd` asserted the old contract
while injecting a bare conflict that never re-added an owner -- which under the
corrected semantics is precisely the case that must retry. It now performs the
add it stands in for, so it tests a genuine re-add rather than any conflict.

`TestRemoveOwnerRef_DeletesAfterConflictFromUnrelatedWrite` is new: a one-shot
conflict standing in for a status write, asserting the delete is retried and
the mirror ends up gone rather than stranded.

Full suite green with envtest provisioned, no skips.

## How it surfaced

`61-shared-mirror-refcount` fails intermittently on the assertion that the
mirror carries a deletionTimestamp within 5s of the last receiver's deletion.
The receiver completes its deletion normally -- it has met its obligation once
the owner ref is dropped -- while the mirror silently survives.

The window is narrow, so it only opens when something is writing mirror status
busily. There is a separate defect that does exactly that, filed alongside this:
the target reconciler watches its own status writes with no predicate, so a
failing open re-triggers itself and churns status. That amplifies this race but
is not its cause; this fix stands on its own.