### PR TITLE
feat: build against libmxl 1.1.0-rc1 via go-mxl 1.1.0-rc.1

### DIFF
--- a/docker/demo-tools.Dockerfile
+++ b/docker/demo-tools.Dockerfile
@@ -12,7 +12,7 @@
 #   docker build -f docker/demo-tools.Dockerfile -t local/mxl-demo-tools:dev .
 
 # renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
-ARG GO_MXL_TAG=1.0.0-rc.15
+ARG GO_MXL_TAG=1.1.0-rc.1
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 ARG GO_MXL_TAG

--- a/docker/exporter.Dockerfile
+++ b/docker/exporter.Dockerfile
@@ -6,7 +6,7 @@
 # Build context: repo root.
 
 # renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
-ARG GO_MXL_TAG=1.0.0-rc.15
+ARG GO_MXL_TAG=1.1.0-rc.1
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 WORKDIR /workspace

--- a/docker/gateway.Dockerfile
+++ b/docker/gateway.Dockerfile
@@ -5,7 +5,7 @@
 # Build context: repo root.
 
 # renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
-ARG GO_MXL_TAG=1.0.0-rc.15
+ARG GO_MXL_TAG=1.1.0-rc.1
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 WORKDIR /workspace

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/prometheus/client_golang v1.24.1
-	github.com/qvest-digital/go-mxl v1.0.0-rc.15
+	github.com/qvest-digital/go-mxl v1.1.0-rc.1
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.10 // x-release-please-version
 	golang.org/x/sys v0.47.0
 	k8s.io/apimachinery v0.36.3

--- a/exporter/go.sum
+++ b/exporter/go.sum
@@ -86,8 +86,8 @@ github.com/prometheus/common v0.70.1 h1:1HvjP4D5oL3t8RsPlwxA9onvvStjtIHYE5XuuwOi
 github.com/prometheus/common v0.70.1/go.mod h1:VdFUQDMZK3VLkurFUVhia6uys/0suUp86TJz5qbJRhc=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
-github.com/qvest-digital/go-mxl v1.0.0-rc.15 h1:jGDDnottemfn0nce0hBwZGGrFEcxYVcTtftmFDFVS4k=
-github.com/qvest-digital/go-mxl v1.0.0-rc.15/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.1.0-rc.1 h1:CUg29Q5c/JA6pqyA5gP3vu7JBr8lRXbOOxC+r0W572s=
+github.com/qvest-digital/go-mxl v1.1.0-rc.1/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -15,6 +15,7 @@ require (
 
 require (
 	github.com/go-logr/logr v1.4.4
+	github.com/prometheus/client_golang v1.23.2
 	k8s.io/utils v0.0.0-20260707023825-cf1189d6abe3
 )
 
@@ -34,12 +35,12 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
 	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/gateway
 go 1.26.0
 
 require (
-	github.com/qvest-digital/go-mxl v1.0.0-rc.15
+	github.com/qvest-digital/go-mxl v1.1.0-rc.1
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.10 // x-release-please-version
 	github.com/stretchr/testify v1.11.1
 	go.uber.org/goleak v1.3.0

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -19,8 +19,6 @@ github.com/fsnotify/fsnotify v1.9.0 h1:2Ml+OJNzbYCTzsxtv8vKSFD9PbJjmhYF14k/jKC7S
 github.com/fsnotify/fsnotify v1.9.0/go.mod h1:8jBTzvmWwFyi3Pb8djgCCO5IBqzKJ/Jwo8TRcHyHii0=
 github.com/fxamacker/cbor/v2 v2.9.0 h1:NpKPmjDBgUfBms6tr6JZkTHtfFGcMKsw3eGcmD/sapM=
 github.com/fxamacker/cbor/v2 v2.9.0/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
-github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
-github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/logr v1.4.4 h1:tG4xh9yMsRCAiodLVTxyrkzSZ9+o0L1Kg/+cPVcbP/8=
 github.com/go-logr/logr v1.4.4/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
 github.com/go-logr/zapr v1.3.0 h1:XGdV8XW8zdwFiwOA2Dryh1gj2KRQyOOoNmBy4EplIcQ=
@@ -88,8 +86,8 @@ github.com/prometheus/common v0.67.5 h1:pIgK94WWlQt1WLwAC5j2ynLaBRDiinoAb86HZHTU
 github.com/prometheus/common v0.67.5/go.mod h1:SjE/0MzDEEAyrdr5Gqc6G+sXI67maCxzaT3A2+HqjUw=
 github.com/prometheus/procfs v0.19.2 h1:zUMhqEW66Ex7OXIiDkll3tl9a1ZdilUOd/F6ZXw4Vws=
 github.com/prometheus/procfs v0.19.2/go.mod h1:M0aotyiemPhBCM0z5w87kL22CxfcH05ZpYlu+b4J7mw=
-github.com/qvest-digital/go-mxl v1.0.0-rc.15 h1:jGDDnottemfn0nce0hBwZGGrFEcxYVcTtftmFDFVS4k=
-github.com/qvest-digital/go-mxl v1.0.0-rc.15/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.1.0-rc.1 h1:CUg29Q5c/JA6pqyA5gP3vu7JBr8lRXbOOxC+r0W572s=
+github.com/qvest-digital/go-mxl v1.1.0-rc.1/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=


### PR DESCRIPTION
Depends on qvest-digital/go-mxl#84. **Cannot merge until go-mxl 1.1.0-rc.1 is
published** — `demo-tools.Dockerfile` installs the go-mxl examples by module
version, so its build fails against an unreleased tag. Confirmed by hitting it.

### No source change is required

The upstream range is 39 files, 430 insertions, 1746 deletions, but the only
edit to a public header is a doc comment recording that `MXL_ERR_INTERRUPTED`
may be returned. That status was already reachable before, via the exception
the C wrapper caught and converted. The Go binding surface does not move
either. So this is a pin bump in five places and nothing else.

### What the upgrade buys

Upstream's `Fix FI_EINTR (interrupted) corrupting internal state for no reason`
turns interruption into a returned value instead of a thrown exception. An
interrupted call no longer unwinds, no longer logs at error level, and no
longer leaves fabrics state disturbed. Both gateway loops poll continuously, so
this path is taken on every async-preemption signal.

Also inherited: a file descriptor leak in `PosixDiscreteFlowReader`,
`PosixContinuousFlowWriter` index corrections, and a fix to sliced transfers
carrying alpha.

### What is deliberately not done

Blocking progress and blocking reads become viable with this fix, and the
Go-side poll loops in `source.go` and `target.go` exist only to avoid them.
Adopting them would remove that workaround, but the failure it was written
against manifests on RDMA transports, and the local integration environment
runs the tcp provider. Shipping it on evidence that cannot reach the affected
path would be a guess, so it is left for a change that can be validated on
RDMA hardware.

### Verification

Builder and runtime images rebuilt against libmxl v1.1.0-rc1, then:

- gateway and exporter unit suites pass
- kind integration suite: **18/18 cases pass**, including `61-shared-mirror-refcount`,
  `85-node-departure` and `86-node-drain`
- `make kind-status` clean afterwards: all pods Running, domains, flows and
  node capabilities present

The integration run used the new library for gateway and exporter, with
demo-tools held at the published tag for the reason above.

### Release

Carries `Release-As: 1.1.0-rc.1`.