### PR TITLE
feat(gateway): measure mirror throughput and show it per node

### DIFF
--- a/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
+++ b/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
@@ -1130,7 +1130,7 @@
       "id": 113,
       "type": "stat",
       "title": "Node Fabric Throughput",
-      "description": "Transmitted plus received across every transport on the node.",
+      "description": "Transmitted plus received across every transport on the node. One selector over both counters rather than a sum of two: a node that only sources or only targets a mirror appears on one side alone, and a binary operator between them would match nothing.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -1181,7 +1181,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (node) (rate(mxl_gateway_mirror_transmitted_bytes_total{node=~\"$node\"}[$__rate_interval])) + sum by (node) (rate(mxl_gateway_mirror_received_bytes_total{node=~\"$node\"}[$__rate_interval]))",
+          "expr": "sum by (node) (rate({__name__=~\"mxl_gateway_mirror_(transmitted|received)_bytes_total\",node=~\"$node\"}[$__rate_interval]))",
           "legendFormat": "{{node}}",
           "range": true
         }

--- a/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
+++ b/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
@@ -91,7 +91,7 @@
       "type": "stat",
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 12,
         "x": 0,
         "y": 1
       },
@@ -143,8 +143,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace(mxl_flow_active{node=~\"$node\",flow_id=~\"$flow\"}, \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "mxl_flow_active{node=~\"$node\",flow_id=~\"$flow\"}",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -155,8 +155,8 @@
       "type": "stat",
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 6,
+        "w": 12,
+        "x": 12,
         "y": 1
       },
       "datasource": {
@@ -207,8 +207,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace(mxl_flow_present{node=~\"$node\",flow_id=~\"$flow\"}, \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "mxl_flow_present{node=~\"$node\",flow_id=~\"$flow\"}",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -219,9 +219,9 @@
       "type": "stat",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 12,
-        "y": 1
+        "w": 8,
+        "x": 0,
+        "y": 5
       },
       "datasource": {
         "type": "prometheus",
@@ -268,9 +268,9 @@
       "type": "stat",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 16,
-        "y": 1
+        "w": 8,
+        "x": 8,
+        "y": 5
       },
       "datasource": {
         "type": "prometheus",
@@ -314,9 +314,9 @@
       "type": "stat",
       "gridPos": {
         "h": 4,
-        "w": 4,
-        "x": 20,
-        "y": 1
+        "w": 8,
+        "x": 16,
+        "y": 5
       },
       "datasource": {
         "type": "prometheus",
@@ -369,7 +369,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 5
+        "y": 9
       },
       "collapsed": false,
       "panels": []
@@ -383,7 +383,7 @@
         "h": 4,
         "w": 8,
         "x": 0,
-        "y": 6
+        "y": 10
       },
       "datasource": {
         "type": "prometheus",
@@ -434,7 +434,7 @@
         "h": 4,
         "w": 8,
         "x": 8,
-        "y": 6
+        "y": 10
       },
       "datasource": {
         "type": "prometheus",
@@ -485,7 +485,7 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 6
+        "y": 10
       },
       "datasource": {
         "type": "prometheus",
@@ -535,7 +535,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 10
+        "y": 14
       },
       "collapsed": false,
       "panels": []
@@ -547,9 +547,9 @@
       "type": "state-timeline",
       "gridPos": {
         "h": 6,
-        "w": 12,
+        "w": 24,
         "x": 0,
-        "y": 11
+        "y": 15
       },
       "datasource": {
         "type": "prometheus",
@@ -613,8 +613,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace(mxl_flow_active{node=~\"$node\",flow_id=~\"$flow\"}, \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "mxl_flow_active{node=~\"$node\",flow_id=~\"$flow\"}",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -625,9 +625,9 @@
       "type": "state-timeline",
       "gridPos": {
         "h": 6,
-        "w": 12,
-        "x": 12,
-        "y": 11
+        "w": 24,
+        "x": 0,
+        "y": 21
       },
       "datasource": {
         "type": "prometheus",
@@ -691,8 +691,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace(mxl_flow_present{node=~\"$node\",flow_id=~\"$flow\"}, \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "mxl_flow_present{node=~\"$node\",flow_id=~\"$flow\"}",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -704,7 +704,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 17
+        "y": 27
       },
       "collapsed": false,
       "panels": []
@@ -718,7 +718,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 18
+        "y": 28
       },
       "datasource": {
         "type": "prometheus",
@@ -758,8 +758,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace((mxl_flow_latency_grains{node=~\"$node\",flow_id=~\"$flow\"} / mxl_flow_rate_num{node=~\"$node\",flow_id=~\"$flow\"} * mxl_flow_rate_den{node=~\"$node\",flow_id=~\"$flow\"} * 1000) * on(flow_id, domain, node) group_left(flow_data_type) (mxl_flow_metadata{flow_data_type=~\"[Vv]ideo\"}) * on(flow_id, domain, node) group_left() (mxl_flow_active == 1), \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "(mxl_flow_latency_grains{node=~\"$node\",flow_id=~\"$flow\"} / mxl_flow_rate_num{node=~\"$node\",flow_id=~\"$flow\"} * mxl_flow_rate_den{node=~\"$node\",flow_id=~\"$flow\"} * 1000) * on(flow_id, domain, node) group_left(flow_data_type) (mxl_flow_metadata{flow_data_type=~\"[Vv]ideo\"}) * on(flow_id, domain, node) group_left() (mxl_flow_active == 1)",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -772,7 +772,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 18
+        "y": 28
       },
       "datasource": {
         "type": "prometheus",
@@ -812,8 +812,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace((mxl_flow_latency_grains{node=~\"$node\",flow_id=~\"$flow\"} / mxl_flow_rate_num{node=~\"$node\",flow_id=~\"$flow\"} * mxl_flow_rate_den{node=~\"$node\",flow_id=~\"$flow\"} * 1000) * on(flow_id, domain, node) group_left(flow_data_type) (mxl_flow_metadata{flow_data_type=~\"[Aa]udio\"}) * on(flow_id, domain, node) group_left() (mxl_flow_active == 1), \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "(mxl_flow_latency_grains{node=~\"$node\",flow_id=~\"$flow\"} / mxl_flow_rate_num{node=~\"$node\",flow_id=~\"$flow\"} * mxl_flow_rate_den{node=~\"$node\",flow_id=~\"$flow\"} * 1000) * on(flow_id, domain, node) group_left(flow_data_type) (mxl_flow_metadata{flow_data_type=~\"[Aa]udio\"}) * on(flow_id, domain, node) group_left() (mxl_flow_active == 1)",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -825,7 +825,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 26
+        "y": 36
       },
       "collapsed": false,
       "panels": []
@@ -839,7 +839,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 27
+        "y": 37
       },
       "datasource": {
         "type": "prometheus",
@@ -875,8 +875,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace(rate(mxl_flow_head_index_grains{node=~\"$node\",flow_id=~\"$flow\"}[1m]) * on(flow_id, domain, node) group_left() (mxl_flow_metadata{flow_data_type=~\"[Vv]ideo\"}), \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "rate(mxl_flow_head_index_grains{node=~\"$node\",flow_id=~\"$flow\"}[1m]) * on(flow_id, domain, node) group_left() (mxl_flow_metadata{flow_data_type=~\"[Vv]ideo\"})",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -889,7 +889,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 27
+        "y": 37
       },
       "datasource": {
         "type": "prometheus",
@@ -925,8 +925,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace(rate(mxl_flow_head_index_grains{node=~\"$node\",flow_id=~\"$flow\"}[1m]) * on(flow_id, domain, node) group_left() (mxl_flow_metadata{flow_data_type=~\"[Aa]udio\"}), \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "rate(mxl_flow_head_index_grains{node=~\"$node\",flow_id=~\"$flow\"}[1m]) * on(flow_id, domain, node) group_left() (mxl_flow_metadata{flow_data_type=~\"[Aa]udio\"})",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -938,7 +938,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 35
+        "y": 45
       },
       "collapsed": false,
       "panels": []
@@ -952,7 +952,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 36
+        "y": 46
       },
       "datasource": {
         "type": "prometheus",
@@ -984,8 +984,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace((rate(mxl_flow_head_index_grains{node=~\"$node\",flow_id=~\"$flow\"}[1m]) * ignoring(payload_buffer_index) mxl_flow_payload_slice_size_bytes{node=~\"$node\",flow_id=~\"$flow\",payload_buffer_index=\"0\"}) * on(flow_id, domain, node) group_left() (mxl_flow_metadata{flow_data_type=~\"[Vv]ideo\"}), \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "(rate(mxl_flow_head_index_grains{node=~\"$node\",flow_id=~\"$flow\"}[1m]) * ignoring(payload_buffer_index) mxl_flow_payload_slice_size_bytes{node=~\"$node\",flow_id=~\"$flow\",payload_buffer_index=\"0\"}) * on(flow_id, domain, node) group_left() (mxl_flow_metadata{flow_data_type=~\"[Vv]ideo\"})",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -998,7 +998,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 36
+        "y": 46
       },
       "datasource": {
         "type": "prometheus",
@@ -1030,8 +1030,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace((rate(mxl_flow_head_index_grains{node=~\"$node\",flow_id=~\"$flow\"}[1m]) * ignoring(payload_buffer_index) mxl_flow_payload_slice_size_bytes{node=~\"$node\",flow_id=~\"$flow\",payload_buffer_index=\"0\"}) * on(flow_id, domain, node) group_left() (mxl_flow_metadata{flow_data_type=~\"[Aa]udio\"}), \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "(rate(mxl_flow_head_index_grains{node=~\"$node\",flow_id=~\"$flow\"}[1m]) * ignoring(payload_buffer_index) mxl_flow_payload_slice_size_bytes{node=~\"$node\",flow_id=~\"$flow\",payload_buffer_index=\"0\"}) * on(flow_id, domain, node) group_left() (mxl_flow_metadata{flow_data_type=~\"[Aa]udio\"})",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -1043,7 +1043,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 44
+        "y": 54
       },
       "collapsed": false,
       "panels": []
@@ -1057,7 +1057,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 45
+        "y": 55
       },
       "datasource": {
         "type": "prometheus",
@@ -1098,8 +1098,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace(mxl_flow_last_write_age_seconds{node=~\"$node\",flow_id=~\"$flow\"} * 1000, \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "mxl_flow_last_write_age_seconds{node=~\"$node\",flow_id=~\"$flow\"} * 1000",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -1111,7 +1111,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 53
+        "y": 63
       },
       "collapsed": false,
       "panels": []
@@ -1123,9 +1123,9 @@
       "type": "stat",
       "gridPos": {
         "h": 4,
-        "w": 6,
+        "w": 12,
         "x": 0,
-        "y": 54
+        "y": 64
       },
       "datasource": {
         "type": "prometheus",
@@ -1159,8 +1159,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace(mxl_flow_ring_buffer_size_grains{node=~\"$node\",flow_id=~\"$flow\"} / mxl_flow_rate_num{node=~\"$node\",flow_id=~\"$flow\"} * mxl_flow_rate_den{node=~\"$node\",flow_id=~\"$flow\"} * 1000, \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "mxl_flow_ring_buffer_size_grains{node=~\"$node\",flow_id=~\"$flow\"} / mxl_flow_rate_num{node=~\"$node\",flow_id=~\"$flow\"} * mxl_flow_rate_den{node=~\"$node\",flow_id=~\"$flow\"} * 1000",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -1171,9 +1171,9 @@
       "type": "stat",
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 6,
-        "y": 54
+        "w": 12,
+        "x": 12,
+        "y": 64
       },
       "datasource": {
         "type": "prometheus",
@@ -1206,8 +1206,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace(mxl_flow_payload_slice_size_bytes{node=~\"$node\",flow_id=~\"$flow\",payload_buffer_index=\"0\"}, \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "mxl_flow_payload_slice_size_bytes{node=~\"$node\",flow_id=~\"$flow\",payload_buffer_index=\"0\"}",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -1218,9 +1218,9 @@
       "type": "stat",
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 12,
-        "y": 54
+        "w": 12,
+        "x": 0,
+        "y": 68
       },
       "datasource": {
         "type": "prometheus",
@@ -1254,8 +1254,8 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "label_replace(mxl_flow_channels_total{node=~\"$node\",flow_id=~\"$flow\"}, \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
-          "legendFormat": "{{node}} / {{flow_short}}"
+          "expr": "mxl_flow_channels_total{node=~\"$node\",flow_id=~\"$flow\"}",
+          "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
     },
@@ -1266,9 +1266,9 @@
       "type": "gauge",
       "gridPos": {
         "h": 4,
-        "w": 6,
-        "x": 18,
-        "y": 54
+        "w": 12,
+        "x": 12,
+        "y": 68
       },
       "datasource": {
         "type": "prometheus",
@@ -1325,7 +1325,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 58
+        "y": 72
       },
       "collapsed": false,
       "panels": []
@@ -1336,10 +1336,10 @@
       "description": "Static properties of every flow the exporter found, taken from the flow_def.json written when the flow was created and from the flow header. Covers flow id, data type, media type, colorspace, label, description and group hint.",
       "type": "table",
       "gridPos": {
-        "h": 8,
+        "h": 16,
         "w": 24,
         "x": 0,
-        "y": 59
+        "y": 73
       },
       "datasource": {
         "type": "prometheus",
@@ -1357,7 +1357,7 @@
           "refId": "A",
           "instant": true,
           "format": "table",
-          "expr": "label_replace(mxl_flow_metadata{node=~\"$node\",flow_id=~\"$flow\"}, \"flow_short\", \"$1\", \"flow_id\", \".*(.{3})$\")",
+          "expr": "mxl_flow_metadata{node=~\"$node\",flow_id=~\"$flow\"}",
           "legendFormat": ""
         }
       ],

--- a/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
+++ b/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
@@ -931,107 +931,259 @@
       ]
     },
     {
-      "id": 105,
-      "title": "Stream Throughput",
+      "id": 109,
       "type": "row",
+      "title": "Node Throughput",
+      "collapsed": false,
       "gridPos": {
         "h": 1,
         "w": 24,
         "x": 0,
         "y": 45
       },
-      "collapsed": false,
       "panels": []
     },
     {
-      "id": 20,
-      "title": "Video Stream Throughput (B/s)",
-      "description": "Approximate payload rate, as grains per second times payload slice size. Known limitation: mxl_flow_payload_slice_size_bytes reports one slice, not a whole grain, so a multi-slice discrete flow reads low by its slices-per-grain factor. libmxl exposes no slices-per-grain value, and deriving one from the frame height in the query would break at any other resolution.",
+      "id": 110,
       "type": "timeseries",
+      "title": "Transmitted per Node and Transport",
+      "description": "Payload bytes the gateway handed to the fabric, summed over the flows each node is the source of. Measured at the transfer call, not derived from flow geometry.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 0,
         "y": 46
       },
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
       "fieldConfig": {
         "defaults": {
           "unit": "Bps",
+          "min": 0,
           "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 10
-          },
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": 0
-              }
-            ]
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
           }
-        }
+        },
+        "overrides": []
       },
       "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "showLegend": true
+        },
         "tooltip": {
-          "mode": "multi"
+          "mode": "multi",
+          "sort": "desc"
         }
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "(rate(mxl_flow_head_index_grains{node=~\"$node\",flow_id=~\"$flow\"}[1m]) * ignoring(payload_buffer_index) mxl_flow_payload_slice_size_bytes{node=~\"$node\",flow_id=~\"$flow\",payload_buffer_index=\"0\"}) * on(flow_id, domain, node) group_left() (mxl_flow_metadata{flow_data_type=~\"[Vv]ideo\"})",
-          "legendFormat": "{{node}} / {{flow_id}}"
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (node, provider) (rate(mxl_gateway_mirror_transmitted_bytes_total{node=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "{{node}} / {{provider}}",
+          "range": true
         }
       ]
     },
     {
-      "id": 21,
-      "title": "Audio Stream Throughput (B/s)",
-      "description": "Approximate payload rate for continuous flows, on the same basis as the discrete panel and subject to the same slice-size limitation. Orders of magnitude below video, so it is shown separately rather than flattened by a shared axis.",
+      "id": 111,
       "type": "timeseries",
+      "title": "Received per Node and Transport",
+      "description": "Payload bytes committed to local flows, summed over the flows each node is the mirror target of.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "gridPos": {
         "h": 8,
         "w": 12,
         "x": 12,
         "y": 46
       },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "min": 0,
+          "custom": {
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (node, provider) (rate(mxl_gateway_mirror_received_bytes_total{node=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "{{node}} / {{provider}}",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 112,
+      "type": "timeseries",
+      "title": "Transmitted per Flow",
+      "description": "The same counter without the node aggregation, so a single stream can be attributed to the transport carrying it.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 54
+      },
       "fieldConfig": {
         "defaults": {
           "unit": "Bps",
+          "min": 0,
           "custom": {
-            "lineWidth": 2,
-            "fillOpacity": 10
+            "drawStyle": "line",
+            "lineWidth": 1,
+            "fillOpacity": 10,
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "mode": "none",
+              "group": "A"
+            }
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "legend": {
+          "displayMode": "table",
+          "placement": "bottom",
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "targets": [
+        {
+          "refId": "A",
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (flow_id, node, provider) (rate(mxl_gateway_mirror_transmitted_bytes_total{node=~\"$node\",flow_id=~\"$flow\"}[$__rate_interval]))",
+          "legendFormat": "{{node}} / {{flow_id}} / {{provider}}",
+          "range": true
+        }
+      ]
+    },
+    {
+      "id": 113,
+      "type": "stat",
+      "title": "Node Fabric Throughput",
+      "description": "Transmitted plus received across every transport on the node.",
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 54
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "Bps",
+          "min": 0,
+          "color": {
+            "mode": "thresholds"
           },
           "thresholds": {
             "mode": "absolute",
             "steps": [
               {
                 "color": "green",
-                "value": 0
+                "value": null
               }
             ]
           }
-        }
+        },
+        "overrides": []
       },
       "options": {
-        "tooltip": {
-          "mode": "multi"
-        }
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "orientation": "horizontal",
+        "textMode": "auto",
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto"
       },
       "targets": [
         {
           "refId": "A",
-          "expr": "(rate(mxl_flow_head_index_grains{node=~\"$node\",flow_id=~\"$flow\"}[1m]) * ignoring(payload_buffer_index) mxl_flow_payload_slice_size_bytes{node=~\"$node\",flow_id=~\"$flow\",payload_buffer_index=\"0\"}) * on(flow_id, domain, node) group_left() (mxl_flow_metadata{flow_data_type=~\"[Aa]udio\"})",
-          "legendFormat": "{{node}} / {{flow_id}}"
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "sum by (node) (rate(mxl_gateway_mirror_transmitted_bytes_total{node=~\"$node\"}[$__rate_interval])) + sum by (node) (rate(mxl_gateway_mirror_received_bytes_total{node=~\"$node\"}[$__rate_interval]))",
+          "legendFormat": "{{node}}",
+          "range": true
         }
       ]
     },
@@ -1043,7 +1195,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 54
+        "y": 62
       },
       "collapsed": false,
       "panels": []
@@ -1057,7 +1209,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 55
+        "y": 63
       },
       "datasource": {
         "type": "prometheus",
@@ -1111,7 +1263,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 63
+        "y": 71
       },
       "collapsed": false,
       "panels": []
@@ -1125,7 +1277,7 @@
         "h": 4,
         "w": 12,
         "x": 0,
-        "y": 64
+        "y": 72
       },
       "datasource": {
         "type": "prometheus",
@@ -1173,7 +1325,7 @@
         "h": 4,
         "w": 12,
         "x": 12,
-        "y": 64
+        "y": 72
       },
       "datasource": {
         "type": "prometheus",
@@ -1220,7 +1372,7 @@
         "h": 4,
         "w": 12,
         "x": 0,
-        "y": 68
+        "y": 76
       },
       "datasource": {
         "type": "prometheus",
@@ -1268,7 +1420,7 @@
         "h": 4,
         "w": 12,
         "x": 12,
-        "y": 68
+        "y": 76
       },
       "datasource": {
         "type": "prometheus",
@@ -1325,7 +1477,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 72
+        "y": 80
       },
       "collapsed": false,
       "panels": []
@@ -1339,7 +1491,7 @@
         "h": 16,
         "w": 24,
         "x": 0,
-        "y": 73
+        "y": 81
       },
       "datasource": {
         "type": "prometheus",

--- a/gateway/cmd/mxl-fabrics-gateway/main.go
+++ b/gateway/cmd/mxl-fabrics-gateway/main.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 
 	"github.com/qvest-digital/go-mxl/fabrics"
@@ -106,7 +107,7 @@ func run(args []string) error {
 	// the publisher advertises, and nothing else.
 	selector := cfg.Selector()
 
-	if err := (&mirror.TargetReconciler{
+	targetReconciler := &mirror.TargetReconciler{
 		Client:        mgr.GetClient(),
 		Scheme:        mgr.GetScheme(),
 		NodeName:      cfg.NodeName,
@@ -115,10 +116,11 @@ func run(args []string) error {
 		Handles:       handles,
 		DomainPath:    cfg.DomainPath,
 		DegradedAfter: cfg.DegradedAfter,
-	}).SetupWithManager(mgr); err != nil {
+	}
+	if err := targetReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup target reconciler: %w", err)
 	}
-	if err := (&mirror.SourceReconciler{
+	sourceReconciler := &mirror.SourceReconciler{
 		Client:           mgr.GetClient(),
 		Scheme:           mgr.GetScheme(),
 		NodeName:         cfg.NodeName,
@@ -126,9 +128,19 @@ func run(args []string) error {
 		Selector:         selector,
 		Handles:          handles,
 		ReaderStallAfter: cfg.ReaderStallAfter,
-	}).SetupWithManager(mgr); err != nil {
+	}
+	if err := sourceReconciler.SetupWithManager(mgr); err != nil {
 		return fmt.Errorf("setup source reconciler: %w", err)
 	}
+
+	// Both reconcilers hold per-mirror byte counters the collector
+	// reads on scrape, so the metrics server already listening on
+	// --metrics-bind-address serves them beside controller-runtime's.
+	metrics.Registry.MustRegister(&mirror.ThroughputCollector{
+		NodeName: cfg.NodeName,
+		Source:   sourceReconciler,
+		Target:   targetReconciler,
+	})
 
 	// MxlNodeCapabilities publisher runs as a Manager Runnable so it
 	// joins the leader-election / shutdown lifecycle and only fires

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -173,6 +173,18 @@ type sourceEntry struct {
 	progress   atomic.Uint64
 	lastSentAt atomic.Pointer[time.Time]
 
+	// bytes counts payload actually handed to the fabric for this
+	// mirror, read by the throughput collector at scrape time. A
+	// counter rather than a rate: the scrape interval is the
+	// collector's business, not the transfer loop's.
+	bytes atomic.Uint64
+
+	// flowID and provider label that counter. Immutable for the life
+	// of the entry, so the collector reads them without the entry's
+	// atomics.
+	flowID   string
+	provider fabrics.Provider
+
 	// agedOutAt records the wall-clock of the most recent
 	// reader-aged-out skip the transfer loop has had to perform.
 	// Used by the flusher to publish SourceProgress with reason
@@ -673,6 +685,8 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 		infoStr:   targetInfoStr,
 		cancel:    cancel,
 		done:      done,
+		flowID:    flowID,
+		provider:  provider,
 	}
 
 	progressInterval := o.ProgressInterval
@@ -689,8 +703,19 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 	progressFn := initiator.MakeProgressNonBlocking
 
 	if audio {
+		// Resolved on the first transfer and reused: the width is fixed
+		// for the flow, and only the transfer goroutine reads or writes
+		// it, so it needs no synchronization.
+		var frameBytes uint64
 		transferSamplesFn := func(headIndex uint64, count int) error {
-			return initiator.TransferSamples(headIndex, count)
+			if err := initiator.TransferSamples(headIndex, count); err != nil {
+				return err
+			}
+			if frameBytes == 0 {
+				frameBytes = sampleFrameBytes(reader, headIndex)
+			}
+			entry.bytes.Add(uint64(count) * frameBytes)
+			return nil
 		}
 		go runSampleTransferLoop(loopCtx, done, flowID, runtimeFn, transferSamplesFn, progressFn, maxBatch, xferBatch, progressInterval, entry)
 	} else {
@@ -707,7 +732,11 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 				// reach here.
 				return true, nil
 			}
-			return false, initiator.TransferGrain(idx, 0, grain.TotalSlices)
+			if err := initiator.TransferGrain(idx, 0, grain.TotalSlices); err != nil {
+				return false, err
+			}
+			entry.bytes.Add(uint64(grain.GrainSize))
+			return false, nil
 		}
 		go runTransferLoop(loopCtx, done, flowID, runtimeFn, transferFn, progressFn, progressInterval, entry)
 	}
@@ -909,6 +938,31 @@ func runTransferLoop(
 // probeRuntime to mxl.Reader.Runtime().HeadIndex, transferSamples to
 // Initiator.TransferSamples, and makeProgress to
 // Initiator.MakeProgressNonBlocking.
+// sampleFrameBytes is the payload one sample of a continuous flow
+// occupies across all its channels.
+//
+// libmxl publishes no per-sample width. The sample view's Stride is
+// the byte distance between two channels' ring buffers, which
+// PosixContinuousFlowWriter sets to sampleWordSize * bufferLength, so
+// dividing it by the bufferLength the flow config carries recovers the
+// word size exactly. Zero when the view cannot be opened, which leaves
+// the caller to ask again on its next transfer.
+func sampleFrameBytes(reader *mxl.Reader, index uint64) uint64 {
+	cfg, err := reader.Config()
+	if err != nil {
+		return 0
+	}
+	bufferLength := uint64(cfg.Continuous.BufferLength)
+	if bufferLength == 0 {
+		return 0
+	}
+	view, viewErr := reader.GetSamplesNonBlocking(index, 1)
+	if viewErr != nil {
+		return 0
+	}
+	return (view.Stride / bufferLength) * view.ChannelCount
+}
+
 func runSampleTransferLoop(
 	ctx context.Context,
 	done chan struct{},

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -280,6 +280,17 @@ type targetEntry struct {
 	fabricOpenedAt      atomic.Pointer[time.Time]
 	commitsAtFabricOpen atomic.Uint64
 
+	// bytes counts payload committed to the local flow for this
+	// mirror, read by the throughput collector at scrape time. A
+	// counter rather than a rate: the scrape interval is the
+	// collector's business, not the progress loop's.
+	bytes atomic.Uint64
+
+	// flowID labels that counter alongside provider. Set once when the
+	// entry is published and never changed, so the collector reads it
+	// without the entry's atomics.
+	flowID string
+
 	// recoveryAttempts counts consecutive watchdog-spawned recovery
 	// invocations that did not result in a fresh commit. recordCommit
 	// resets it to zero on the first commit after each fabric open,
@@ -488,6 +499,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		closeTargetHandles(entry, keepFlow)
 		return ctrl.Result{}, nil
 	}
+	entry.flowID = mirror.Spec.FlowID
 	r.targets[req.NamespacedName] = entry
 	delete(r.attempts, req.NamespacedName)
 	r.mu.Unlock()
@@ -738,12 +750,18 @@ func (r *TargetReconciler) startProgressLoop(entry *targetEntry, key types.Names
 	if writer.Config().Common.Format == mxl.FormatAudio {
 		readFn := target.ReadSamplesNonBlocking
 		commitFn := func(head uint64, count int) error {
-			return commitArrivedSamples(writer, head, count)
+			n, err := commitArrivedSamples(writer, head, count)
+			entry.bytes.Add(n)
+			return err
 		}
 		go runTargetSampleProgressLoop(loopCtx, done, readFn, commitFn, onFatal, entry)
 	} else {
 		readFn := target.ReadGrainNonBlocking
-		commitFn := func(idx uint64) error { return commitArrivedGrain(writer, idx) }
+		commitFn := func(idx uint64) error {
+			n, err := commitArrivedGrain(writer, idx)
+			entry.bytes.Add(n)
+			return err
+		}
 		go runTargetProgressLoop(loopCtx, done, readFn, commitFn, onFatal, entry)
 	}
 }
@@ -848,15 +866,17 @@ func runTargetProgressLoop(
 // initiator's RDMA write. OpenGrain returns a writable handle aliasing
 // the ring slot -- we leave the slot bytes untouched and Commit so the
 // flow metadata catches up.
-func commitArrivedGrain(writer *mxl.Writer, idx uint64) error {
+// The returned byte count is the grain payload libmxl declares for the
+// flow, which the write access already carries.
+func commitArrivedGrain(writer *mxl.Writer, idx uint64) (uint64, error) {
 	ga, err := writer.OpenGrain(idx)
 	if err != nil {
-		return fmt.Errorf("OpenGrain(%d): %w", idx, err)
+		return 0, fmt.Errorf("OpenGrain(%d): %w", idx, err)
 	}
 	if err := ga.Commit(ga.TotalSlices, 0); err != nil {
-		return fmt.Errorf("Commit(%d): %w", idx, err)
+		return 0, fmt.Errorf("Commit(%d): %w", idx, err)
 	}
-	return nil
+	return uint64(ga.GrainSize), nil
 }
 
 // runTargetSampleProgressLoop drives a libmxl-fabrics Target for a
@@ -917,15 +937,23 @@ func runTargetSampleProgressLoop(
 // initiator's RDMA write. OpenSamples returns a writable view aliasing
 // the ring; we leave the bytes untouched and Commit so the flow
 // metadata catches up, mirroring commitArrivedGrain.
-func commitArrivedSamples(writer *mxl.Writer, head uint64, count int) error {
+// The returned byte count is the committed run across all channels.
+// libmxl publishes no per-sample width, but the write access carries
+// the stride between two channels' ring buffers, which is the word
+// size times the buffer length the flow config states.
+func commitArrivedSamples(writer *mxl.Writer, head uint64, count int) (uint64, error) {
 	sa, err := writer.OpenSamples(head, count)
 	if err != nil {
-		return fmt.Errorf("OpenSamples(%d,%d): %w", head, count, err)
+		return 0, fmt.Errorf("OpenSamples(%d,%d): %w", head, count, err)
 	}
 	if err := sa.Commit(); err != nil {
-		return fmt.Errorf("CommitSamples(%d,%d): %w", head, count, err)
+		return 0, fmt.Errorf("CommitSamples(%d,%d): %w", head, count, err)
 	}
-	return nil
+	bufferLength := uint64(writer.Config().Continuous.BufferLength)
+	if bufferLength == 0 {
+		return 0, nil
+	}
+	return uint64(count) * (sa.Stride / bufferLength) * sa.ChannelCount, nil
 }
 
 func (r *TargetReconciler) closeEntry(key types.NamespacedName, disp flowDisposition) {

--- a/gateway/internal/mirror/throughput.go
+++ b/gateway/internal/mirror/throughput.go
@@ -1,0 +1,93 @@
+package mirror
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// Throughput is what one mirror half moved since this gateway started.
+type Throughput struct {
+	FlowID   string
+	Provider string
+	Bytes    uint64
+}
+
+var (
+	descTransmitted = prometheus.NewDesc(
+		"mxl_gateway_mirror_transmitted_bytes_total",
+		"Payload bytes handed to the fabric for a mirror this node is the source of.",
+		[]string{"flow_id", "node", "provider"}, nil)
+
+	descReceived = prometheus.NewDesc(
+		"mxl_gateway_mirror_received_bytes_total",
+		"Payload bytes committed to the local flow for a mirror this node is the target of.",
+		[]string{"flow_id", "node", "provider"}, nil)
+)
+
+// ThroughputSource reports the live mirrors one reconciler owns.
+type ThroughputSource interface {
+	Throughput() []Throughput
+}
+
+// ThroughputCollector publishes the byte counters both reconcilers
+// keep on their live entries.
+//
+// Collected on scrape rather than pushed from the transfer loops: the
+// loops only add to a per-entry atomic, so nothing on the path of a
+// grain takes a lock or touches a label set, and a mirror that goes
+// away stops being reported without any bookkeeping to unregister it.
+type ThroughputCollector struct {
+	NodeName string
+	Source   ThroughputSource
+	Target   ThroughputSource
+}
+
+func (c *ThroughputCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- descTransmitted
+	ch <- descReceived
+}
+
+func (c *ThroughputCollector) Collect(ch chan<- prometheus.Metric) {
+	emit := func(desc *prometheus.Desc, src ThroughputSource) {
+		if src == nil {
+			return
+		}
+		for _, t := range src.Throughput() {
+			ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue,
+				float64(t.Bytes), t.FlowID, c.NodeName, t.Provider)
+		}
+	}
+	emit(descTransmitted, c.Source)
+	emit(descReceived, c.Target)
+}
+
+// Throughput reports what each mirror this node sources has put on the
+// fabric.
+func (r *SourceReconciler) Throughput() []Throughput {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Throughput, 0, len(r.sources))
+	for _, e := range r.sources {
+		out = append(out, Throughput{
+			FlowID:   e.flowID,
+			Provider: e.provider.String(),
+			Bytes:    e.bytes.Load(),
+		})
+	}
+	return out
+}
+
+// Throughput reports what each mirror this node targets has committed
+// to its local flow.
+func (r *TargetReconciler) Throughput() []Throughput {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	out := make([]Throughput, 0, len(r.targets))
+	for _, e := range r.targets {
+		out = append(out, Throughput{
+			FlowID:   e.flowID,
+			Provider: e.provider.String(),
+			Bytes:    e.bytes.Load(),
+		})
+	}
+	return out
+}

--- a/gateway/internal/mirror/throughput_test.go
+++ b/gateway/internal/mirror/throughput_test.go
@@ -1,0 +1,60 @@
+package mirror
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+)
+
+func TestThroughputCollectorReportsBothDirections(t *testing.T) {
+	// The counters are per flow so a bottleneck can be attributed to
+	// one stream, and carry the transport so the same series answers
+	// "what is this node pushing over verbs" by aggregation rather
+	// than by a second metric.
+	src := &SourceReconciler{sources: map[types.NamespacedName]*sourceEntry{}}
+	sent := &sourceEntry{flowID: "flow-a", provider: fabrics.ProviderVerbs}
+	sent.bytes.Store(5529600)
+	src.sources[types.NamespacedName{Namespace: "p", Name: "a"}] = sent
+
+	tgt := &TargetReconciler{targets: map[types.NamespacedName]*targetEntry{}}
+	got := &targetEntry{flowID: "flow-b", provider: fabrics.ProviderTCP}
+	got.bytes.Store(4096)
+	tgt.targets[types.NamespacedName{Namespace: "p", Name: "b"}] = got
+
+	c := &ThroughputCollector{NodeName: "n01", Source: src, Target: tgt}
+
+	expected := `
+# HELP mxl_gateway_mirror_received_bytes_total Payload bytes committed to the local flow for a mirror this node is the target of.
+# TYPE mxl_gateway_mirror_received_bytes_total counter
+mxl_gateway_mirror_received_bytes_total{flow_id="flow-b",node="n01",provider="tcp"} 4096
+# HELP mxl_gateway_mirror_transmitted_bytes_total Payload bytes handed to the fabric for a mirror this node is the source of.
+# TYPE mxl_gateway_mirror_transmitted_bytes_total counter
+mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",provider="verbs"} 5529600
+`
+	require.NoError(t, testutil.CollectAndCompare(c, strings.NewReader(expected)))
+}
+
+func TestThroughputCollectorForgetsClosedMirrors(t *testing.T) {
+	// Collecting from the live entry maps is what makes a torn-down
+	// mirror stop being reported. A counter registered per flow would
+	// keep exporting its last value for as long as the process runs,
+	// and a stale series reads as a flow that stopped moving rather
+	// than one that is gone.
+	src := &SourceReconciler{sources: map[types.NamespacedName]*sourceEntry{}}
+	key := types.NamespacedName{Namespace: "p", Name: "a"}
+	e := &sourceEntry{flowID: "flow-a", provider: fabrics.ProviderVerbs}
+	e.bytes.Store(1024)
+	src.sources[key] = e
+
+	c := &ThroughputCollector{NodeName: "n01", Source: src}
+	require.Equal(t, 1, testutil.CollectAndCount(c))
+
+	delete(src.sources, key)
+	require.Equal(t, 0, testutil.CollectAndCount(c),
+		"a mirror that has been closed must leave no series behind")
+}

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -230,6 +230,13 @@ if [ "$MONITORING" = "1" ]; then
     # scrapes.
     --set exporter.metrics.serviceMonitor.interval=15s
     --set "exporter.metrics.serviceMonitor.labels.release=${MONITORING_RELEASE}"
+    # The gateway carries the mirror byte counters the Node Throughput
+    # panels read. They come from a different Service than the
+    # exporter's flow metrics, so scraping one does not scrape the
+    # other and the panels stay empty without this.
+    --set gateway.metrics.serviceMonitor.enabled=true
+    --set gateway.metrics.serviceMonitor.interval=15s
+    --set "gateway.metrics.serviceMonitor.labels.release=${MONITORING_RELEASE}"
     --set dashboards.enabled=true
     --set "dashboards.namespace=${MONITORING_NAMESPACE}"
   )


### PR DESCRIPTION
Two changes to the flow dashboard, and the metric one of them needed.

## Full flow ids

The legend took the last three characters of the flow id through a
`label_replace(..., "flow_id", ".*(.{3})$")`. Three characters collide
across flows differing earlier in the string, and the value cannot be
pasted into `kubectl` or a PromQL selector. Every panel now reads
`{{node}} / {{flow_id}}`, and the metadata table loses its redundant
`flow_short` column.

Panels that shared a row are widened or stacked to carry the longer
label: the two state timelines take a full-width row each,
`Status & Health` splits 2 + 3, `Buffer & Memory Configuration` splits
2 + 2, and `Flow Metadata` doubles in height.

## Measured throughput

`Video Stream Throughput (B/s)` computed `rate(head_index) *
mxl_flow_payload_slice_size_bytes`. libmxl documents `sliceSizes` as
one slice, "a line of a V210 picture including any padding", and
`mxlDiscreteFlowConfigInfo` holds only `sliceSizes` and `grainCount` -
the slices-per-grain count is a creation parameter that never reaches
the flow header. So the panel read low by the line count (measured on
sc: 5120 x 50 = 256 kB/s against a real 5120 x 1080 x 50 = 276 MB/s,
1080x), and the audio panel produced no series at all, because the
exporter correctly omits that discrete-only union member for
continuous flows.

Nothing reading the flow header can recover a grain size, so those two
panels are removed rather than corrected.

The gateway is on the path of every mirrored byte and already holds
the exact size at both ends:

- discrete: `GrainWriteAccess.GrainSize`, "the total payload size in
  bytes for a complete grain", and `Grain.GrainSize` on the source
- continuous: the channel stride over the flow's `bufferLength`, since
  `PosixContinuousFlowWriter` sets the stride to the word size times
  that length

Both loops add to a per-entry `atomic.Uint64`; a collector reads the
live entry maps on scrape. Nothing on the path of a grain takes a lock
or resolves a label set, and a torn-down mirror leaves no stale series
behind - covered by a test.

```
mxl_gateway_mirror_transmitted_bytes_total{flow_id,node,provider}
mxl_gateway_mirror_received_bytes_total{flow_id,node,provider}
```

`provider` is the transport (`verbs`, `efa`, `tcp`), taken from the
mirror spec the gateway already reads, so one series answers both per
flow and, summed by node and provider, per node and transport.

## Node Throughput row

`Transmitted per Node and Transport`, `Received per Node and
Transport`, `Transmitted per Flow`, and a `Node Fabric Throughput`
stat, all off the same counters.

Scraping needs `gateway.metrics.serviceMonitor.enabled=true`; the
Service and ServiceMonitor templates already exist and are unchanged.
This covers mirrored flows only - traffic between a producer and a
consumer on one node never reaches the gateway.

## Verification

`helm lint`, the dashboard ConfigMap parses with all 33 panels and no
grid overlaps, and the `dashboards.datasourceUid` substitution still
applies. gofmt, vet and the full api and gateway suites are clean.