### PR TITLE
fix(gateway): reopen a source reader that stopped delivering

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -59,12 +59,16 @@ const (
 
 	// ReasonReaderAgedOut marks a mirror whose source-side flow
 	// reader fell behind the writer and advanced past the missed
-	// grains.
+	// grains. Benign on its own: a reader that skips once and reaches
+	// the live tail again keeps the mirror delivering. The message
+	// separates that from a reader still outside the ring a whole
+	// stall window after its last delivered grain, which is the one
+	// the gateway reopens.
 	ReasonReaderAgedOut = "ReaderAgedOut"
 
 	// ReasonReaderNotAdvancing marks a mirror whose source-side flow
-	// reader has never transferred a grain and whose head index has
-	// not moved since the reader opened.
+	// reader has delivered no grain within the stall window and whose
+	// head index has not moved either.
 	ReasonReaderNotAdvancing = "ReaderNotAdvancing"
 
 	// ReasonTransfersNotLanding marks a mirror whose source-side reader

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -77,9 +77,9 @@ const maxReaderRebuilds = 5
 
 // ReasonReaderRebuildCapReached marks a mirror whose source-side
 // reader stayed wedged across maxReaderRebuilds consecutive reopens.
-// Distinct from ReasonReaderNotAdvancing: that one is the
-// recoverable observation, this one says the gateway has stopped
-// reopening the reader.
+// Distinct from ReasonReaderNotAdvancing and ReasonReaderAgedOut:
+// those are the recoverable observations that spend the budget, this
+// one says the gateway has stopped reopening the reader.
 const ReasonReaderRebuildCapReached = "ReaderRebuildCapReached"
 
 // SourceReconciler reconciles MxlFlowMirror resources from the
@@ -200,7 +200,9 @@ type sourceEntry struct {
 	// agedOutAt records the wall-clock of the most recent
 	// reader-aged-out skip the transfer loop has had to perform.
 	// Used by the flusher to publish SourceProgress with reason
-	// ReaderAgedOut on the transition.
+	// ReaderAgedOut on the transition, and read against lastSentAt to
+	// tell a reader that skipped and caught up from one still outside
+	// the ring.
 	agedOutAt atomic.Pointer[time.Time]
 
 	// lastHead is the most recent head index the transfer loop probed
@@ -1145,6 +1147,12 @@ type sourceProgressState struct {
 	reason   string
 	message  string
 	attempts uint32
+	// rebuildReader marks the states only a fresh FlowReader resolves,
+	// so the flusher does not have to re-derive that from the reason:
+	// ReaderAgedOut is published both for a reader that skipped once
+	// and kept delivering and for one stuck outside the ring, and only
+	// the second is a wedge.
+	rebuildReader bool
 	// lastSentAt carries the wall-clock of the most recent successful
 	// TransferGrain forward into the SSA payload. The target-side
 	// stuck-handshake watchdog reads it to discriminate "source is
@@ -1242,22 +1250,23 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 		}
 		state := observedState(entry, r.readerStallAfter())
 
-		// A reader whose head never moves is the one wedge neither
-		// side of the mirror resolves on its own. The target's
+		// A reader that has stopped feeding the fabric is the one wedge
+		// neither side of the mirror resolves on its own. The target's
 		// stuck-handshake watchdog is gated on status.lastSentAt
-		// postdating its own fabric open, and a reader that has
-		// transferred nothing never advances lastSentAt, so the
-		// target reads the mirror as an idle producer and declines to
-		// rebuild. Reporting the wedge and waiting for the other side
-		// leaves the mirror Degraded indefinitely; reopening the
-		// reader here is what ends it.
-		if state.reason == mxlv1alpha1.ReasonReaderNotAdvancing {
+		// postdating its own fabric open, and a reader that transfers
+		// nothing never advances lastSentAt, so the target reads the
+		// mirror as an idle producer and declines to rebuild.
+		// Reporting the wedge and waiting for the other side leaves
+		// the mirror Degraded indefinitely; reopening the reader here
+		// is what ends it, and it is the same recovery an operator
+		// gets by deleting the mirror and letting the requestor
+		// recreate it.
+		if state.rebuildReader {
 			switch {
 			case r.readerRebuildsExhausted(key):
 				state.reason = ReasonReaderRebuildCapReached
-				state.message = fmt.Sprintf(
-					"reader head stuck at %d across %d reopens",
-					entry.lastHead.Load(), maxReaderRebuilds)
+				state.message = fmt.Sprintf("%s; unresolved across %d reopens",
+					state.message, maxReaderRebuilds)
 			case entry.rebuilding.CompareAndSwap(false, true):
 				attempt := r.bumpReaderRebuilds(key)
 				if err := r.publishSourceProgress(ctx, key, state); err != nil {
@@ -1265,8 +1274,8 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 						"mirror", key, "reason", state.reason)
 				}
 				ctrl.Log.WithName("source-flush").Info(
-					"reader head stuck; reopening reader",
-					"mirror", key, "attempt", attempt)
+					"source reader wedged; reopening reader",
+					"mirror", key, "reason", state.reason, "attempt", attempt)
 				// Returning first is what makes the reopen safe:
 				// closeSourceHandles waits on flusherDone, and this
 				// goroutine is the one that closes it.
@@ -1391,6 +1400,14 @@ func sourceStateEqual(a, b sourceProgressState) bool {
 // propagated into every state so the target-side watchdog gets a
 // freshness signal regardless of which condition is currently being
 // published.
+//
+// Every fault here is judged against the last grain that reached the
+// target rather than against the lifetime transfer count. A mirror
+// that delivered for hours and then stopped reads identically to one
+// that never started, and the lifetime count reports the history
+// instead: it turned a source that had gone dead into ConditionTrue /
+// Recovered, and no watchdog on either side of the mirror looks at a
+// source that calls itself healthy.
 func observedState(entry *sourceEntry, stallAfter time.Duration) sourceProgressState {
 	var sent *time.Time
 	if p := entry.lastSentAt.Load(); p != nil {
@@ -1411,7 +1428,73 @@ func observedState(entry *sourceEntry, stallAfter time.Duration) sourceProgressS
 			lastSentAt: sent,
 		}
 	}
-	if entry.agedOutAt.Load() != nil {
+	delivering := sent != nil && time.Since(*sent) <= stallAfter
+	// An aged-out skip is only evidence about the reader while it is
+	// recent. Held for the stall window rather than until the next
+	// transfer so a reader skipping every tick stays on one condition
+	// instead of flapping it against Recovered, and so a single skip
+	// stays visible to an operator for a moment either way.
+	agedOut := false
+	if at := entry.agedOutAt.Load(); at != nil && time.Since(*at) <= stallAfter {
+		agedOut = true
+	}
+
+	// The head has not moved: the loop's inner range never runs, so it
+	// emits no error and no aged-out skip, and the target reads the
+	// mirror as an idle producer and declines to recover. This is what
+	// a reader left on a producer's previous flow directory looks like
+	// after the producer restarts -- the ring it is mapped onto is
+	// gone, so no later grain can ever arrive and only a fresh reader
+	// resolves it.
+	if at := entry.headAdvancedAt.Load(); at != nil &&
+		time.Since(*at) > stallAfter && !delivering {
+		return sourceProgressState{
+			status: metav1.ConditionFalse,
+			reason: mxlv1alpha1.ReasonReaderNotAdvancing,
+			message: fmt.Sprintf("reader head stuck at %d for over %s",
+				entry.lastHead.Load(), stallAfter),
+			rebuildReader: true,
+			lastSentAt:    sent,
+		}
+	}
+	// The head is moving and the reader keeps landing outside the
+	// producer's ring. Skipping to the head is the loop's own recovery
+	// and it works whenever the ring underneath is live, so a reader
+	// still aging out a whole stall window after its last delivery is
+	// one that cannot reach the live tail at all; only reopening it
+	// gets the mirror back.
+	if agedOut && !delivering {
+		return sourceProgressState{
+			status: metav1.ConditionFalse,
+			reason: mxlv1alpha1.ReasonReaderAgedOut,
+			message: fmt.Sprintf(
+				"source reader fell behind writer and has delivered nothing in %s",
+				stallAfter),
+			rebuildReader: true,
+			lastSentAt:    sent,
+		}
+	}
+	// The head is moving, so the producer is alive and the reader is
+	// following it, yet nothing has landed at the target. Reporting
+	// True here calls that healthy, and it is the state a source sits
+	// in when its target publishes an endpoint that never accepts: the
+	// initiator retries the address forever, transfers nothing, and
+	// never advances lastSentAt. Left to the target's stuck-handshake
+	// watchdog rather than reopened here: the reader is demonstrably
+	// reading, and the target gates its own rebuild on seeing this
+	// reason.
+	if !delivering && !entry.openedAt.IsZero() &&
+		time.Since(entry.openedAt) > stallAfter {
+		return sourceProgressState{
+			status: metav1.ConditionFalse,
+			reason: mxlv1alpha1.ReasonTransfersNotLanding,
+			message: fmt.Sprintf(
+				"reader head at %d is advancing but nothing has reached the target in %s",
+				entry.lastHead.Load(), stallAfter),
+			lastSentAt: sent,
+		}
+	}
+	if agedOut {
 		return sourceProgressState{
 			status:     metav1.ConditionFalse,
 			reason:     mxlv1alpha1.ReasonReaderAgedOut,
@@ -1424,37 +1507,6 @@ func observedState(entry *sourceEntry, stallAfter time.Duration) sourceProgressS
 			status:     metav1.ConditionTrue,
 			reason:     mxlv1alpha1.ReasonRecovered,
 			message:    "grain progress observed",
-			lastSentAt: sent,
-		}
-	}
-	// Nothing transferred and the head has not moved: the loop's inner
-	// range never runs, so it emits no error and no aged-out skip, and
-	// the target reads the mirror as an idle producer and declines to
-	// recover. Reporting True here describes that wedge as healthy.
-	if at := entry.headAdvancedAt.Load(); at != nil && time.Since(*at) > stallAfter {
-		return sourceProgressState{
-			status: metav1.ConditionFalse,
-			reason: mxlv1alpha1.ReasonReaderNotAdvancing,
-			message: fmt.Sprintf("reader head stuck at %d for over %s",
-				entry.lastHead.Load(), stallAfter),
-			lastSentAt: sent,
-		}
-	}
-	// The head is moving, so the producer is alive and the reader is
-	// following it, yet nothing has landed at the target since this
-	// initiator opened. Reporting True here calls that healthy, and it
-	// is the state a source sits in when its target publishes an
-	// endpoint that never accepts: the initiator retries the address
-	// forever, transfers nothing, and never advances lastSentAt.
-	if !entry.openedAt.IsZero() &&
-		time.Since(entry.openedAt) > stallAfter &&
-		(sent == nil || sent.Before(entry.openedAt)) {
-		return sourceProgressState{
-			status: metav1.ConditionFalse,
-			reason: mxlv1alpha1.ReasonTransfersNotLanding,
-			message: fmt.Sprintf(
-				"reader head at %d is advancing but nothing has reached the target in %s",
-				entry.lastHead.Load(), stallAfter),
 			lastSentAt: sent,
 		}
 	}

--- a/gateway/internal/mirror/source_stall_test.go
+++ b/gateway/internal/mirror/source_stall_test.go
@@ -16,7 +16,10 @@ import (
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 )
 
-func stalledEntry(head uint64, headAt *time.Time, transfers uint64) *sourceEntry {
+// stalledEntry builds a sourceEntry whose head last moved at headAt
+// and which has delivered transfers grains, the last of them at
+// sentAt. A zero sentAt leaves the entry with no delivery on record.
+func stalledEntry(head uint64, headAt *time.Time, transfers uint64, sentAt time.Time) *sourceEntry {
 	e := &sourceEntry{}
 	e.lastHead.Store(head)
 	if headAt != nil {
@@ -24,7 +27,7 @@ func stalledEntry(head uint64, headAt *time.Time, transfers uint64) *sourceEntry
 		e.headAdvancedAt.Store(&t)
 	}
 	for i := uint64(0); i < transfers; i++ {
-		e.recordTransfer(i, time.Now())
+		e.recordTransfer(i, sentAt)
 	}
 	return e
 }
@@ -39,32 +42,50 @@ func TestObservedState_ReaderNotAdvancing(t *testing.T) {
 	fresh := time.Now()
 
 	tests := []struct {
-		name       string
-		entry      *sourceEntry
-		wantStatus metav1.ConditionStatus
-		wantReason string
+		name        string
+		entry       *sourceEntry
+		wantStatus  metav1.ConditionStatus
+		wantReason  string
+		wantRebuild bool
 	}{
 		{
 			name:       "never probed",
-			entry:      stalledEntry(0, nil, 0),
+			entry:      stalledEntry(0, nil, 0, time.Time{}),
 			wantStatus: metav1.ConditionTrue,
 			wantReason: mxlv1alpha1.ReasonHandshakeComplete,
 		},
 		{
 			name:       "head advanced within window",
-			entry:      stalledEntry(42, &fresh, 0),
+			entry:      stalledEntry(42, &fresh, 0, time.Time{}),
 			wantStatus: metav1.ConditionTrue,
 			wantReason: mxlv1alpha1.ReasonHandshakeComplete,
 		},
 		{
-			name:       "head frozen past window without transfers",
-			entry:      stalledEntry(42, &stale, 0),
-			wantStatus: metav1.ConditionFalse,
-			wantReason: mxlv1alpha1.ReasonReaderNotAdvancing,
+			name:        "head frozen past window without transfers",
+			entry:       stalledEntry(42, &stale, 0, time.Time{}),
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  mxlv1alpha1.ReasonReaderNotAdvancing,
+			wantRebuild: true,
 		},
 		{
-			name:       "head frozen past window after transfers",
-			entry:      stalledEntry(42, &stale, 3),
+			// The state a mirror lands in when the producer on its
+			// source node restarts: the reader stays on the flow
+			// directory that went away, so the head it can see never
+			// moves again. Judged on the lifetime transfer count this
+			// read as Recovered, which is how a mirror that had
+			// delivered for hours could then sit dead for hours with
+			// neither side reopening anything.
+			name:        "head frozen past window after transfers stopped",
+			entry:       stalledEntry(42, &stale, 3, stale),
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  mxlv1alpha1.ReasonReaderNotAdvancing,
+			wantRebuild: true,
+		},
+		{
+			// A backlog drained after the head stopped moving is a
+			// reader doing its job, not a wedge.
+			name:       "head frozen past window while transfers land",
+			entry:      stalledEntry(42, &stale, 3, fresh),
 			wantStatus: metav1.ConditionTrue,
 			wantReason: mxlv1alpha1.ReasonRecovered,
 		},
@@ -75,8 +96,65 @@ func TestObservedState_ReaderNotAdvancing(t *testing.T) {
 			got := observedState(tc.entry, window)
 			assert.Equal(t, tc.wantStatus, got.status)
 			assert.Equal(t, tc.wantReason, got.reason)
+			assert.Equal(t, tc.wantRebuild, got.rebuildReader)
 		})
 	}
+}
+
+func TestObservedState_AgedOutDoesNotOutliveItself(t *testing.T) {
+	// The aged-out skip used to be reported for the life of the entry
+	// and ahead of every other state, so one fall-behind pinned
+	// SourceProgress at ReaderAgedOut whatever the reader did next.
+	// That hid both stall detectors behind it: the flusher never saw
+	// ReaderNotAdvancing, so it never reopened the reader, and the
+	// target's stuck-handshake watchdog never saw TransfersNotLanding,
+	// so it never rebuilt its endpoint. The mirror kept reporting a
+	// fault that had already passed and nothing recovered it.
+	const window = 20 * time.Second
+	stale := time.Now().Add(-window - time.Second)
+	fresh := time.Now()
+
+	skipped := stalledEntry(42, &fresh, 1, fresh)
+	skipped.recordAgedOut(fresh)
+	state := observedState(skipped, window)
+	assert.Equal(t, mxlv1alpha1.ReasonReaderAgedOut, state.reason,
+		"a recent skip stays visible while the reader delivers")
+	assert.False(t, state.rebuildReader,
+		"a reader that skipped and caught up needs no reopen")
+
+	recovered := stalledEntry(42, &fresh, 1, fresh)
+	recovered.recordAgedOut(stale)
+	assert.Equal(t, mxlv1alpha1.ReasonRecovered,
+		observedState(recovered, window).reason,
+		"a skip a whole window old is history, not the current state")
+
+	wedged := stalledEntry(42, &fresh, 1, stale)
+	wedged.recordAgedOut(fresh)
+	state = observedState(wedged, window)
+	assert.Equal(t, metav1.ConditionFalse, state.status)
+	assert.Equal(t, mxlv1alpha1.ReasonReaderAgedOut, state.reason)
+	assert.True(t, state.rebuildReader,
+		"skipping to the head is the loop's own recovery, so a reader "+
+			"still aging out a window after its last grain cannot reach "+
+			"the live tail at all")
+}
+
+func TestObservedState_TransfersStoppedWithLiveHead(t *testing.T) {
+	// The head keeps moving, so the reader is demonstrably reading and
+	// reopening it fixes nothing; the target owns this recovery and
+	// gates it on seeing this reason. Judged on the lifetime transfer
+	// count instead, a mirror that delivered and then stopped reported
+	// Recovered, and the target went on reading it as an idle producer.
+	const window = 20 * time.Second
+	entry := stalledEntry(4242, ptrTime(time.Now()), 3,
+		time.Now().Add(-window-time.Second))
+	entry.openedAt = time.Now().Add(-time.Hour)
+
+	state := observedState(entry, window)
+	assert.Equal(t, metav1.ConditionFalse, state.status)
+	assert.Equal(t, mxlv1alpha1.ReasonTransfersNotLanding, state.reason)
+	assert.False(t, state.rebuildReader,
+		"a reader whose head advances is not the broken half")
 }
 
 func TestRecordHead_StampsOnlyOnChange(t *testing.T) {
@@ -230,7 +308,7 @@ func TestRunFlusher_ReopensWedgedReader(t *testing.T) {
 	}
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
-	entry := stalledEntry(42, ptrTime(time.Now().Add(-time.Minute)), 0)
+	entry := stalledEntry(42, ptrTime(time.Now().Add(-time.Minute)), 0, time.Time{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -260,6 +338,60 @@ func TestRunFlusher_ReopensWedgedReader(t *testing.T) {
 		"the wedge stays visible on status while the reopen runs")
 }
 
+func TestRunFlusher_ReopensReaderStuckOutsideTheRing(t *testing.T) {
+	// Observed in a running deployment: a mirror sat at
+	// SourceProgress=ReaderAgedOut with TargetProgress=NoGrains for
+	// hours while its producer wrote continuously, and came back
+	// within a minute and a half of being deleted by hand. Deleting it
+	// amounts to a fresh reader at the current head, which is what the
+	// reopen does without an operator.
+	scheme := newSourceTestScheme(t)
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", "flow-1", "info-1")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	rebuilt := make(chan types.NamespacedName, 4)
+	r := &SourceReconciler{
+		Client:   c,
+		Scheme:   scheme,
+		NodeName: "node-a",
+		sources:  map[types.NamespacedName]*sourceEntry{},
+		attempts: attemptTable[sourceAddInputs]{},
+		rebuilds: map[types.NamespacedName]uint32{},
+		rebuildFn: func(key types.NamespacedName) {
+			rebuilt <- key
+		},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	// A live head, a delivery a stall window old, and a skip the loop
+	// is still performing: the reader keeps landing outside the ring.
+	entry := stalledEntry(42, ptrTime(time.Now()), 1,
+		time.Now().Add(-defaultReaderStallAfter-time.Second))
+	entry.recordAgedOut(time.Now())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+
+	select {
+	case got := <-rebuilt:
+		assert.Equal(t, key, got)
+	case <-time.After(5 * time.Second):
+		t.Fatal("an aged-out reader that cannot reach the tail must be reopened")
+	}
+	<-done
+
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &got))
+	require.Len(t, got.Status.Conditions, 1)
+	assert.Equal(t, mxlv1alpha1.ReasonReaderAgedOut, got.Status.Conditions[0].Reason)
+}
+
 func TestRunFlusher_StopsReopeningAtCap(t *testing.T) {
 	// A flow whose producer is genuinely gone would otherwise cost a
 	// reopen every stall window for as long as the mirror exists.
@@ -284,7 +416,7 @@ func TestRunFlusher_StopsReopeningAtCap(t *testing.T) {
 		},
 	}
 
-	entry := stalledEntry(42, ptrTime(time.Now().Add(-time.Minute)), 0)
+	entry := stalledEntry(42, ptrTime(time.Now().Add(-time.Minute)), 0, time.Time{})
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
@@ -324,7 +456,7 @@ func TestRunFlusher_ClearsRebuildBudgetOnProgress(t *testing.T) {
 		rebuilds: map[types.NamespacedName]uint32{key: 3},
 	}
 
-	entry := stalledEntry(42, ptrTime(time.Now()), 5)
+	entry := stalledEntry(42, ptrTime(time.Now()), 5, time.Now())
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go r.runFlusher(ctx, done, key, entry, time.Millisecond)


### PR DESCRIPTION
An MxlFlowMirror whose source reader stops delivering stays dead until
an operator deletes it. Observed in a running deployment: a mirror sat
at `SourceProgress=ReaderAgedOut` with `TargetProgress=NoGrains` for
hours while its producer wrote continuously, and came back within a
minute and a half of being deleted by hand.

The transfer loop is not the problem. On an aged-out error it sets
`lastSent = head` and tails the live ring again, which works whenever
the ring underneath is live. The wedge needs a producer restart on the
source node: the reader is left on the flow directory that went away,
so its head can never move again and re-seeking to it achieves nothing.

Nothing restarted it because `observedState` judged progress from the
lifetime transfer count and from an `agedOutAt` that was set once and
never cleared:

- the aged-out branch returned unconditionally and first, so a single
  fall-behind pinned SourceProgress at `ReaderAgedOut` for the life of
  the entry whatever the reader did next;
- every wedge detector sat behind `progress == 0`, which a mirror that
  had ever moved a grain could not satisfy again.

That disabled both watchdogs the gateway already has. The flusher
reopens a reader when it sees `ReaderNotAdvancing` and never saw it.
The target's stuck-handshake rebuild is gated on reading
`TransfersNotLanding` from the source and never saw that either.

Every state is now judged against the last grain that reached the
target:

| observation | condition | recovery |
| --- | --- | --- |
| head frozen past the stall window, nothing delivered | `ReaderNotAdvancing` | source reopens the reader |
| aged out within the window, nothing delivered in it | `ReaderAgedOut` | source reopens the reader |
| head advancing, nothing delivered | `TransfersNotLanding` | target's stuck-handshake rebuild |
| aged out and still delivering | `ReaderAgedOut`, clears after the window | none needed |

The reopen is the existing `closeEntry` plus one `Reconcile`, which is
the fresh reader at the current head that the manual mirror deletion
produced, and it keeps the existing per-mirror budget before
`ReaderRebuildCapReached`.

`ReaderAgedOut` stops being sticky, so it becomes a live signal rather
than a latch: a reader that skips once and catches up reports it for
the stall window and then clears.

A mirror whose producer has legitimately stopped now spends its reopen
budget instead of reporting `Recovered`, which is the same policy that
already applied to a mirror that had never delivered.

Stacked on #275: based on `feat/grain-pacing`, so only the last commit
belongs to this change. Retarget to `main` once #275 merges.

Verified in `ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.1`: the four
tests covering this fail against the old ordering and pass with the
change; `gofmt`, `go vet ./...` and `go test ./...` are clean across
the gateway module.