### PR TITLE
fix(gateway): classify target progress errors instead of assuming fatal

### DIFF
--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -809,7 +809,9 @@ func (e *targetEntry) recordCommit(_ uint64, at time.Time) {
 // OpenGrain + Commit dance on the local FlowWriter so consumer
 // FlowReaders see the arrived grain.
 //
-// On any non-ErrNotReady error from ReadGrain the underlying Target
+// Errors from ReadGrain are classified: idle means nothing arrived,
+// transient means the call was disturbed and the handles are still
+// good. On anything else the underlying Target
 // is no longer safe to poll - libmxl-fabrics has been observed to
 // dangle internal state after the remote endpoint drops, and the
 // next ReadGrain call segfaults inside cgo. We exit the loop and
@@ -838,7 +840,7 @@ func runTargetProgressLoop(
 		default:
 		}
 		idx, err := readGrain()
-		switch {
+		switch kind := classifyFabricError(err); {
 		case err == nil:
 			if err := commit(idx); err != nil {
 				l.Error(err, "commit received grain", "idx", idx)
@@ -847,14 +849,25 @@ func runTargetProgressLoop(
 			if tracker != nil {
 				tracker.recordCommit(idx, time.Now())
 			}
-		case errors.Is(err, fabrics.ErrNotReady):
+		case kind == fabricIdle:
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(idleSleep):
+			}
+		case kind == fabricTransient:
+			// Disturbed, not broken: the handles are still usable, so
+			// poll again instead of rebuilding the fabric side.
+			l.V(1).Info("ReadGrain disturbed, retrying",
+				"error", err.Error(), "class", kind.String())
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(idleSleep):
 			}
 		default:
-			l.Error(err, "ReadGrain - target is no longer safe to poll, exiting loop")
+			l.Error(err, "ReadGrain - target is no longer safe to poll, exiting loop",
+				"class", kind.String())
 			if onFatal != nil {
 				onFatal()
 			}
@@ -889,8 +902,9 @@ func commitArrivedGrain(writer *mxl.Writer, idx uint64) (uint64, error) {
 // blocking-variant SIGURG interaction documented there. For every run
 // of samples ReadSamples reports as arrived, commit does the
 // OpenSamples + Commit dance on the local FlowWriter so consumer
-// FlowReaders see them. Any non-ErrNotReady error is fatal and fires
-// onFatal so the reconciler rebuilds the fabric side.
+// FlowReaders see them. Errors are classified as in the grain loop:
+// idle and transient are retried, anything else fires onFatal so the
+// reconciler rebuilds the fabric side.
 func runTargetSampleProgressLoop(
 	ctx context.Context,
 	done chan struct{},
@@ -909,7 +923,7 @@ func runTargetSampleProgressLoop(
 		default:
 		}
 		head, count, err := readSamples()
-		switch {
+		switch kind := classifyFabricError(err); {
 		case err == nil:
 			if err := commit(head, count); err != nil {
 				l.Error(err, "commit received samples", "headIndex", head, "count", count)
@@ -918,14 +932,25 @@ func runTargetSampleProgressLoop(
 			if tracker != nil {
 				tracker.recordCommit(head, time.Now())
 			}
-		case errors.Is(err, fabrics.ErrNotReady):
+		case kind == fabricIdle:
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(idleSleep):
+			}
+		case kind == fabricTransient:
+			// Disturbed, not broken: the handles are still usable, so
+			// poll again instead of rebuilding the fabric side.
+			l.V(1).Info("ReadSamples disturbed, retrying",
+				"error", err.Error(), "class", kind.String())
 			select {
 			case <-ctx.Done():
 				return
 			case <-time.After(idleSleep):
 			}
 		default:
-			l.Error(err, "ReadSamples - target is no longer safe to poll, exiting loop")
+			l.Error(err, "ReadSamples - target is no longer safe to poll, exiting loop",
+				"class", kind.String())
 			if onFatal != nil {
 				onFatal()
 			}

--- a/gateway/internal/mirror/target_test.go
+++ b/gateway/internal/mirror/target_test.go
@@ -107,6 +107,79 @@ func TestRunTargetProgressLoop_FatalErrorExitsAndCallsOnFatalOnce(t *testing.T) 
 			"concurrent recoverFromFatalError invocations against the same writer")
 }
 
+func TestRunTargetProgressLoop_InterruptedIsRetriedNotFatal(t *testing.T) {
+	// Go's async preemption sends SIGURG to running goroutines, so
+	// libmxl-fabrics reports MXL_ERR_INTERRUPTED as a matter of course.
+	// Rebuilding the fabric side on each one would churn continuously,
+	// so the loop must poll again and eventually commit.
+	var calls atomic.Int32
+	read := func() (uint64, error) {
+		if calls.Add(1) <= 3 {
+			return 0, mxl.ErrInterrupted
+		}
+		return 7, nil
+	}
+
+	committed := make(chan uint64, 1)
+	commit := func(idx uint64) error {
+		select {
+		case committed <- idx:
+		default:
+		}
+		return nil
+	}
+	onFatal := func() { t.Error("interrupted read must not be treated as fatal") }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go runTargetProgressLoop(ctx, done, read, commit, onFatal, nil)
+
+	select {
+	case idx := <-committed:
+		assert.Equal(t, uint64(7), idx)
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop never got past the interrupted reads")
+	}
+	cancel()
+	<-done
+}
+
+func TestRunTargetSampleProgressLoop_InterruptedIsRetriedNotFatal(t *testing.T) {
+	// Same contract on the sample path, which shares the classifier.
+	var calls atomic.Int32
+	read := func() (uint64, int, error) {
+		if calls.Add(1) <= 3 {
+			return 0, 0, mxl.ErrInterrupted
+		}
+		return 11, 2, nil
+	}
+
+	committed := make(chan uint64, 1)
+	commit := func(head uint64, _ int) error {
+		select {
+		case committed <- head:
+		default:
+		}
+		return nil
+	}
+	onFatal := func() { t.Error("interrupted read must not be treated as fatal") }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go runTargetSampleProgressLoop(ctx, done, read, commit, onFatal, nil)
+
+	select {
+	case head := <-committed:
+		assert.Equal(t, uint64(11), head)
+	case <-time.After(2 * time.Second):
+		t.Fatal("loop never got past the interrupted reads")
+	}
+	cancel()
+	<-done
+}
+
 func TestRunTargetProgressLoop_CommitErrorIsLoggedButLoopContinues(t *testing.T) {
 	// A commit-side error (e.g. OpenGrain returning busy under load)
 	// must not exit the loop. The next ReadGrain is allowed to


### PR DESCRIPTION
Closes #265.

Correction to the issue as filed: the source loop was already fine. It calls
`classifyFabricError`, which has mapped `MXL_ERR_INTERRUPTED` to
`fabricTransient` all along. The gap is the two target loops, which never used
the classifier.

`runTargetProgressLoop` and `runTargetSampleProgressLoop` branched on
`fabrics.ErrNotReady` and sent everything else down a `default` branch that
logs "target is no longer safe to poll", fires `onFatal` and exits so the
reconciler rebuilds the fabric side.

`MXL_ERR_INTERRUPTED` lands in that branch. libmxl-fabrics returns it whenever
a signal interrupts the poll, and Go's async preemption sends SIGURG to running
goroutines, so it is a steady-state outcome. A mirror could therefore rebuild
its fabric side over and over with nothing actually wrong.

Both loops now use the same classifier as the source side: retry on
`fabricTransient`, keep the rebuild path for `fabricEndpointLost` and
`fabricPermanent`. The class is included in the log line so a rebuild records
which category triggered it. Two stale doc comments claiming "any non-ErrNotReady
error is fatal" are corrected.

Tests cover both loops recovering from a run of interrupted reads and going on
to commit, with `onFatal` failing the test if it fires. The existing
fatal-error tests are unchanged and still pass, so the rebuild path is intact.

Verified in the builder image: `gofmt` and `go vet` clean, full gateway suite
passes.

Independent of qvest-digital/go-mxl#82. That PR adds a `fabrics.ErrInterrupted`
sentinel; this one matches on `mxl.ErrInterrupted`, which the classifier already
used and which the new sentinel will keep matching under `errors.Is` via its
`MxlStatus` bridge.