### PR TITLE
fix(gateway): retry a full send queue instead of falling behind it

### DIFF
--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -1080,16 +1080,35 @@ func runSampleTransferLoop(
 			// Transfer the remaining (lastSent, head] delta in chunks
 			// of at most xferBatch samples, each ending at the chunk's
 			// last index.
+			//
+			// A chunk that comes back not-ready is backpressure, not a
+			// failure: libmxl-fabrics reports the initiator's send
+			// queue being full as EAGAIN, which surfaces here as
+			// fabrics.ErrNotReady. The queue drains on MakeProgress, so
+			// the chunk is retried after driving it rather than
+			// abandoned until the next tick. Abandoning it is what let
+			// the reader slide out of the readable window while the
+			// producer kept writing, at which point the loop skipped
+			// samples and published ReaderAgedOut for what was really a
+			// momentarily full queue.
+			retries := 0
 			for lastSent < head {
 				count := head - lastSent
 				if xferBatch > 0 && count > xferBatch {
 					count = xferBatch
 				}
 				end := lastSent + count
-				if err := transferSamples(end, int(count)); err != nil {
-					l.Error(err, "TransferSamples", "headIndex", end, "count", count)
+				err := transferSamples(end, int(count))
+				if err != nil {
+					if classifyFabricError(err) == fabricIdle && retries < maxSampleTransferRetries {
+						retries++
+						progress.runProgress(makeProgress, func(perr error) { logProgressFailure(l, perr) })
+						continue
+					}
+					logSampleTransferFailure(l, err, end, count)
 					break
 				}
+				retries = 0
 				if tracker != nil {
 					tracker.recordTransfer(end, time.Now())
 				}
@@ -1679,6 +1698,32 @@ func (r *SourceReconciler) flowToMirrors(ctx context.Context, obj client.Object)
 //
 // The classification is logged alongside the error so an operator can
 // tell the two apart without reading libmxl's headers.
+// maxSampleTransferRetries bounds how many times one chunk is retried
+// against a full send queue within a single tick. Each retry drives
+// MakeProgress first, so the bound is what stops a genuinely wedged
+// fabric from spinning the tick instead of yielding to the next one,
+// where the head is re-read and the wedge becomes visible as a stalled
+// lastSent.
+const maxSampleTransferRetries = 8
+
+// logSampleTransferFailure renders a TransferSamples failure at a level
+// that matches what it means. A full send queue that outlived its
+// retries is congestion the next tick will pick up, and a disturbed
+// call is one the handles survive; neither is worth an error line per
+// occurrence on a flow that transfers hundreds of times a second.
+func logSampleTransferFailure(l logr.Logger, err error, end, count uint64) {
+	kind := classifyFabricError(err)
+	switch kind {
+	case fabricIdle, fabricTransient:
+		l.V(1).Info("TransferSamples deferred, retrying",
+			"error", err.Error(), "class", kind.String(),
+			"headIndex", end, "count", count)
+	default:
+		l.Error(err, "TransferSamples", "class", kind.String(),
+			"headIndex", end, "count", count)
+	}
+}
+
 func logProgressFailure(l logr.Logger, err error) {
 	kind := classifyFabricError(err)
 	switch kind {

--- a/gateway/internal/mirror/source_samples_test.go
+++ b/gateway/internal/mirror/source_samples_test.go
@@ -1,0 +1,261 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+	"github.com/qvest-digital/go-mxl/mxl"
+)
+
+// The sample loop's failure mode on a busy fabric was a livelock rather
+// than a stall: TransferSamples returned not-ready because the send
+// queue was full, the loop abandoned the chunk until the next tick, the
+// producer kept writing, and once the gap passed the readable window
+// the loop skipped samples and published ReaderAgedOut. Observed on a
+// live deployment as a mirror pinned at ReaderAgedOut + NoGrains while
+// its reader was healthy, which the reader-reopen watchdog could not
+// fix because the reader was never the broken part.
+
+func TestRunSampleTransferLoop_RetriesAFullSendQueueWithinTheTick(t *testing.T) {
+	// Discriminates on tick count, not wall clock: the loop probes the
+	// head exactly once per tick, plus once at attach. Retrying in place
+	// means the chunk lands during the first tick, so the probe count
+	// stands at 2 when it does. Abandoning the chunk until the next tick
+	// would need one tick per refusal and leave the count at 4.
+	var probes atomic.Int32
+	probe := func() (uint64, error) {
+		if probes.Add(1) == 1 {
+			return 1000, nil
+		}
+		return 1480, nil
+	}
+
+	var mu sync.Mutex
+	var attempts int
+	probesAtFirstSend := int32(-1)
+	transfer := func(_ uint64, _ int) error {
+		mu.Lock()
+		defer mu.Unlock()
+		attempts++
+		if attempts <= 2 {
+			return fabrics.ErrNotReady
+		}
+		if probesAtFirstSend < 0 {
+			probesAtFirstSend = probes.Load()
+		}
+		return nil
+	}
+	var progressCalls atomic.Int32
+	progress := func() error { progressCalls.Add(1); return nil }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runSampleTransferLoop(ctx, done, "f", probe, transfer, progress,
+		4800, 480, time.Millisecond, nil)
+
+	require.Eventually(t, func() bool {
+		mu.Lock()
+		defer mu.Unlock()
+		return probesAtFirstSend >= 0
+	}, 2*time.Second, time.Millisecond, "the chunk never landed at all")
+
+	cancel()
+	<-done
+
+	mu.Lock()
+	got := probesAtFirstSend
+	mu.Unlock()
+	assert.Equalf(t, int32(2), got,
+		"a chunk refused for a full queue must be retried inside the same tick; "+
+			"probe count %d means it waited for a later tick", got)
+	assert.Positive(t, progressCalls.Load(),
+		"the retry must drive MakeProgress, which is what drains the queue")
+}
+
+func TestRunSampleTransferLoop_BackpressureDoesNotReportReaderAgedOut(t *testing.T) {
+	// The producer writes one chunk per tick and the send queue refuses
+	// two attempts out of every three. Retrying in place clears a chunk
+	// per tick and keeps pace. One attempt per tick clears a chunk every
+	// third tick, falls behind 320 samples a tick, crosses the 4800
+	// readable window in about fifteen, and then skips samples and
+	// publishes ReaderAgedOut for a queue that was merely busy. That is
+	// the live symptom: a mirror pinned at ReaderAgedOut whose reader
+	// was never at fault.
+	var probes atomic.Uint64
+	probe := func() (uint64, error) { return 1000 + probes.Add(480), nil }
+
+	var calls atomic.Int32
+	transfer := func(uint64, int) error {
+		if calls.Add(1)%3 != 0 {
+			return fabrics.ErrNotReady
+		}
+		return nil
+	}
+	tr := &recordingSampleTracker{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
+		4800, 480, time.Millisecond, tr)
+
+	// Well past the ~15 ticks it takes to cross the window unretried.
+	require.Eventually(t, func() bool { return tr.transfers() >= 60 }, 3*time.Second, time.Millisecond,
+		"the loop made no progress at all")
+	cancel()
+	<-done
+
+	assert.Zerof(t, tr.agedOut(),
+		"a send queue that fills and drains is congestion, not a reader that fell "+
+			"out of its window; got %d aged-out reports", tr.agedOut())
+}
+
+func TestRunSampleTransferLoop_BoundsRetriesSoAWedgedFabricYieldsTheTick(t *testing.T) {
+	// A permanently full queue must not spin inside one tick. The loop
+	// has to give up on the chunk and come back on the next tick, where
+	// the head is re-read and the stall becomes visible.
+	var probes atomic.Uint64
+	probe := func() (uint64, error) {
+		if probes.Add(1) == 1 {
+			return 1000, nil
+		}
+		return 1480, nil
+	}
+	var attempts atomic.Int32
+	transfer := func(uint64, int) error {
+		attempts.Add(1)
+		return fabrics.ErrNotReady
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
+		4800, 480, 20*time.Millisecond, nil)
+
+	// Two ticks' worth of time. With the bound, attempts stay near
+	// 2 * (1 + maxSampleTransferRetries); without it the loop would
+	// spin on the first tick and the count would run away.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	n := attempts.Load()
+	assert.Positive(t, n)
+	assert.Lessf(t, n, int32(200),
+		"a permanently full queue must yield the tick, got %d attempts", n)
+}
+
+func TestRunSampleTransferLoop_NonIdleErrorBreaksImmediately(t *testing.T) {
+	// Only a full queue earns a retry. A real failure must not be
+	// retried eight times per tick against a fabric that cannot serve it.
+	var probes atomic.Uint64
+	probe := func() (uint64, error) {
+		if probes.Add(1) == 1 {
+			return 1000, nil
+		}
+		return 1480, nil
+	}
+	var attempts atomic.Int32
+	transfer := func(uint64, int) error {
+		attempts.Add(1)
+		return errors.New("endpoint is gone")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
+		4800, 480, 20*time.Millisecond, nil)
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+	<-done
+
+	n := attempts.Load()
+	assert.Positive(t, n)
+	assert.Lessf(t, n, int32(20),
+		"a fatal transfer error must break the chunk loop at once, got %d attempts", n)
+}
+
+func TestRunSampleTransferLoop_StillSkipsWhenGenuinelyLapped(t *testing.T) {
+	// The producer laps the reader by more than the readable window
+	// while transfers succeed. That is a real aged-out and must still
+	// be reported: the fix narrows what counts as aged-out, it does not
+	// remove the condition.
+	var calls atomic.Int32
+	probe := func() (uint64, error) {
+		if calls.Add(1) == 1 {
+			return 1000, nil
+		}
+		return 100000, nil
+	}
+	transfer := func(uint64, int) error { return nil }
+	tr := &recordingSampleTracker{}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
+		4800, 480, time.Millisecond, tr)
+
+	require.Eventually(t, func() bool { return tr.agedOut() > 0 }, time.Second, time.Millisecond,
+		"a producer that lapped the readable window is still ReaderAgedOut")
+	cancel()
+	<-done
+}
+
+// recordingSampleTracker counts what the sample loop reports.
+type recordingSampleTracker struct {
+	mu    sync.Mutex
+	xfers int
+	aged  int
+}
+
+func (r *recordingSampleTracker) recordTransfer(uint64, time.Time) {
+	r.mu.Lock()
+	r.xfers++
+	r.mu.Unlock()
+}
+
+func (r *recordingSampleTracker) recordAgedOut(time.Time) {
+	r.mu.Lock()
+	r.aged++
+	r.mu.Unlock()
+}
+
+func (r *recordingSampleTracker) recordHead(uint64, time.Time) {}
+
+func (r *recordingSampleTracker) transfers() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.xfers
+}
+
+func (r *recordingSampleTracker) agedOut() int {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return r.aged
+}
+
+func TestLogSampleTransferFailure_ClassifiesRatherThanErroring(t *testing.T) {
+	// The live gateway emitted an error line per refused chunk, which
+	// on a 48 kHz flow is hundreds a second and buried everything else.
+	// Classification is what keeps a full queue at V(1).
+	for name, tc := range map[string]struct {
+		err  error
+		kind fabricFailure
+	}{
+		"full send queue": {fabrics.ErrNotReady, fabricIdle},
+		"interrupted":     {mxl.ErrInterrupted, fabricTransient},
+		"endpoint lost":   {errors.New("gone"), fabricEndpointLost},
+	} {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.kind, classifyFabricError(tc.err))
+		})
+	}
+}


