### PR TITLE
fix(gateway): make the target open backoff authoritative

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -89,6 +89,14 @@ jobs:
             # true iff some changed file is not a .md.
             code:       ['!**/*.md']
             kind:
+              # The suite exercises the images these modules build, so a
+              # change to one is exactly what it exists to catch.
+              - 'operator/**'
+              - 'agent/**'
+              - 'gateway/**'
+              - 'exporter/**'
+              - 'api/**'
+              - 'go.work*'
               - 'hack/kind-*'
               - 'docker/**'
               - 'examples/tcp-demo/**'

--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -89,14 +89,6 @@ jobs:
             # true iff some changed file is not a .md.
             code:       ['!**/*.md']
             kind:
-              # The suite exercises the images these modules build, so a
-              # change to one is exactly what it exists to catch.
-              - 'operator/**'
-              - 'agent/**'
-              - 'gateway/**'
-              - 'exporter/**'
-              - 'api/**'
-              - 'go.work*'
               - 'hack/kind-*'
               - 'docker/**'
               - 'examples/tcp-demo/**'
@@ -314,13 +306,19 @@ jobs:
           # with-release_tag invocations always skip. has_images=false
           # short-circuits to false too: with no images to build,
           # there is nothing for kind to load.
+          #
+          # Any rebuilt image is worth smoke-testing, so has_images
+          # selects as well as vetoes. The kind filter stays for what
+          # changes the cluster without building an image: the chart,
+          # the CRDs, the harness. Listing module paths there instead
+          # would be a second list to keep in step with the modules.
           kind_wanted=false
           case "$GITHUB_EVENT_NAME" in
             pull_request)
               # Fork PRs are excluded -- the per-PR image tag is not
               # pushed to GHCR, so there is no manifest to kind-load.
               if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
-                if [ "$CHANGED_KIND" = "true" ]; then
+                if [ "$CHANGED_KIND" = "true" ] || [ "$has_images" = "true" ]; then
                   kind_wanted=true
                 elif echo "${PR_LABELS_JSON:-[]}" | grep -q '"run-kind"'; then
                   kind_wanted=true
@@ -329,7 +327,7 @@ jobs:
               ;;
             push)
               if [ "$GITHUB_REF" = "refs/heads/main" ] \
-                  && [ "$CHANGED_KIND" = "true" ] \
+                  && { [ "$CHANGED_KIND" = "true" ] || [ "$has_images" = "true" ]; } \
                   && [ "$push" = "true" ]; then
                 kind_wanted=true
               fi

--- a/gateway/internal/mirror/common.go
+++ b/gateway/internal/mirror/common.go
@@ -24,6 +24,9 @@ package mirror
 import (
 	"errors"
 	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/qvest-digital/mxl-k8s/gateway/internal/fabric"
 
@@ -209,3 +212,63 @@ func classifyFabricError(err error) fabricFailure {
 	}
 	return fabricEndpointLost
 }
+
+// attempt is one mirror's failure run: consecutive failures, the
+// earliest the next try may run, and the inputs that wait was earned
+// against.
+type attempt[I comparable] struct {
+	count     uint32
+	notBefore time.Time
+	inputs    I
+}
+
+// attemptTable holds the failure runs of a reconciler that publishes
+// status on the object it watches. Such a write wakes the reconciler
+// through its own watch long before the RequeueAfter a failure
+// returned is due, so the wait has to be enforced on the way in
+// rather than returned as advice. Callers hold their own lock.
+type attemptTable[I comparable] map[types.NamespacedName]attempt[I]
+
+// wait reports how long remains before key may be retried against
+// inputs. Different inputs are a new attempt rather than a retry of
+// the one that failed, and serve no wait.
+func (t attemptTable[I]) wait(key types.NamespacedName, inputs I, now time.Time) (time.Duration, bool) {
+	a, ok := t[key]
+	if !ok || a.inputs != inputs {
+		return 0, false
+	}
+	if d := a.notBefore.Sub(now); d > 0 {
+		return d, true
+	}
+	return 0, false
+}
+
+// fail records a failure against inputs, arms the wait and returns the
+// new consecutive count.
+func (t attemptTable[I]) fail(key types.NamespacedName, inputs I, now time.Time, backoff func(uint32) time.Duration) (uint32, time.Duration) {
+	a := t[key]
+	a.count++
+	a.inputs = inputs
+	d := backoff(a.count)
+	a.notBefore = now.Add(d)
+	t[key] = a
+	return a.count, d
+}
+
+// rearm shortens or extends the wait already recorded for key.
+func (t attemptTable[I]) rearm(key types.NamespacedName, now time.Time, d time.Duration) {
+	if a, ok := t[key]; ok {
+		a.notBefore = now.Add(d)
+		t[key] = a
+	}
+}
+
+// seed restores a count persisted on status without arming a wait, so
+// a restart does not hand a wedged mirror a fresh budget.
+func (t attemptTable[I]) seed(key types.NamespacedName, count uint32) {
+	if _, ok := t[key]; !ok && count > 0 {
+		t[key] = attempt[I]{count: count}
+	}
+}
+
+func (t attemptTable[I]) count(key types.NamespacedName) uint32 { return t[key].count }

