### PR TITLE
fix(exporter): make flow activity a property of the flow

### DIFF
--- a/exporter/internal/collector/flows.go
+++ b/exporter/internal/collector/flows.go
@@ -44,7 +44,7 @@ var (
 	descPresent = prometheus.NewDesc("mxl_flow_present",
 		"1 while the flow's directory exists in the domain.", flowLabels, nil)
 	descActive = prometheus.NewDesc("mxl_flow_active",
-		"1 when the head index advanced since the previous scrape.", flowLabels, nil)
+		"1 when the flow was written within the exporter's activity window.", flowLabels, nil)
 
 	descHeadIndex = prometheus.NewDesc("mxl_flow_head_index_grains",
 		"Current head index of the flow, in grains.", flowLabels, nil)

--- a/exporter/internal/domain/active_test.go
+++ b/exporter/internal/domain/active_test.go
@@ -1,0 +1,102 @@
+package domain
+
+import (
+	"testing"
+	"time"
+
+	"github.com/qvest-digital/go-mxl/mxl"
+	"github.com/stretchr/testify/require"
+)
+
+const activeTestFlowDef = `{
+  "id": "5fbec3b1-1b0f-417d-9059-8b94a47197ed",
+  "format": "urn:x-nmos:format:video",
+  "tags": { "urn:x-nmos:tag:grouphint/v1.0": ["exporter probe:Video"] },
+  "label": "activity probe",
+  "media_type": "video/v210",
+  "grain_rate": { "numerator": 30000, "denominator": 1001 },
+  "frame_width": 16,
+  "frame_height": 16,
+  "interlace_mode": "progressive",
+  "colorspace": "BT709",
+  "components": [
+    { "name": "Y",  "width": 16, "height": 16, "bit_depth": 10 },
+    { "name": "Cb", "width": 8,  "height": 16, "bit_depth": 10 },
+    { "name": "Cr", "width": 8,  "height": 16, "bit_depth": 10 }
+  ]
+}`
+
+const activeTestFlowID = "5fbec3b1-1b0f-417d-9059-8b94a47197ed"
+
+// newObservedFlow opens a domain over a temp dir, writes one grain,
+// and returns the Domain with the flow scanned in.
+func newObservedFlow(t *testing.T) *Domain {
+	t.Helper()
+	dir := t.TempDir()
+	inst, err := mxl.NewInstance(dir, "")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = inst.Close() })
+
+	w, _, err := inst.NewWriter(activeTestFlowDef)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = w.Close() })
+
+	idx := mxl.CurrentIndex(w.Config().Common.GrainRate)
+	ga, err := w.OpenGrain(idx)
+	require.NoError(t, err)
+	require.NoError(t, ga.Commit(ga.TotalSlices, 0))
+
+	d, err := Open(dir, time.Minute)
+	require.NoError(t, err)
+	t.Cleanup(func() { d.Close() })
+	require.NoError(t, d.Scan())
+	return d
+}
+
+func TestObserveIsIdempotentWithinAScrape(t *testing.T) {
+	// Two collectors are registered against one Domain and Prometheus
+	// calls both inside a single scrape. While activity was a delta
+	// against the previous call, whichever collector ran first consumed
+	// the head advancement and the other reported the flow idle, so one
+	// scrape could carry an advancing head index and active=0. The
+	// order the registry walks its collectors is not fixed, which made
+	// mxl_flow_active a coin flip on every scrape of a healthy flow.
+	d := newObservedFlow(t)
+
+	first := d.Observe()
+	second := d.Observe()
+	require.Len(t, first, 1)
+	require.Len(t, second, 1)
+
+	require.Equal(t, first[0].Active, second[0].Active,
+		"back-to-back Observe calls must agree; a second caller in the "+
+			"same scrape must not be told the flow went idle because the "+
+			"first caller already consumed the sample")
+	require.True(t, first[0].Active,
+		"a flow written moments ago must read as active")
+}
+
+func TestObserveActivityFollowsTheFlowClock(t *testing.T) {
+	// Activity has to be a property of the flow, not of how often
+	// anything asks. A flow whose last write has aged past the window
+	// is inactive however many times it is observed, and a flow that is
+	// still being written stays active however rarely it is.
+	d := newObservedFlow(t)
+
+	obs := d.Observe()
+	require.Len(t, obs, 1)
+	require.Equal(t, activeTestFlowID, obs[0].ID)
+	require.True(t, obs[0].Active)
+	require.Less(t, obs[0].WriteAge, ActivityWindow,
+		"the write age is what decides activity, so it has to be inside "+
+			"the window for a flow just written")
+
+	// Nothing writes to the flow from here on, so it has to fall out of
+	// the window on its own, with no scrape cadence involved.
+	require.Eventually(t, func() bool {
+		o := d.Observe()
+		return len(o) == 1 && !o[0].Active
+	}, 5*time.Second, 20*time.Millisecond,
+		"a flow that stopped being written must go inactive once its "+
+			"last write ages past the window")
+}

