### PR TITLE
fix(gateway): keep the mirror throughput label set unique

### DIFF
--- a/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
+++ b/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
@@ -960,7 +960,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps",
+          "unit": "bps",
           "min": 0,
           "custom": {
             "drawStyle": "line",
@@ -998,7 +998,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (node, provider) (rate(mxl_gateway_mirror_transmitted_bytes_total{node=~\"$node\"}[$__rate_interval]))",
+          "expr": "8 * sum by (node, provider) (rate(mxl_gateway_mirror_transmitted_bytes_total{node=~\"$node\"}[$__rate_interval]))",
           "legendFormat": "{{node}} / {{provider}}",
           "range": true
         }
@@ -1021,7 +1021,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps",
+          "unit": "bps",
           "min": 0,
           "custom": {
             "drawStyle": "line",
@@ -1059,7 +1059,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (node, provider) (rate(mxl_gateway_mirror_received_bytes_total{node=~\"$node\"}[$__rate_interval]))",
+          "expr": "8 * sum by (node, provider) (rate(mxl_gateway_mirror_received_bytes_total{node=~\"$node\"}[$__rate_interval]))",
           "legendFormat": "{{node}} / {{provider}}",
           "range": true
         }
@@ -1069,7 +1069,7 @@
       "id": 112,
       "type": "timeseries",
       "title": "Transmitted per Flow",
-      "description": "The same counter without the node aggregation, so a single stream can be attributed to the transport carrying it.",
+      "description": "The same counter without the node aggregation, so a single stream can be attributed to the peer and the transport carrying it.",
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -1082,7 +1082,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps",
+          "unit": "bps",
           "min": 0,
           "custom": {
             "drawStyle": "line",
@@ -1120,8 +1120,8 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (flow_id, node, provider) (rate(mxl_gateway_mirror_transmitted_bytes_total{node=~\"$node\",flow_id=~\"$flow\"}[$__rate_interval]))",
-          "legendFormat": "{{node}} / {{flow_id}} / {{provider}}",
+          "expr": "8 * sum by (flow_id, node, peer_node, provider) (rate(mxl_gateway_mirror_transmitted_bytes_total{node=~\"$node\",flow_id=~\"$flow\"}[$__rate_interval]))",
+          "legendFormat": "{{node}} -> {{peer_node}} / {{flow_id}} / {{provider}}",
           "range": true
         }
       ]
@@ -1143,7 +1143,7 @@
       },
       "fieldConfig": {
         "defaults": {
-          "unit": "Bps",
+          "unit": "bps",
           "min": 0,
           "color": {
             "mode": "thresholds"
@@ -1181,7 +1181,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "sum by (node) (rate({__name__=~\"mxl_gateway_mirror_(transmitted|received)_bytes_total\",node=~\"$node\"}[$__rate_interval]))",
+          "expr": "8 * sum by (node) (rate({__name__=~\"mxl_gateway_mirror_(transmitted|received)_bytes_total\",node=~\"$node\"}[$__rate_interval]))",
           "legendFormat": "{{node}}",
           "range": true
         }

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -179,10 +179,12 @@ type sourceEntry struct {
 	// collector's business, not the transfer loop's.
 	bytes atomic.Uint64
 
-	// flowID and provider label that counter. Immutable for the life
-	// of the entry, so the collector reads them without the entry's
-	// atomics.
+	// flowID, peerNode and provider label that counter. Immutable for
+	// the life of the entry, so the collector reads them without the
+	// entry's atomics. peerNode is what keeps the label set unique
+	// when one node mirrors the same flow to several targets.
 	flowID   string
+	peerNode string
 	provider fabrics.Provider
 
 	// agedOutAt records the wall-clock of the most recent
@@ -422,6 +424,7 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, fmt.Errorf("open initiator: %w", err)
 	}
 	entry.openedAt = time.Now()
+	entry.peerNode = mirror.Spec.TargetNode
 	if originAt != nil {
 		t := *originAt
 		entry.lastObservedOriginAt.Store(&t)

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -286,10 +286,11 @@ type targetEntry struct {
 	// collector's business, not the progress loop's.
 	bytes atomic.Uint64
 
-	// flowID labels that counter alongside provider. Set once when the
-	// entry is published and never changed, so the collector reads it
-	// without the entry's atomics.
-	flowID string
+	// flowID and peerNode label that counter alongside provider. Set
+	// once when the entry is published and never changed, so the
+	// collector reads them without the entry's atomics.
+	flowID   string
+	peerNode string
 
 	// recoveryAttempts counts consecutive watchdog-spawned recovery
 	// invocations that did not result in a fresh commit. recordCommit
@@ -500,6 +501,7 @@ func (r *TargetReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{}, nil
 	}
 	entry.flowID = mirror.Spec.FlowID
+	entry.peerNode = mirror.Spec.SourceNode
 	r.targets[req.NamespacedName] = entry
 	delete(r.attempts, req.NamespacedName)
 	r.mu.Unlock()

--- a/gateway/internal/mirror/throughput.go
+++ b/gateway/internal/mirror/throughput.go
@@ -7,6 +7,7 @@ import (
 // Throughput is what one mirror half moved since this gateway started.
 type Throughput struct {
 	FlowID   string
+	PeerNode string
 	Provider string
 	Bytes    uint64
 }
@@ -15,12 +16,12 @@ var (
 	descTransmitted = prometheus.NewDesc(
 		"mxl_gateway_mirror_transmitted_bytes_total",
 		"Payload bytes handed to the fabric for a mirror this node is the source of.",
-		[]string{"flow_id", "node", "provider"}, nil)
+		[]string{"flow_id", "node", "peer_node", "provider"}, nil)
 
 	descReceived = prometheus.NewDesc(
 		"mxl_gateway_mirror_received_bytes_total",
 		"Payload bytes committed to the local flow for a mirror this node is the target of.",
-		[]string{"flow_id", "node", "provider"}, nil)
+		[]string{"flow_id", "node", "peer_node", "provider"}, nil)
 )
 
 // ThroughputSource reports the live mirrors one reconciler owns.
@@ -46,14 +47,26 @@ func (c *ThroughputCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descReceived
 }
 
+// Collect folds the live entries onto their label set before emitting.
+//
+// One node mirrors the same flow to several peers, so peer_node is what
+// separates those series; the fold is what guarantees the label set is
+// unique regardless. A duplicate reaching the registry fails the whole
+// scrape with a 500, taking every other metric on the endpoint with it,
+// so this cannot be left to the labels alone.
 func (c *ThroughputCollector) Collect(ch chan<- prometheus.Metric) {
+	type key struct{ flowID, peerNode, provider string }
 	emit := func(desc *prometheus.Desc, src ThroughputSource) {
 		if src == nil {
 			return
 		}
+		totals := map[key]uint64{}
 		for _, t := range src.Throughput() {
+			totals[key{t.FlowID, t.PeerNode, t.Provider}] += t.Bytes
+		}
+		for k, bytes := range totals {
 			ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue,
-				float64(t.Bytes), t.FlowID, c.NodeName, t.Provider)
+				float64(bytes), k.flowID, c.NodeName, k.peerNode, k.provider)
 		}
 	}
 	emit(descTransmitted, c.Source)
@@ -69,6 +82,7 @@ func (r *SourceReconciler) Throughput() []Throughput {
 	for _, e := range r.sources {
 		out = append(out, Throughput{
 			FlowID:   e.flowID,
+			PeerNode: e.peerNode,
 			Provider: e.provider.String(),
 			Bytes:    e.bytes.Load(),
 		})
@@ -85,6 +99,7 @@ func (r *TargetReconciler) Throughput() []Throughput {
 	for _, e := range r.targets {
 		out = append(out, Throughput{
 			FlowID:   e.flowID,
+			PeerNode: e.peerNode,
 			Provider: e.provider.String(),
 			Bytes:    e.bytes.Load(),
 		})

--- a/gateway/internal/mirror/throughput_test.go
+++ b/gateway/internal/mirror/throughput_test.go
@@ -17,12 +17,12 @@ func TestThroughputCollectorReportsBothDirections(t *testing.T) {
 	// "what is this node pushing over verbs" by aggregation rather
 	// than by a second metric.
 	src := &SourceReconciler{sources: map[types.NamespacedName]*sourceEntry{}}
-	sent := &sourceEntry{flowID: "flow-a", provider: fabrics.ProviderVerbs}
+	sent := &sourceEntry{flowID: "flow-a", peerNode: "n02", provider: fabrics.ProviderVerbs}
 	sent.bytes.Store(5529600)
 	src.sources[types.NamespacedName{Namespace: "p", Name: "a"}] = sent
 
 	tgt := &TargetReconciler{targets: map[types.NamespacedName]*targetEntry{}}
-	got := &targetEntry{flowID: "flow-b", provider: fabrics.ProviderTCP}
+	got := &targetEntry{flowID: "flow-b", peerNode: "n03", provider: fabrics.ProviderTCP}
 	got.bytes.Store(4096)
 	tgt.targets[types.NamespacedName{Namespace: "p", Name: "b"}] = got
 
@@ -31,10 +31,10 @@ func TestThroughputCollectorReportsBothDirections(t *testing.T) {
 	expected := `
 # HELP mxl_gateway_mirror_received_bytes_total Payload bytes committed to the local flow for a mirror this node is the target of.
 # TYPE mxl_gateway_mirror_received_bytes_total counter
-mxl_gateway_mirror_received_bytes_total{flow_id="flow-b",node="n01",provider="tcp"} 4096
+mxl_gateway_mirror_received_bytes_total{flow_id="flow-b",node="n01",peer_node="n03",provider="tcp"} 4096
 # HELP mxl_gateway_mirror_transmitted_bytes_total Payload bytes handed to the fabric for a mirror this node is the source of.
 # TYPE mxl_gateway_mirror_transmitted_bytes_total counter
-mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",provider="verbs"} 5529600
+mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node="n02",provider="verbs"} 5529600
 `
 	require.NoError(t, testutil.CollectAndCompare(c, strings.NewReader(expected)))
 }
@@ -47,7 +47,7 @@ func TestThroughputCollectorForgetsClosedMirrors(t *testing.T) {
 	// than one that is gone.
 	src := &SourceReconciler{sources: map[types.NamespacedName]*sourceEntry{}}
 	key := types.NamespacedName{Namespace: "p", Name: "a"}
-	e := &sourceEntry{flowID: "flow-a", provider: fabrics.ProviderVerbs}
+	e := &sourceEntry{flowID: "flow-a", peerNode: "n02", provider: fabrics.ProviderVerbs}
 	e.bytes.Store(1024)
 	src.sources[key] = e
 
@@ -57,4 +57,34 @@ func TestThroughputCollectorForgetsClosedMirrors(t *testing.T) {
 	delete(src.sources, key)
 	require.Equal(t, 0, testutil.CollectAndCount(c),
 		"a mirror that has been closed must leave no series behind")
+}
+
+func TestThroughputCollectorSurvivesOneFlowMirroredTwice(t *testing.T) {
+	// A node mirrors one flow to several peers, so its source
+	// reconciler holds several entries carrying the same flow id. Two
+	// series with one label set fail the whole gather with a 500,
+	// which takes every other metric on the endpoint down with it --
+	// observed on sc, where three of five gateways stopped being
+	// scraped at all.
+	src := &SourceReconciler{sources: map[types.NamespacedName]*sourceEntry{}}
+	for _, peer := range []string{"n02", "n03"} {
+		e := &sourceEntry{flowID: "flow-a", peerNode: peer, provider: fabrics.ProviderVerbs}
+		e.bytes.Store(1000)
+		src.sources[types.NamespacedName{Namespace: "p", Name: "flow-a--" + peer}] = e
+	}
+	c := &ThroughputCollector{NodeName: "n01", Source: src}
+	require.NoError(t, testutil.CollectAndCompare(c, strings.NewReader(`
+# HELP mxl_gateway_mirror_transmitted_bytes_total Payload bytes handed to the fabric for a mirror this node is the source of.
+# TYPE mxl_gateway_mirror_transmitted_bytes_total counter
+mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node="n02",provider="verbs"} 1000
+mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node="n03",provider="verbs"} 1000
+`)), "one flow mirrored to two peers must yield two distinct series")
+
+	// Same flow and same peer in two namespaces cannot be separated by
+	// labels at all, so the fold has to carry it.
+	dup := &sourceEntry{flowID: "flow-a", peerNode: "n02", provider: fabrics.ProviderVerbs}
+	dup.bytes.Store(500)
+	src.sources[types.NamespacedName{Namespace: "other", Name: "flow-a--n02"}] = dup
+	require.Equal(t, 2, testutil.CollectAndCount(c),
+		"a label set that repeats must fold into one series, never a duplicate")
 }


### PR DESCRIPTION
Three of the five gateways on sc were not being scraped at all:

```
10.20.53.11 (n01) down   server returned HTTP status 500
10.20.53.12 (n02) down   server returned HTTP status 500
10.20.53.13 (n03) down   server returned HTTP status 500
10.20.53.14 (n04) up
10.20.53.15 (n05) up
```

A node mirrors one flow to several peers - n01 sources
`d4d00000-...-0004` to both n02 and n03 - and each of those entries
carried the same `flow_id`, `node` and `provider`. Two series sharing a
label set fail the whole gather, so the endpoint answered 500 and
Prometheus dropped every metric on it, not just the throughput ones.

The three failing nodes are also the target-side nodes, which is why
`Received per Node and Transport` had no data anywhere and the other
panels showed only n04 and n05. Nothing was wrong with the queries.

I dropped `peer_node` while building this to avoid changing the opener
interface. It turns out not to be optional: it is what makes the label
set unique, and it names the far end of each mirror, which is what
attributes a slow stream to a link rather than just to a node. It is
set in Reconcile beside `flowID`, so the opener signature is untouched.

`Collect` also folds entries onto their label set before emitting. Two
mirrors of one flow to one peer can still exist in different
namespaces, and a duplicate reaching the registry is far too expensive
to leave to the labels alone.

## Units

The four Node Throughput panels now read bits per second, which is how
the rest of the signal chain is specified. Expressions are scaled by 8
and the unit is `bps`.

`Transmitted per Flow` also breaks out `peer_node`, reading
`{{node}} -> {{peer_node}} / {{flow_id}} / {{provider}}`.

## Verification

`TestThroughputCollectorSurvivesOneFlowMirroredTwice` covers both
halves: one flow to two peers must yield two distinct series, and a
label set that repeats must fold rather than duplicate. It fails
against the pre-fix collector. gofmt, vet and the full gateway suite
are clean; `helm lint` passes and the dashboard renders with all 33
panels, no grid overlaps, and the datasource substitution intact.