### PR TITLE
fix(ci): publish the exporter image on a release tag

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -203,7 +203,7 @@ jobs:
           # The images the repository version covers. demo-tools is
           # excluded on purpose: it carries no Go module and ships
           # only on the :dev / :sha-<short> channel.
-          declare -a released=(operator agent gateway shim)
+          declare -a released=(operator agent gateway exporter shim)
 
           if [ -n "${INPUT_RELEASE_TAG:-}" ]; then
             push=true
@@ -216,8 +216,8 @@ jobs:
             esac
             # One tag covers every released image: the root
             # release-please package spans operator, agent, gateway,
-            # shim and the chart, so they all publish the same
-            # version. Selecting them here overrides the diff filter,
+            # exporter, shim and the chart, so they all publish the
+            # same version. Selecting them here overrides the diff filter,
             # which is meaningless for a workflow_call.
             for k in "${!wanted[@]}"; do wanted[$k]=false; done
             for k in "${released[@]}"; do wanted[$k]=true; done


### PR DESCRIPTION
`v1.0.0-rc.21` shipped a chart whose `appVersion` names an exporter
image that was never pushed. `ghcr.io/qvest-digital/mxl-k8s/exporter:v1.0.0-rc.21`
does not exist, so installing that chart with `exporter.enabled=true`
gets an ImagePullBackOff.

A release run clears the per-image diff filter and re-enables only the
images listed in `released`, and the exporter was not among them:

```
declare -a released=(operator agent gateway shim)
```

The same omission failed that release run's `kind-integration`, which
pulls the published images rather than building them on a release and
reported `manifest unknown`. That is the check catching it.

`demo-tools` stays excluded for the reason its comment already gives.

Remediation for the published `v1.0.0-rc.21` is separate from this
change: `images.yml` accepts a `release_tag` on `workflow_dispatch` for
exactly this recovery, and the exporter sources are identical between
the tag and this branch.