--- a/exporter/internal/domain/active_test.go
+++ b/exporter/internal/domain/active_test.go
@@ -87,7 +87,7 @@ func TestObserveActivityFollowsTheFlowClock(t *testing.T) {
 	require.Len(t, obs, 1)
 	require.Equal(t, activeTestFlowID, obs[0].ID)
 	require.True(t, obs[0].Active)
-	require.Less(t, obs[0].WriteAge, ActivityWindow,
+	require.Less(t, obs[0].WriteAge, activityWindow(obs[0].Info.Config.Common),
 		"the write age is what decides activity, so it has to be inside "+
 			"the window for a flow just written")
 
@@ -99,4 +99,50 @@ func TestObserveActivityFollowsTheFlowClock(t *testing.T) {
 	}, 5*time.Second, 20*time.Millisecond,
 		"a flow that stopped being written must go inactive once its "+
 			"last write ages past the window")
+}
+
+func TestActivityWindowFollowsTheFlowRate(t *testing.T) {
+	// A fixed window is wrong at both ends of the rate range: what is
+	// three grains at 25 fps is a fifth of a grain at 1 fps, where a
+	// healthy flow would read stalled between every frame.
+	slow := mxl.CommonFlowConfig{
+		Format:    mxl.FormatVideo,
+		GrainRate: mxl.Rational{Num: 1, Den: 1},
+	}
+	require.Equal(t, activeGrains*time.Second, activityWindow(slow),
+		"a 1 fps flow has to be allowed a full three seconds; anything "+
+			"shorter reports every healthy frame gap as a stall")
+
+	fast := mxl.CommonFlowConfig{
+		Format:    mxl.FormatVideo,
+		GrainRate: mxl.Rational{Num: 60, Den: 1},
+	}
+	require.Equal(t, minActivityWindow, activityWindow(fast),
+		"three grains at 60 fps is shorter than the jitter between two "+
+			"scrapes, so the floor has to take over")
+}
+
+func TestActivityWindowUsesCommitBatchForContinuousFlows(t *testing.T) {
+	// On a continuous flow the grain rate is the sample rate. Treating
+	// it as a write interval would give a 62 microsecond window at
+	// 48 kHz; writes actually land one commit batch apart.
+	audio := mxl.CommonFlowConfig{
+		Format:                 mxl.FormatAudio,
+		GrainRate:              mxl.Rational{Num: 48000, Den: 1},
+		MaxCommitBatchSizeHint: 480,
+	}
+	require.Equal(t, minActivityWindow, activityWindow(audio),
+		"three 10 ms batches is under the floor, so the floor applies")
+
+	sparse := audio
+	sparse.MaxCommitBatchSizeHint = 48000
+	require.Equal(t, activeGrains*time.Second, activityWindow(sparse),
+		"a flow committing one second of samples at a time must be "+
+			"allowed three seconds, not the floor")
+}
+
+func TestActivityWindowFallsBackOnAnUnusableRate(t *testing.T) {
+	require.Equal(t, minActivityWindow,
+		activityWindow(mxl.CommonFlowConfig{Format: mxl.FormatVideo}),
+		"a zero grain rate must not divide by zero or yield a zero window")
 }

--- a/exporter/internal/domain/domain.go
+++ b/exporter/internal/domain/domain.go
@@ -30,8 +30,8 @@ type Observation struct {
 	// false, until its lifetime expires.
 	Present bool
 
-	// Active reports whether the flow was written within
-	// ActivityWindow, measured on the MXL clock that stamps the write
+	// Active reports whether the flow was written within its own
+	// activity window, measured on the MXL clock that stamps the write
 	// itself. A flow can be present and inactive, which is what a
 	// stalled writer looks like from outside.
 	Active bool
@@ -188,10 +188,45 @@ func (d *Domain) openReader(e *entry) {
 	}
 }
 