### PR DESCRIPTION
libmxl-fabrics reports the initiator's send queue being full as EAGAIN,
which reaches the sample loop as `fabrics.ErrNotReady`. The loop treated it
as a failed chunk: logged an error, abandoned the range, and waited for the
next tick. The producer kept writing meanwhile, so the gap grew, and once it
passed the reader's readable window the loop skipped samples and published
`SourceProgress=ReaderAgedOut`.

That turns momentary congestion into a self-sustaining livelock, because
each abandoned tick leaves the next one further behind.

Observed on a running deployment: an audio mirror pinned at
`SourceProgress=ReaderAgedOut` with `TargetProgress=NoGrains` while its
reader was healthy and its producer writing continuously. The reader-reopen
watchdog fired on it repeatedly and could not clear it, because the reader
was never the broken part.

A refused chunk is now retried in place after driving MakeProgress, which is
what drains the queue, bounded so a genuinely wedged fabric yields the tick
rather than spinning it. The grain path already gets this behaviour, since
pacing drives MakeProgress between slice ranges.

Only a full queue earns a retry. Anything else breaks the chunk loop as
before, and a producer that really has lapped the readable window still
reports ReaderAgedOut. The change narrows what counts as aged-out rather
than removing it.

Failures are classified rather than logged at error level unconditionally.
At 48 kHz a refused chunk arrived hundreds of times a second, and those
lines buried everything else in the gateway log.

The two tests that carry the fix fail against the current loop and pass with
the change: one discriminates on tick count, showing the chunk landing in the
first tick rather than the third, and one reproduces the live symptom
directly, reporting 52 spurious aged-out events where the fixed loop reports
none.
