### PR TITLE
ci(renovate): drop the "*" that invalidates the gomod group rule

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -33,8 +33,7 @@
       "semanticCommitType": "deps",
       "semanticCommitScope": "gomod",
       "matchPackageNames": [
-        "!github.com/qvest-digital/mxl-k8s/api",
-        "*"
+        "!github.com/qvest-digital/mxl-k8s/api"
       ]
     },
     {


### PR DESCRIPTION
Renovate has been refusing to open pull requests since it hit `packageRules[0].matchPackageNames`, which combined `"*"` with a negative pattern. Renovate rejects that combination outright, so no dependency has been tracked while the error stood.

A negation-only list already means "everything except the negations", so removing `"*"` restores a valid config without changing which modules the Go modules group covers: `github.com/qvest-digital/mxl-k8s/api` stays out, everything else stays in.

Verified against Renovate 42.99.0: `config/validation-helpers/regex-glob-matchers` reports the reported error for the old list and nothing for the new one, and `util/string-match.matchRegexOrGlobList` returns identical results for both lists across the repo's own api module, `github.com/qvest-digital/go-mxl`, `k8s.io/client-go` and `github.com/prometheus/client_golang`.

Closes #215