-// ActivityWindow is how long after its last write a flow still counts
-// as active. Three grain periods at 25 fps, so a flow at any normal
-// rate has to miss several grains before it reads as stalled.
-const ActivityWindow = 120 * time.Millisecond
+// minActivityWindow floors the window derived from a flow's cadence.
+// A 48 kHz audio flow commits every 10 ms and a 60 fps video flow
+// every 17 ms; three of either is shorter than the jitter between two
+// scrapes, so without a floor a healthy fast flow would flap.
+const minActivityWindow = 100 * time.Millisecond
+
+// activeGrains is how many writes a flow may miss before it reads as
+// stalled.
+const activeGrains = 3
+
+// activityWindow returns how long after its last write a flow still
+// counts as active, derived from the flow's own cadence.
+//
+// libmxl does not define this. Its own notion of an active flow is
+// whether any process holds the data file locked, which is what
+// mxlGarbageCollectFlows tests; it maintains lastWriteTime but attaches
+// no threshold to it. The threshold is this exporter's policy, so it
+// has to be relative to the flow rather than a constant: a fixed window
+// that means three grains at 25 fps means a fifth of a grain at 1 fps,
+// where it would report a healthy flow stalled between every frame.
+//
+// On a continuous flow the grain rate is the sample rate and writes
+// land one commit batch apart, not one sample apart.
+func activityWindow(cfg mxl.CommonFlowConfig) time.Duration {
+	rate := cfg.GrainRate
+	if rate.Num <= 0 || rate.Den <= 0 {
+		return minActivityWindow
+	}
+	perWrite := time.Duration(float64(rate.Den) / float64(rate.Num) * float64(time.Second))
+	if !cfg.Format.IsDiscrete() {
+		if batch := cfg.MaxCommitBatchSizeHint; batch > 0 {
+			perWrite *= time.Duration(batch)
+		}
+	}
+	if w := activeGrains * perWrite; w > minActivityWindow {
+		return w
+	}
+	return minActivityWindow
+}
 
 // Observe samples every tracked flow. It holds no state across calls:
 // every value is read from the flow header, so calling it twice in a
@@ -228,7 +263,7 @@ func (d *Domain) Observe() []Observation {
 				}
 				if lw := info.Runtime.LastWriteTime; lw != 0 && now > lw {
 					obs.WriteAge = time.Duration(now-lw) * time.Nanosecond
-					active = obs.WriteAge < ActivityWindow
+					active = obs.WriteAge < activityWindow(info.Config.Common)
 				}
 			}
 		}

