### PR TITLE
docs: record the throughput work in the rc.23 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [1.0.0-rc.23](https://github.com/qvest-digital/mxl-k8s/compare/v1.0.0-rc.22...v1.0.0-rc.23) (2026-08-11)
 
 
+### Features
+
+* **gateway:** measure mirror throughput and show it per node ([#260](https://github.com/qvest-digital/mxl-k8s/issues/260)) ([a9087cc](https://github.com/qvest-digital/mxl-k8s/commit/a9087ccf986161bc0f76ec4e7c2d48131e8993eb))
+
+
 ### Bug Fixes
 
 * judge flow activity and mirror wedges on evidence that moves ([#258](https://github.com/qvest-digital/mxl-k8s/issues/258)) ([27996eb](https://github.com/qvest-digital/mxl-k8s/commit/27996eb6b84d82ee170b8337d64d1df2ad4cf200))


### PR DESCRIPTION
The generated rc.23 section lists only #258. #260 had merged before the
release PR was built, and release-please counted one commit for the root
package where two were pending, so the entry was never written.

The release is otherwise correct: `v1.0.0-rc.23` is tagged at `69f0afb`,
which has `a9087cc` in its history, so the published images and chart do
contain the throughput counters and the dashboard.

`docs` is `hidden: true` in `changelog-sections`, so this commit adds no
entry of its own to the next release.