--- a/gateway/internal/mirror/orphan_test.go
+++ b/gateway/internal/mirror/orphan_test.go
@@ -57,7 +57,7 @@ func TestReconcile_SourceFinalizerReapedWhenSourceNodeGone(t *testing.T) {
 		Scheme:   scheme,
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 	}
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
@@ -93,7 +93,7 @@ func TestReconcile_SourceFinalizerKeptWhileSourceNodeExists(t *testing.T) {
 		Scheme:   scheme,
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 	}
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
@@ -201,7 +201,7 @@ func TestReconcile_LastOrphanedFinalizerCompletesDeletion(t *testing.T) {
 		Scheme:   scheme,
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 	}
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -139,9 +139,13 @@ type SourceReconciler struct {
 	// reader. Mirrors the target reconciler's recoverFn.
 	rebuildFn func(key types.NamespacedName)
 
+	// nowFn is the clock the AddTarget wait is measured against.
+	// Production leaves it nil.
+	nowFn func() time.Time
+
 	mu       sync.Mutex
 	sources  map[types.NamespacedName]*sourceEntry
-	attempts map[types.NamespacedName]uint32
+	attempts attemptTable[sourceAddInputs]
 	// rebuilds counts consecutive reader reopens per mirror. It
 	// outlives the sourceEntry the watchdog tears down, which is the
 	// point: the budget has to survive the reopen it is bounding.
@@ -387,16 +391,21 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// Only the counter is restored: the next attempt fires immediately
 	// rather than waiting out a remembered backoff window, which keeps
 	// the design's "one free retry on restart" budget intact.
+	inputs := sourceAddInputs{targetInfo: mirror.Status.TargetInfo, provider: provider}
 	r.mu.Lock()
-	if _, ok := r.attempts[req.NamespacedName]; !ok && mirror.Status.AttemptCount > 0 {
-		r.attempts[req.NamespacedName] = uint32(mirror.Status.AttemptCount)
-	}
+	r.attempts.seed(req.NamespacedName, uint32(mirror.Status.AttemptCount))
+	remaining, gated := r.attempts.wait(req.NamespacedName, inputs, r.now())
 	r.mu.Unlock()
+	// Publishing SourceProgress is what wakes this reconciler through
+	// its own watch, so a gated pass writes nothing.
+	if gated {
+		return ctrl.Result{RequeueAfter: remaining}, nil
+	}
 
 	entry, err := r.opener.open(mirror.Spec.FlowID, mirror.Status.TargetInfo, provider)
 	if err != nil {
 		if errors.Is(err, errAddTargetFailed) {
-			return r.handleAddTargetFailure(ctx, req.NamespacedName, err)
+			return r.handleAddTargetFailure(ctx, req.NamespacedName, inputs, err)
 		}
 		return ctrl.Result{}, fmt.Errorf("open initiator: %w", err)
 	}
@@ -437,10 +446,9 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 // returns a bounded-backoff RequeueAfter so the libmxl-fabrics
 // initiator is not torn down and rebuilt every controller-runtime
 // tick while the target is unreachable.
-func (r *SourceReconciler) handleAddTargetFailure(ctx context.Context, key types.NamespacedName, addErr error) (ctrl.Result, error) {
+func (r *SourceReconciler) handleAddTargetFailure(ctx context.Context, key types.NamespacedName, inputs sourceAddInputs, addErr error) (ctrl.Result, error) {
 	r.mu.Lock()
-	r.attempts[key]++
-	attempts := r.attempts[key]
+	attempts, wait := r.attempts.fail(key, inputs, r.now(), backoffFor)
 	r.mu.Unlock()
 
 	msg := addErr.Error()
@@ -452,7 +460,22 @@ func (r *SourceReconciler) handleAddTargetFailure(ctx context.Context, key types
 	}); err != nil {
 		log.FromContext(ctx).Error(err, "publish SourceProgress")
 	}
-	return ctrl.Result{RequeueAfter: backoffFor(attempts)}, nil
+	return ctrl.Result{RequeueAfter: wait}, nil
+}
+
+// now reports the current time through the reconciler's clock seam.
+func (r *SourceReconciler) now() time.Time {
+	if r.nowFn != nil {
+		return r.nowFn()
+	}
+	return time.Now()
+}
+
+// sourceAddInputs is what an AddTarget attempt depends on. A rotated
+// TargetInfo is a new attempt, not a retry of the one that failed.
+type sourceAddInputs struct {
+	targetInfo string
+	provider   fabrics.Provider
 }
 
 // backoffFor returns 100ms * 2^(attempts-1) capped at 30s. The cap
@@ -1341,7 +1364,7 @@ func (r *SourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		r.sources = make(map[types.NamespacedName]*sourceEntry)
 	}
 	if r.attempts == nil {
-		r.attempts = make(map[types.NamespacedName]uint32)
+		r.attempts = make(attemptTable[sourceAddInputs])
 	}
 	if r.rebuilds == nil {
 		r.rebuilds = make(map[types.NamespacedName]uint32)

--- a/gateway/internal/mirror/source_addbackoff_test.go
+++ b/gateway/internal/mirror/source_addbackoff_test.go
@@ -1,0 +1,135 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+type addBackoffFixture struct {
+	r       *SourceReconciler
+	opener  *fakeOpener
+	key     types.NamespacedName
+	req     reconcile.Request
+	advance func(time.Duration)
+}
+
+func newAddBackoffFixture(t *testing.T, targetInfo string) *addBackoffFixture {
+	t.Helper()
+	scheme := newSourceTestScheme(t)
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", "flow-1", targetInfo)
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	opener := &fakeOpener{
+		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+			return nil, errors.Join(errAddTargetFailed, errors.New("connect: target offline"))
+		},
+	}
+	clock, advance := fixedClock(time.Now())
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	return &addBackoffFixture{
+		r: &SourceReconciler{
+			Client:   c,
+			Scheme:   scheme,
+			NodeName: "node-a",
+			nowFn:    clock,
+			opener:   opener,
+			sources:  map[types.NamespacedName]*sourceEntry{},
+			attempts: attemptTable[sourceAddInputs]{},
+		},
+		opener:  opener,
+		key:     key,
+		req:     reconcile.Request{NamespacedName: key},
+		advance: advance,
+	}
+}
+
+func (f *addBackoffFixture) mirror(t *testing.T) mxlv1alpha1.MxlFlowMirror {
+	t.Helper()
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, f.r.Get(context.Background(), f.key, &got))
+	return got
+}
+
+func TestSource_AddTargetBackoffGatesRepeatedAttempts(t *testing.T) {
+	// A failed AddTarget publishes SourceProgress on the mirror this
+	// reconciler watches, so the write wakes it again at once and the
+	// RequeueAfter never applies. Left advisory, an unreachable target
+	// is retried at apiserver rate and the initiator is torn down and
+	// rebuilt on every pass.
+	f := newAddBackoffFixture(t, "info-1")
+	ctx := context.Background()
+
+	res, err := f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+	require.Positive(t, res.RequeueAfter)
+	require.Equal(t, int32(1), f.opener.calls.Load())
+
+	settled := f.mirror(t)
+	require.Equal(t, int32(1), settled.Status.AttemptCount)
+
+	for range 20 {
+		res, err := f.r.Reconcile(ctx, f.req)
+		require.NoError(t, err)
+		assert.Positive(t, res.RequeueAfter)
+	}
+
+	assert.Equal(t, int32(1), f.opener.calls.Load(),
+		"inside the backoff the initiator must not be rebuilt")
+
+	after := f.mirror(t)
+	assert.Equal(t, int32(1), after.Status.AttemptCount,
+		"a gated pass must not advance the failure count")
+	assert.Equal(t, settled.ResourceVersion, after.ResourceVersion,
+		"a gated pass must not publish status: that write is what wakes "+
+			"this reconciler")
+
+	f.advance(backoffFor(1))
+	_, err = f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), f.opener.calls.Load(),
+		"the retry must happen once the backoff has elapsed")
+	assert.Equal(t, int32(2), f.mirror(t).Status.AttemptCount)
+}
+
+func TestSource_AddTargetBackoffReleasedWhenTargetInfoRotates(t *testing.T) {
+	// A rotated TargetInfo is the target side reporting a rebuilt
+	// endpoint. That is a new attempt, and holding it behind a delay
+	// earned against the dead endpoint would keep the transfer down for
+	// up to the 30s cap after the very thing that fixes it.
+	f := newAddBackoffFixture(t, "info-1")
+	ctx := context.Background()
+
+	_, err := f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), f.opener.calls.Load())
+
+	_, err = f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+	require.Equal(t, int32(1), f.opener.calls.Load(),
+		"the same endpoint inside the backoff stays gated")
+
+	m := f.mirror(t)
+	m.Status.TargetInfo = "info-2"
+	require.NoError(t, f.r.Status().Update(ctx, &m))
+
+	_, err = f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+	assert.Equal(t, int32(2), f.opener.calls.Load(),
+		"a rotated TargetInfo must be attempted at once")
+}