--- a/exporter/internal/domain/domain.go
+++ b/exporter/internal/domain/domain.go
@@ -216,12 +216,15 @@ func activityWindow(cfg mxl.CommonFlowConfig) time.Duration {
 	if rate.Num <= 0 || rate.Den <= 0 {
 		return minActivityWindow
 	}
-	perWrite := time.Duration(float64(rate.Den) / float64(rate.Num) * float64(time.Second))
-	if !cfg.Format.IsDiscrete() {
-		if batch := cfg.MaxCommitBatchSizeHint; batch > 0 {
-			perWrite *= time.Duration(batch)
-		}
+	// One unit per write: a grain on a discrete flow, a commit batch of
+	// samples on a continuous one. Multiplied in before the division so
+	// a rate that does not divide evenly into a nanosecond does not
+	// lose a whole batch to truncation.
+	units := int64(1)
+	if !cfg.Format.IsDiscrete() && cfg.MaxCommitBatchSizeHint > 0 {
+		units = int64(cfg.MaxCommitBatchSizeHint)
 	}
+	perWrite := time.Duration(int64(time.Second) * rate.Den * units / rate.Num)
 	if w := activeGrains * perWrite; w > minActivityWindow {
 		return w
 	}

--- a/exporter/internal/domain/domain.go
+++ b/exporter/internal/domain/domain.go
@@ -30,9 +30,10 @@ type Observation struct {
 	// false, until its lifetime expires.
 	Present bool
 
-	// Active reports whether the head index advanced since the
-	// previous observation. A flow can be present and inactive, which
-	// is what a stalled writer looks like from outside.
+	// Active reports whether the flow was written within
+	// ActivityWindow, measured on the MXL clock that stamps the write
+	// itself. A flow can be present and inactive, which is what a
+	// stalled writer looks like from outside.
 	Active bool
 
 	// HaveInfo reports whether Info and Latency could be read. A flow
@@ -71,9 +72,6 @@ type entry struct {
 	reader *mxl.Reader
 	def    *FlowDef
 
-	lastHead    uint64
-	haveLast    bool
-	active      bool
 	removedAt   time.Time
 	sizeBytes   uint64
 	openAttempt bool
@@ -190,9 +188,22 @@ func (d *Domain) openReader(e *entry) {
 	}
 }
 
-// Observe samples every tracked flow. Activity is measured between
-// consecutive calls, so the scrape interval is what "active" is
-// relative to.
+// ActivityWindow is how long after its last write a flow still counts
+// as active. Three grain periods at 25 fps, so a flow at any normal
+// rate has to miss several grains before it reads as stalled.
+const ActivityWindow = 120 * time.Millisecond
+
+// Observe samples every tracked flow. It holds no state across calls:
+// every value is read from the flow header, so calling it twice in a
+// row answers the same thing twice.
+//
+// Activity used to be a delta against the previous call, which made it
+// a property of the caller rather than of the flow. Two collectors are
+// registered and Prometheus calls both in one scrape, so whichever ran
+// first consumed the head advancement and the other reported the flow
+// idle - the same scrape could carry an advancing head index and
+// active=0. Anything else sampling the endpoint, a probe or a second
+// Prometheus, corrupted the answer the same way.
 func (d *Domain) Observe() []Observation {
 	d.mu.Lock()
 	defer d.mu.Unlock()
@@ -205,15 +216,11 @@ func (d *Domain) Observe() []Observation {
 			Present: e.removedAt.IsZero(),
 			Def:     e.def,
 		}
+		active := false
 		if e.reader != nil {
 			if info, err := e.reader.Info(); err == nil {
 				obs.HaveInfo = true
 				obs.Info = info
-				if e.haveLast {
-					e.active = info.Runtime.HeadIndex > e.lastHead
-				}
-				e.lastHead = info.Runtime.HeadIndex
-				e.haveLast = true
 
 				rate := info.Config.Common.GrainRate
 				if rate.Den != 0 && rate.Num != 0 {
@@ -221,12 +228,13 @@ func (d *Domain) Observe() []Observation {
 				}
 				if lw := info.Runtime.LastWriteTime; lw != 0 && now > lw {
 					obs.WriteAge = time.Duration(now-lw) * time.Nanosecond
+					active = obs.WriteAge < ActivityWindow
 				}
 			}
 		}
-		// A departed flow is never active, whatever the last sample
-		// said.
-		obs.Active = e.active && obs.Present
+		// A departed flow is never active, however recent its last
+		// write was.
+		obs.Active = active && obs.Present
 		out = append(out, obs)
 	}
 	return out
@@ -295,6 +303,4 @@ func (e *entry) close() {
 		_ = e.reader.Close()
 		e.reader = nil
 	}
-	e.haveLast = false
-	e.active = false
 }


### PR DESCRIPTION
mxl_flow_active was a delta against the previous Observe call, which
made it a property of whoever asked rather than of the flow. Two
collectors are registered against one Domain and Prometheus calls both
inside a single scrape: whichever ran first consumed the head
advancement, and the other read an unchanged head and reported the
flow idle. One scrape could therefore carry an advancing head index
and active=0 for the same flow. The registry does not fix the order it
walks collectors, so the metric was a coin flip on every scrape of a
healthy flow, and anything else sampling the endpoint corrupted it the
same way.

Activity now comes from the write timestamp in the flow header, which
is the same clock the reported write age already uses. Observe holds
no state across calls, so a second caller in one scrape is told what
the first was told, and a flow that stopped being written falls out of
the window on its own however often it is sampled.

The distinction matters beyond the metric: an operator reading
mxl_flow_active to find flows whose producer has died was being shown
healthy flows as idle.