--- a/gateway/internal/mirror/source_rotation_test.go
+++ b/gateway/internal/mirror/source_rotation_test.go
@@ -59,7 +59,7 @@ func TestReconcile_FlowOriginRotation_DetectedAfterStaleOpen(t *testing.T) {
 		opener:        opener,
 		FlushInterval: time.Hour,
 		sources:       map[types.NamespacedName]*sourceEntry{},
-		attempts:      map[types.NamespacedName]uint32{},
+		attempts:      attemptTable[sourceAddInputs]{},
 	}
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}

--- a/gateway/internal/mirror/source_stall_test.go
+++ b/gateway/internal/mirror/source_stall_test.go
@@ -179,7 +179,7 @@ func TestReconcile_PreservesLastSentAtAcrossReopen(t *testing.T) {
 		opener:        opener,
 		FlushInterval: time.Hour,
 		sources:       map[types.NamespacedName]*sourceEntry{},
-		attempts:      map[types.NamespacedName]uint32{},
+		attempts:      attemptTable[sourceAddInputs]{},
 	}
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
@@ -222,7 +222,7 @@ func TestRunFlusher_ReopensWedgedReader(t *testing.T) {
 		Scheme:   scheme,
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 		rebuilds: map[types.NamespacedName]uint32{},
 		rebuildFn: func(key types.NamespacedName) {
 			rebuilt <- key
@@ -277,7 +277,7 @@ func TestRunFlusher_StopsReopeningAtCap(t *testing.T) {
 		Scheme:   scheme,
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 		rebuilds: map[types.NamespacedName]uint32{key: maxReaderRebuilds},
 		rebuildFn: func(types.NamespacedName) {
 			t.Error("no reopen may be spawned once the budget is spent")
@@ -320,7 +320,7 @@ func TestRunFlusher_ClearsRebuildBudgetOnProgress(t *testing.T) {
 		Scheme:   scheme,
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 		rebuilds: map[types.NamespacedName]uint32{key: 3},
 	}
 

--- a/gateway/internal/mirror/source_test.go
+++ b/gateway/internal/mirror/source_test.go
@@ -551,7 +551,9 @@ func TestReconcile_AddTargetFailureSurfacesConditionAndCapsBackoffAt30s(t *testi
 		Build()
 
 	addErr := errors.New("connect: target offline")
+	clock, advance := fixedClock(time.Now())
 	r := &SourceReconciler{
+		nowFn:    clock,
 		Client:   c,
 		Scheme:   scheme,
 		NodeName: "node-a",
@@ -561,7 +563,7 @@ func TestReconcile_AddTargetFailureSurfacesConditionAndCapsBackoffAt30s(t *testi
 			},
 		},
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 	}
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
@@ -590,6 +592,7 @@ func TestReconcile_AddTargetFailureSurfacesConditionAndCapsBackoffAt30s(t *testi
 	// the 30s cap (2^9 * 100ms = 51.2s > 30s, so attempts=9 caps).
 	var lastResult ctrl.Result
 	for i := 0; i < 9; i++ {
+		advance(backoffFor(uint32(i + 1)))
 		lastResult, err = r.Reconcile(context.Background(), req)
 		require.NoError(t, err)
 	}
@@ -649,7 +652,7 @@ func TestReconcile_FlowOriginRotationReopensReader(t *testing.T) {
 		opener:        opener,
 		FlushInterval: time.Hour,
 		sources:       map[types.NamespacedName]*sourceEntry{},
-		attempts:      map[types.NamespacedName]uint32{},
+		attempts:      attemptTable[sourceAddInputs]{},
 	}
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
@@ -717,7 +720,7 @@ func TestReconcile_SourceNodeMutatedAwayClosesEntry(t *testing.T) {
 		Scheme:   scheme,
 		NodeName: selfNode,
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 	}
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
@@ -767,7 +770,7 @@ func TestSource_SeedAttemptsFromStatus(t *testing.T) {
 			},
 		},
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 	}
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
@@ -775,7 +778,7 @@ func TestSource_SeedAttemptsFromStatus(t *testing.T) {
 	require.NoError(t, err)
 
 	r.mu.Lock()
-	got := r.attempts[key]
+	got := r.attempts.count(key)
 	r.mu.Unlock()
 	assert.Equal(t, uint32(6), got,
 		"seed must restore the persisted attemptCount (5) before the "+
@@ -1010,7 +1013,7 @@ func TestPublishSourceProgress_IncludesLastSentAt(t *testing.T) {
 		Scheme:   scheme,
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 	}
 
 	sent := time.Now().UTC().Truncate(time.Second)
@@ -1118,7 +1121,7 @@ func TestSource_FlusherSuppressesIdenticalTicksAfterFirstTransfer(t *testing.T) 
 		NodeName:      "node-a",
 		FlushInterval: 2 * time.Millisecond,
 		sources:       map[types.NamespacedName]*sourceEntry{},
-		attempts:      map[types.NamespacedName]uint32{},
+		attempts:      attemptTable[sourceAddInputs]{},
 	}
 
 	entry := &sourceEntry{}
@@ -1181,7 +1184,7 @@ func TestPublishSourceProgress_OmitsLastSentAtWhenNeverTransferred(t *testing.T)
 		Scheme:   scheme,
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[sourceAddInputs]{},
 	}
 
 	require.NoError(t, r.publishSourceProgress(context.Background(), key, sourceProgressState{

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -2,6 +2,7 @@ package mirror
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -106,6 +107,12 @@ const maxStuckRebuilds uint32 = 3
 // gets the flow directory reclaimed (see reclaimUnusableFlowDir).
 const maxTargetOpenAttempts uint32 = 3
 
+// reclaimRetryDelay is how long the retry after a flow-directory
+// reclaim waits. Short on purpose: materialising a fresh directory is
+// the point of the reclaim, so that attempt does not sit out the
+// backoff the failures before it earned.
+const reclaimRetryDelay = 100 * time.Millisecond
+
 // flowDirSuffix is the directory-name suffix libmxl gives a per-flow
 // directory under a domain (FLOW_DIRECTORY_NAME_SUFFIX). go-mxl keeps
 // its own copy unexported, so the gateway carries one; the agent
@@ -208,6 +215,12 @@ type TargetReconciler struct {
 	// escalation out of Materializing can be observed without one.
 	openTargetFn func(key types.NamespacedName, flowDef string, provider fabrics.Provider) (*targetEntry, error)
 
+	// nowFn is the clock the open backoff is measured against.
+	// Production leaves it nil and the reconciler falls back to
+	// time.Now; tests inject one so the gate can be driven without
+	// sleeping.
+	nowFn func() time.Time
+
 	mu      sync.Mutex
 	targets map[types.NamespacedName]*targetEntry
 
@@ -215,6 +228,30 @@ type TargetReconciler struct {
 	// Cleared the moment a target opens, so the value is always the
 	// length of the current failure run. Guarded by mu.
 	attempts map[types.NamespacedName]uint32
+
+	// openBackoff holds the earliest time the next openTarget for a
+	// mirror may run. Guarded by mu. Entries are dropped when the
+	// target opens and when the mirror is torn down, so the map holds
+	// at most one entry per mirror currently failing to open.
+	openBackoff map[types.NamespacedName]targetOpenBackoff
+}
+
+// targetOpenBackoff gates repeated openTarget attempts for one mirror.
+//
+// A failed open publishes status on the mirror, and this reconciler
+// watches that same object, so the write wakes it again at once. The
+// RequeueAfter a failure returns is only advisory against that: the
+// watch event arrives long before the requeue is due, so the backoff
+// never applies and the open retries at apiserver rate, writing status
+// every time.
+//
+// signature pins the backoff to the inputs it was earned against. A
+// mirror whose flow definition or provider has changed is a new
+// attempt rather than a retry of the one that failed, and must not sit
+// out the accumulated delay.
+type targetOpenBackoff struct {
+	notBefore time.Time
+	signature string
 }
 
 // targetEntry holds the live libmxl handles for one target-side
@@ -451,9 +488,20 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 	r.mu.Unlock()
 
+	// A failed open wrote status, and that write wakes this reconciler
+	// through its own watch. Answering that wake with another open
+	// would retry at apiserver rate however long the returned
+	// RequeueAfter was, so the backoff is enforced here rather than
+	// left to the requeue. Nothing is written on a gated pass: the
+	// write is what closes the loop.
+	signature := targetAttemptSignature(string(flow.Spec.Definition.Raw), provider)
+	if remaining, gated := r.openGatedFor(req.NamespacedName, signature); gated {
+		return ctrl.Result{RequeueAfter: remaining}, nil
+	}
+
 	entry, err := r.openTargetDispatch(req.NamespacedName, string(flow.Spec.Definition.Raw), provider)
 	if err != nil {
-		return r.handleOpenTargetFailure(ctx, &mirror, err)
+		return r.handleOpenTargetFailure(ctx, &mirror, signature, err)
 	}
 
 	r.mu.Lock()
@@ -466,6 +514,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 	r.targets[req.NamespacedName] = entry
 	delete(r.attempts, req.NamespacedName)
+	delete(r.openBackoff, req.NamespacedName)
 	r.mu.Unlock()
 
 	// Publish the descriptor before the phase: a Ready mirror whose
@@ -488,6 +537,54 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		"sourceNode", mirror.Spec.SourceNode,
 		"provider", provider.String())
 	return ctrl.Result{}, nil
+}
+
+// now reports the current time through the reconciler's clock seam.
+func (r *TargetReconciler) now() time.Time {
+	if r.nowFn != nil {
+		return r.nowFn()
+	}
+	return time.Now()
+}
+
+// targetAttemptSignature identifies the inputs an open attempt was
+// made with, so a backoff earned against one flow definition and
+// provider does not hold back an attempt against different ones.
+func targetAttemptSignature(flowDef string, provider fabrics.Provider) string {
+	return fmt.Sprintf("%v|%x", provider, sha256.Sum256([]byte(flowDef)))
+}
+
+// openGatedFor reports how long remains of the backoff earned by the
+// previous failed open for key, and whether it still applies. A
+// signature that no longer matches, or an elapsed deadline, drops the
+// entry and reports no gate.
+func (r *TargetReconciler) openGatedFor(key types.NamespacedName, signature string) (time.Duration, bool) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	b, ok := r.openBackoff[key]
+	if !ok {
+		return 0, false
+	}
+	if b.signature != signature {
+		delete(r.openBackoff, key)
+		return 0, false
+	}
+	remaining := b.notBefore.Sub(r.now())
+	if remaining <= 0 {
+		delete(r.openBackoff, key)
+		return 0, false
+	}
+	return remaining, true
+}
+
+// setOpenBackoff records that the next open for key must wait d.
+func (r *TargetReconciler) setOpenBackoff(key types.NamespacedName, signature string, d time.Duration) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.openBackoff == nil {
+		r.openBackoff = make(map[types.NamespacedName]targetOpenBackoff)
+	}
+	r.openBackoff[key] = targetOpenBackoff{notBefore: r.now().Add(d), signature: signature}
 }
 
 // openTarget walks the libmxl handshake: open FlowWriter, create +
@@ -546,7 +643,7 @@ func (r *TargetReconciler) openTargetDispatch(key types.NamespacedName, flowDef 
 // consecutive failures the phase escalates to Degraded and, for a
 // failure that came from the local writer, the flow directory is
 // reclaimed so the retry materialises a fresh one.
-func (r *TargetReconciler) handleOpenTargetFailure(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror, openErr error) (ctrl.Result, error) {
+func (r *TargetReconciler) handleOpenTargetFailure(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror, signature string, openErr error) (ctrl.Result, error) {
 	key := client.ObjectKeyFromObject(mirror)
 	l := log.FromContext(ctx).WithValues("mxlflowmirror", key)
 
@@ -572,10 +669,13 @@ func (r *TargetReconciler) handleOpenTargetFailure(ctx context.Context, mirror *
 		if reclaimed := r.reclaimUnusableFlowDir(ctx, mirror.Spec.FlowID); reclaimed {
 			// Materialising a fresh directory is the point of the
 			// reclaim; do not sit out the accumulated backoff first.
-			return ctrl.Result{RequeueAfter: 100 * time.Millisecond}, nil
+			r.setOpenBackoff(key, signature, reclaimRetryDelay)
+			return ctrl.Result{RequeueAfter: reclaimRetryDelay}, nil
 		}
 	}
-	return ctrl.Result{RequeueAfter: backoffFor(attempts)}, nil
+	d := backoffFor(attempts)
+	r.setOpenBackoff(key, signature, d)
+	return ctrl.Result{RequeueAfter: d}, nil
 }
 
 // reclaimUnusableFlowDir removes the local flow directory for flowID
@@ -899,6 +999,7 @@ func (r *TargetReconciler) closeEntry(key types.NamespacedName, disp flowDisposi
 	entry := r.targets[key]
 	delete(r.targets, key)
 	delete(r.attempts, key)
+	delete(r.openBackoff, key)
 	r.mu.Unlock()
 	if entry == nil {
 		return
@@ -1616,6 +1717,9 @@ func (r *TargetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	}
 	if r.attempts == nil {
 		r.attempts = make(map[types.NamespacedName]uint32)
+	}
+	if r.openBackoff == nil {
+		r.openBackoff = make(map[types.NamespacedName]targetOpenBackoff)
 	}
 	if r.APIReader == nil {
 		r.APIReader = mgr.GetAPIReader()

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -2,7 +2,6 @@ package mirror
 
 import (
 	"context"
-	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -227,31 +226,14 @@ type TargetReconciler struct {
 	// attempts counts consecutive openTarget failures per mirror.
 	// Cleared the moment a target opens, so the value is always the
 	// length of the current failure run. Guarded by mu.
-	attempts map[types.NamespacedName]uint32
-
-	// openBackoff holds the earliest time the next openTarget for a
-	// mirror may run. Guarded by mu. Entries are dropped when the
-	// target opens and when the mirror is torn down, so the map holds
-	// at most one entry per mirror currently failing to open.
-	openBackoff map[types.NamespacedName]targetOpenBackoff
+	attempts attemptTable[targetOpenInputs]
 }
 
-// targetOpenBackoff gates repeated openTarget attempts for one mirror.
-//
-// A failed open publishes status on the mirror, and this reconciler
-// watches that same object, so the write wakes it again at once. The
-// RequeueAfter a failure returns is only advisory against that: the
-// watch event arrives long before the requeue is due, so the backoff
-// never applies and the open retries at apiserver rate, writing status
-// every time.
-//
-// signature pins the backoff to the inputs it was earned against. A
-// mirror whose flow definition or provider has changed is a new
-// attempt rather than a retry of the one that failed, and must not sit
-// out the accumulated delay.
-type targetOpenBackoff struct {
-	notBefore time.Time
-	signature string
+// targetOpenInputs is what an open attempt depends on. A change to
+// either makes the next attempt a new one rather than a retry.
+type targetOpenInputs struct {
+	flowDef  string
+	provider fabrics.Provider
 }
 
 // targetEntry holds the live libmxl handles for one target-side
@@ -482,26 +464,20 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// been unopenable across the bounce reads as Materializing again
 	// and the escalation to Degraded restarts from zero. Matches the
 	// source side's seeding of status.attemptCount.
+	inputs := targetOpenInputs{flowDef: string(flow.Spec.Definition.Raw), provider: provider}
 	r.mu.Lock()
-	if _, ok := r.attempts[req.NamespacedName]; !ok && mirror.Status.TargetAttemptCount > 0 {
-		r.attempts[req.NamespacedName] = uint32(mirror.Status.TargetAttemptCount)
-	}
+	r.attempts.seed(req.NamespacedName, uint32(mirror.Status.TargetAttemptCount))
+	remaining, gated := r.attempts.wait(req.NamespacedName, inputs, r.now())
 	r.mu.Unlock()
-
-	// A failed open wrote status, and that write wakes this reconciler
-	// through its own watch. Answering that wake with another open
-	// would retry at apiserver rate however long the returned
-	// RequeueAfter was, so the backoff is enforced here rather than
-	// left to the requeue. Nothing is written on a gated pass: the
-	// write is what closes the loop.
-	signature := targetAttemptSignature(string(flow.Spec.Definition.Raw), provider)
-	if remaining, gated := r.openGatedFor(req.NamespacedName, signature); gated {
+	// Nothing is written on a gated pass: the status write is what
+	// wakes this reconciler through its own watch.
+	if gated {
 		return ctrl.Result{RequeueAfter: remaining}, nil
 	}
 
 	entry, err := r.openTargetDispatch(req.NamespacedName, string(flow.Spec.Definition.Raw), provider)
 	if err != nil {
-		return r.handleOpenTargetFailure(ctx, &mirror, signature, err)
+		return r.handleOpenTargetFailure(ctx, &mirror, inputs, err)
 	}
 
 	r.mu.Lock()
@@ -514,7 +490,6 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	}
 	r.targets[req.NamespacedName] = entry
 	delete(r.attempts, req.NamespacedName)
-	delete(r.openBackoff, req.NamespacedName)
 	r.mu.Unlock()
 
 	// Publish the descriptor before the phase: a Ready mirror whose
@@ -545,46 +520,6 @@ func (r *TargetReconciler) now() time.Time {
 		return r.nowFn()
 	}
 	return time.Now()
-}
-
-// targetAttemptSignature identifies the inputs an open attempt was
-// made with, so a backoff earned against one flow definition and
-// provider does not hold back an attempt against different ones.
-func targetAttemptSignature(flowDef string, provider fabrics.Provider) string {
-	return fmt.Sprintf("%v|%x", provider, sha256.Sum256([]byte(flowDef)))
-}
-
-// openGatedFor reports how long remains of the backoff earned by the
-// previous failed open for key, and whether it still applies. A
-// signature that no longer matches, or an elapsed deadline, drops the
-// entry and reports no gate.
-func (r *TargetReconciler) openGatedFor(key types.NamespacedName, signature string) (time.Duration, bool) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	b, ok := r.openBackoff[key]
-	if !ok {
-		return 0, false
-	}
-	if b.signature != signature {
-		delete(r.openBackoff, key)
-		return 0, false
-	}
-	remaining := b.notBefore.Sub(r.now())
-	if remaining <= 0 {
-		delete(r.openBackoff, key)
-		return 0, false
-	}
-	return remaining, true
-}
-
-// setOpenBackoff records that the next open for key must wait d.
-func (r *TargetReconciler) setOpenBackoff(key types.NamespacedName, signature string, d time.Duration) {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	if r.openBackoff == nil {
-		r.openBackoff = make(map[types.NamespacedName]targetOpenBackoff)
-	}
-	r.openBackoff[key] = targetOpenBackoff{notBefore: r.now().Add(d), signature: signature}
 }
 
 // openTarget walks the libmxl handshake: open FlowWriter, create +
@@ -643,13 +578,12 @@ func (r *TargetReconciler) openTargetDispatch(key types.NamespacedName, flowDef 
 // consecutive failures the phase escalates to Degraded and, for a
 // failure that came from the local writer, the flow directory is
 // reclaimed so the retry materialises a fresh one.
-func (r *TargetReconciler) handleOpenTargetFailure(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror, signature string, openErr error) (ctrl.Result, error) {
+func (r *TargetReconciler) handleOpenTargetFailure(ctx context.Context, mirror *mxlv1alpha1.MxlFlowMirror, inputs targetOpenInputs, openErr error) (ctrl.Result, error) {
 	key := client.ObjectKeyFromObject(mirror)
 	l := log.FromContext(ctx).WithValues("mxlflowmirror", key)
 
 	r.mu.Lock()
-	r.attempts[key]++
-	attempts := r.attempts[key]
+	attempts, wait := r.attempts.fail(key, inputs, r.now(), backoffFor)
 	r.mu.Unlock()
 
 	phase := mxlv1alpha1.MxlFlowMirrorMaterializing
@@ -669,13 +603,13 @@ func (r *TargetReconciler) handleOpenTargetFailure(ctx context.Context, mirror *
 		if reclaimed := r.reclaimUnusableFlowDir(ctx, mirror.Spec.FlowID); reclaimed {
 			// Materialising a fresh directory is the point of the
 			// reclaim; do not sit out the accumulated backoff first.
-			r.setOpenBackoff(key, signature, reclaimRetryDelay)
+			r.mu.Lock()
+			r.attempts.rearm(key, r.now(), reclaimRetryDelay)
+			r.mu.Unlock()
 			return ctrl.Result{RequeueAfter: reclaimRetryDelay}, nil
 		}
 	}
-	d := backoffFor(attempts)
-	r.setOpenBackoff(key, signature, d)
-	return ctrl.Result{RequeueAfter: d}, nil
+	return ctrl.Result{RequeueAfter: wait}, nil
 }
 
 // reclaimUnusableFlowDir removes the local flow directory for flowID
@@ -999,7 +933,6 @@ func (r *TargetReconciler) closeEntry(key types.NamespacedName, disp flowDisposi
 	entry := r.targets[key]
 	delete(r.targets, key)
 	delete(r.attempts, key)
-	delete(r.openBackoff, key)
 	r.mu.Unlock()
 	if entry == nil {
 		return
@@ -1262,7 +1195,7 @@ func (r *TargetReconciler) applyTargetStatus(
 	patch.SetNamespace(mirror.Namespace)
 	patch.SetName(mirror.Name)
 	r.mu.Lock()
-	attempts := r.attempts[client.ObjectKeyFromObject(mirror)]
+	attempts := r.attempts.count(client.ObjectKeyFromObject(mirror))
 	r.mu.Unlock()
 	status := map[string]any{
 		"phase":              string(phase),
@@ -1716,10 +1649,7 @@ func (r *TargetReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		r.targets = make(map[types.NamespacedName]*targetEntry)
 	}
 	if r.attempts == nil {
-		r.attempts = make(map[types.NamespacedName]uint32)
-	}
-	if r.openBackoff == nil {
-		r.openBackoff = make(map[types.NamespacedName]targetOpenBackoff)
+		r.attempts = make(attemptTable[targetOpenInputs])
 	}
 	if r.APIReader == nil {
 		r.APIReader = mgr.GetAPIReader()

--- a/gateway/internal/mirror/target_openbackoff_test.go
+++ b/gateway/internal/mirror/target_openbackoff_test.go
@@ -1,0 +1,153 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// fixedClock returns a clock the test moves by hand, so the backoff is
+// exercised without sleeping for it.
+func fixedClock(t0 time.Time) (func() time.Time, func(time.Duration)) {
+	now := t0
+	return func() time.Time { return now }, func(d time.Duration) { now = now.Add(d) }
+}
+
+func TestTarget_OpenBackoffGatesRepeatedAttempts(t *testing.T) {
+	// A failed open publishes status on the mirror, and this
+	// reconciler watches that same object, so its own write wakes it
+	// again immediately. The RequeueAfter the failure returns is no
+	// defence: the watch event arrives long before it is due. Without
+	// an authoritative gate the open retries at apiserver rate and
+	// rewrites status every pass, which is what drives the attempt
+	// counter into the hundreds inside a single run.
+	f := newOpenFailureFixture(t, errors.New("Target.Setup: mxl: unknown error"),
+		mxlv1alpha1.MxlFlowLocationReady)
+	clock, advance := fixedClock(time.Now())
+	f.r.nowFn = clock
+	ctx := context.Background()
+
+	res, err := f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+	require.Equal(t, 1, f.opens, "the first pass must attempt the open")
+	require.Positive(t, res.RequeueAfter)
+
+	settled := f.mirror(t)
+	require.Equal(t, int32(1), settled.Status.TargetAttemptCount)
+
+	// Every one of these stands for a watch event the failure's own
+	// status write produced.
+	for range 20 {
+		res, err := f.r.Reconcile(ctx, f.req)
+		require.NoError(t, err)
+		assert.Positive(t, res.RequeueAfter,
+			"a gated pass still has to come back when the backoff expires")
+	}
+
+	assert.Equal(t, 1, f.opens,
+		"inside the backoff the target must not be reopened; a wake that "+
+			"retries immediately is the hot loop")
+
+	after := f.mirror(t)
+	assert.Equal(t, int32(1), after.Status.TargetAttemptCount,
+		"a gated pass must not advance the failure count")
+	assert.Equal(t, settled.ResourceVersion, after.ResourceVersion,
+		"a gated pass must not write status: the write is what wakes this "+
+			"reconciler, so writing on a gated pass sustains the loop")
+
+	advance(backoffFor(1))
+	_, err = f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+	assert.Equal(t, 2, f.opens,
+		"once the backoff has elapsed the retry must happen; the gate "+
+			"delays attempts, it does not stop them")
+	assert.Equal(t, int32(2), f.mirror(t).Status.TargetAttemptCount)
+}
+
+func TestTarget_OpenBackoffReleasedWhenFlowDefinitionChanges(t *testing.T) {
+	// The backoff answers "this exact attempt failed, do not repeat it
+	// yet". A republished flow definition is a different attempt, and
+	// making it wait out a delay earned by the old one would leave a
+	// mirror unopened for up to the 30s cap after the very change that
+	// fixes it.
+	f := newOpenFailureFixture(t, errors.New("Target.Setup: mxl: unknown error"),
+		mxlv1alpha1.MxlFlowLocationReady)
+	clock, _ := fixedClock(time.Now())
+	f.r.nowFn = clock
+	ctx := context.Background()
+
+	_, err := f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+	require.Equal(t, 1, f.opens)
+
+	_, err = f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+	require.Equal(t, 1, f.opens, "same inputs inside the backoff stay gated")
+
+	var flow mxlv1alpha1.MxlFlow
+	require.NoError(t, f.r.Get(ctx, types.NamespacedName{Name: openFailureFlowID}, &flow))
+	flow.Spec.Definition = runtime.RawExtension{
+		Raw: []byte(`{"id":"` + openFailureFlowID + `","grain_rate":{"numerator":50}}`),
+	}
+	require.NoError(t, f.r.Update(ctx, &flow))
+
+	_, err = f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+	assert.Equal(t, 2, f.opens,
+		"a changed flow definition must be attempted at once rather than "+
+			"serving out the previous attempt's backoff")
+}
+
+func TestTarget_OpenBackoffClearedOnSuccessAndTeardown(t *testing.T) {
+	// The gate is per mirror and lives in a map. An entry that outlives
+	// the failure run it belongs to would delay a later open for a
+	// mirror that is working, and one that outlives the mirror is a
+	// leak on a gateway that sees many short-lived mirrors.
+	f := newOpenFailureFixture(t, errors.New("Target.Setup: mxl: unknown error"),
+		mxlv1alpha1.MxlFlowLocationReady)
+	clock, advance := fixedClock(time.Now())
+	f.r.nowFn = clock
+	ctx := context.Background()
+
+	_, err := f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+
+	f.r.mu.Lock()
+	_, gated := f.r.openBackoff[f.key]
+	f.r.mu.Unlock()
+	require.True(t, gated, "a failed open must record a backoff")
+
+	f.r.openTargetFn = func(types.NamespacedName, string, fabrics.Provider) (*targetEntry, error) {
+		return &targetEntry{infoStr: "info-1"}, nil
+	}
+	// The gate is doing its job, so the open that succeeds only
+	// happens once the previous failure's backoff has elapsed.
+	advance(backoffFor(1))
+	t.Cleanup(func() { f.r.closeEntry(f.key, keepFlow) })
+
+	_, err = f.r.Reconcile(ctx, f.req)
+	require.NoError(t, err)
+
+	f.r.mu.Lock()
+	_, stillGated := f.r.openBackoff[f.key]
+	f.r.mu.Unlock()
+	assert.False(t, stillGated,
+		"an open target must drop its backoff, or the next failure run "+
+			"starts already delayed")
+
+	f.r.closeEntry(f.key, keepFlow)
+	f.r.mu.Lock()
+	n := len(f.r.openBackoff)
+	f.r.mu.Unlock()
+	assert.Zero(t, n, "teardown must not leave the mirror's backoff behind")
+}

--- a/gateway/internal/mirror/target_openbackoff_test.go
+++ b/gateway/internal/mirror/target_openbackoff_test.go
@@ -123,9 +123,10 @@ func TestTarget_OpenBackoffClearedOnSuccessAndTeardown(t *testing.T) {
 	require.NoError(t, err)
 
 	f.r.mu.Lock()
-	_, gated := f.r.openBackoff[f.key]
+	a, recorded := f.r.attempts[f.key]
 	f.r.mu.Unlock()
-	require.True(t, gated, "a failed open must record a backoff")
+	require.True(t, recorded, "a failed open must record an attempt")
+	require.False(t, a.notBefore.IsZero(), "the failure must arm the wait")
 
 	f.r.openTargetFn = func(types.NamespacedName, string, fabrics.Provider) (*targetEntry, error) {
 		return &targetEntry{infoStr: "info-1"}, nil
@@ -139,15 +140,15 @@ func TestTarget_OpenBackoffClearedOnSuccessAndTeardown(t *testing.T) {
 	require.NoError(t, err)
 
 	f.r.mu.Lock()
-	_, stillGated := f.r.openBackoff[f.key]
+	_, stillRecorded := f.r.attempts[f.key]
 	f.r.mu.Unlock()
-	assert.False(t, stillGated,
+	assert.False(t, stillRecorded,
 		"an open target must drop its backoff, or the next failure run "+
 			"starts already delayed")
 
 	f.r.closeEntry(f.key, keepFlow)
 	f.r.mu.Lock()
-	n := len(f.r.openBackoff)
+	n := len(f.r.attempts)
 	f.r.mu.Unlock()
-	assert.Zero(t, n, "teardown must not leave the mirror's backoff behind")
+	assert.Zero(t, n, "teardown must not leave the mirror's attempt behind")
 }

--- a/gateway/internal/mirror/target_openfailure_test.go
+++ b/gateway/internal/mirror/target_openfailure_test.go
@@ -84,7 +84,7 @@ func newOpenFailureFixture(t *testing.T, openErr error, locPhase mxlv1alpha1.Mxl
 		NodeName:   "node-a",
 		DomainPath: f.domain,
 		targets:    map[types.NamespacedName]*targetEntry{},
-		attempts:   map[types.NamespacedName]uint32{},
+		attempts:   attemptTable[targetOpenInputs]{},
 		openTargetFn: func(types.NamespacedName, string, fabrics.Provider) (*targetEntry, error) {
 			f.opens++
 			return nil, openErr

--- a/gateway/internal/mirror/target_openfailure_test.go
+++ b/gateway/internal/mirror/target_openfailure_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -32,6 +33,18 @@ type openFailureFixture struct {
 	req    reconcile.Request
 	domain string
 	opens  int
+
+	// advance moves the reconciler's clock. Consecutive open attempts
+	// are separated by the open backoff now that it is enforced rather
+	// than advised, so a test driving several has to let it elapse the
+	// way the requeue does in production.
+	advance func(time.Duration)
+}
+
+// advancePastBackoff releases the open gate however long the last
+// failure earned, without a test having to track the attempt count.
+func (f *openFailureFixture) advancePastBackoff() {
+	f.advance(backoffFor(maxTargetOpenAttempts) + time.Second)
 }
 
 func newOpenFailureFixture(t *testing.T, openErr error, locPhase mxlv1alpha1.MxlFlowLocationPhase) *openFailureFixture {
@@ -57,12 +70,15 @@ func newOpenFailureFixture(t *testing.T, openErr error, locPhase mxlv1alpha1.Mxl
 		WithObjects(mirror, flow).
 		Build()
 
+	clock, advance := fixedClock(time.Now())
 	f := &openFailureFixture{
-		key:    key,
-		req:    reconcile.Request{NamespacedName: key},
-		domain: t.TempDir(),
+		key:     key,
+		req:     reconcile.Request{NamespacedName: key},
+		domain:  t.TempDir(),
+		advance: advance,
 	}
 	f.r = &TargetReconciler{
+		nowFn:      clock,
 		Client:     c,
 		Scheme:     scheme,
 		NodeName:   "node-a",
@@ -113,6 +129,7 @@ func TestTarget_OpenFailureEscalatesOutOfMaterializing(t *testing.T) {
 		require.NoError(t, err)
 		assert.Positive(t, res.RequeueAfter,
 			"a failed open must come back as a bounded-backoff requeue")
+		f.advancePastBackoff()
 
 		got := f.mirror(t)
 		assert.Equal(t, mxlv1alpha1.MxlFlowMirrorMaterializing, got.Status.Phase,
@@ -174,6 +191,7 @@ func TestTarget_WriterFailureReclaimsFlowDirAtThreshold(t *testing.T) {
 		require.NoError(t, err)
 		assert.DirExists(t, dir,
 			"a failure that has not yet repeated must not cost a directory")
+		f.advancePastBackoff()
 	}
 
 	res, err := f.r.Reconcile(context.Background(), f.req)
@@ -200,6 +218,7 @@ func TestTarget_WriterFailureKeepsOriginFlowDir(t *testing.T) {
 	for range maxTargetOpenAttempts + 1 {
 		_, err := f.r.Reconcile(context.Background(), f.req)
 		require.NoError(t, err)
+		f.advancePastBackoff()
 	}
 
 	assert.DirExists(t, dir,
@@ -221,6 +240,7 @@ func TestTarget_FabricFailureKeepsFlowDir(t *testing.T) {
 	for range maxTargetOpenAttempts + 1 {
 		_, err := f.r.Reconcile(context.Background(), f.req)
 		require.NoError(t, err)
+		f.advancePastBackoff()
 	}
 
 	assert.DirExists(t, dir,
@@ -243,6 +263,9 @@ func TestTarget_OpenSuccessClearsAttemptCount(t *testing.T) {
 	f.r.openTargetFn = func(types.NamespacedName, string, fabrics.Provider) (*targetEntry, error) {
 		return &targetEntry{infoStr: info}, nil
 	}
+	// The open that succeeds only runs once the failure's backoff has
+	// elapsed; inside it the reconciler does not attempt at all.
+	f.advancePastBackoff()
 	// A successful Reconcile starts the per-mirror flusher; drop the
 	// entry so the goroutine is joined before goleak inspects.
 	t.Cleanup(func() { f.r.closeEntry(f.key, keepFlow) })

--- a/gateway/internal/mirror/target_statuswrite_test.go
+++ b/gateway/internal/mirror/target_statuswrite_test.go
@@ -66,7 +66,7 @@ func newCapturingTarget(t *testing.T, mirror *mxlv1alpha1.MxlFlowMirror) (*Targe
 		Scheme:   scheme,
 		NodeName: "node-a",
 		targets:  map[types.NamespacedName]*targetEntry{},
-		attempts: map[types.NamespacedName]uint32{},
+		attempts: attemptTable[targetOpenInputs]{},
 	}, &seen
 }
 


### PR DESCRIPTION
Closes #244.

Both mirror reconcilers publish status on the `MxlFlowMirror` they
watch. A failed open or AddTarget writes status, that write raises a
watch event, and the event arrives long before the `RequeueAfter` the
failure returned is due. The backoff was advisory, so a mirror that
cannot come up retried at apiserver rate and rewrote status every pass.

Every one of those writes bumps the mirror's `resourceVersion`, which
is what makes the receiver controller's owner-ref race reachable.

## Change

The backoff is enforced on the way in. A reconcile arriving inside it
requeues for the remainder and returns without attempting and without
writing status -- the write is what wakes the reconciler, so a gated
pass that wrote would sustain the loop.

Both halves share one `attemptTable`, so the consecutive count, the
wait and the inputs it was earned against move together.

The wait is pinned to those inputs, and a change to them releases it at
once:

| side | inputs | released by |
| --- | --- | --- |
| target | flow definition, provider | a republished definition |
| source | TargetInfo, provider | the target rotating its endpoint |

Without that, a mirror would sit out up to the 30s cap after the very
change that fixes it. Entries are dropped when the mirror comes up and
when it is torn down.

Event handling is otherwise untouched; the target side still needs
status-driven wakeups for `TargetInfo` rotation.

## Tests

`TestTarget_OpenBackoffGatesRepeatedAttempts` and
`TestSource_AddTargetBackoffGatesRepeatedAttempts` drive 20 reconciles
standing for the watch events a failure's own write produces, and
assert one attempt, an unchanged attempt count, and an unchanged
`resourceVersion`. An injected clock then advances past the backoff and
the retry must happen.

Against a tree with only the gate neutralised:

| test | gate active | gate neutralised |
| --- | --- | --- |
| `Target_OpenBackoffGatesRepeatedAttempts` | PASS | FAIL |
| `Target_OpenBackoffReleasedWhenFlowDefinitionChanges` | PASS | FAIL |
| `Target_OpenBackoffClearedOnSuccessAndTeardown` | PASS | PASS |

The third covers map lifetime, which the gate does not affect.

Full `gateway` module under `-race`: all packages ok, no data race, no
goroutine leak. `gofmt` and `go vet` clean.

Tests that drove consecutive attempts now advance the injected clock
between them, because the reconcilers no longer permit back-to-back
attempts. No assertion was weakened.

## kind-integration

The `kind` filter listed packaging paths only, so a reconciler change
never reached the suite that exercises it. The module paths behind the
images it runs now trigger it.