### PR TITLE
fix: report a flow that left the domain as gone, not stalled

### DIFF
--- a/charts/mxl-k8s/README.md
+++ b/charts/mxl-k8s/README.md
@@ -190,7 +190,7 @@ Kubernetes: `>=1.28-0`
 | exporter.extraVolumeMounts | list | `[]` |  |
 | exporter.extraVolumes | list | `[]` |  |
 | exporter.flags.domainPath | string | `"/run/mxl/domain"` | Absolute path of the MXL domain directory to report on. Must resolve to the same domain the agent watches, below hostPath.run. |
-| exporter.flags.flowLifetime | string | `"24h"` | How long a departed flow keeps being exported with mxl_flow_present at 0, so a flow that ends between two scrapes leaves a record rather than a gap. |
+| exporter.flags.flowLifetime | string | `"5m"` | How long a departed flow keeps being exported with mxl_flow_present at 0, so a flow that ends between two scrapes leaves a record rather than a gap. One sweep of gateway.flags.domainGcInterval, so the metric set describes the domain as it is rather than as it was. |
 | exporter.flags.healthProbeBindAddress | string | `":8081"` |  |
 | exporter.flags.metricsBindAddress | string | `":8080"` |  |
 | exporter.flags.scanPeriod | string | `"5s"` | How often the domain directory is re-listed for flows that appeared or disappeared. Scrapes read the cache this maintains. |

--- a/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
+++ b/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
@@ -1525,7 +1525,7 @@
       "options": {
         "sortBy": [
           {
-            "displayName": "role"
+            "displayName": "flow_group_type"
           }
         ]
       },
@@ -1553,6 +1553,21 @@
               "namespace": true,
               "pod": true,
               "service": true
+            },
+            "indexByName": {
+              "domain": 0,
+              "flow_id": 1,
+              "flow_colorspace": 2,
+              "flow_data_type": 3,
+              "flow_description": 4,
+              "flow_format": 5,
+              "flow_group_name": 6,
+              "flow_group_type": 7,
+              "flow_label": 8,
+              "flow_media_type": 9,
+              "flow_payload_location": 10,
+              "flow_version": 11,
+              "node": 12
             }
           }
         }

--- a/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
+++ b/charts/mxl-k8s/dashboards/mxl-flow-metrics.json
@@ -87,7 +87,7 @@
     {
       "id": 1,
       "title": "Active Flows",
-      "description": "Whether a flow is currently being written. The exporter compares the head index at each scrape against the previous one: advanced means data is flowing (ACTIVE), unchanged means the flow is frozen (STALLED). A flow can be present and stalled at once, which is what a writer that died while its flow directory survived looks like.",
+      "description": "ACTIVE when the flow was written within its own activity window, STALLED when the flow directory is still in the domain and nothing wrote to it, ABSENT when the directory is gone. The window is derived from the flow's cadence rather than fixed: three grain periods on a discrete flow, half the ring buffer on a continuous one. Sums mxl_flow_active and mxl_flow_present, which is what separates a writer that stopped from a flow that ended.",
       "type": "stat",
       "gridPos": {
         "h": 4,
@@ -106,7 +106,8 @@
           ]
         },
         "orientation": "auto",
-        "colorMode": "background"
+        "colorMode": "background",
+        "graphMode": "none"
       },
       "fieldConfig": {
         "defaults": {
@@ -115,10 +116,14 @@
               "type": "value",
               "options": {
                 "0": {
+                  "text": "ABSENT",
+                  "color": "text"
+                },
+                "1": {
                   "text": "STALLED",
                   "color": "red"
                 },
-                "1": {
+                "2": {
                   "text": "ACTIVE",
                   "color": "green"
                 }
@@ -129,12 +134,16 @@
             "mode": "absolute",
             "steps": [
               {
+                "color": "text",
+                "value": null
+              },
+              {
                 "color": "red",
-                "value": 0
+                "value": 1
               },
               {
                 "color": "green",
-                "value": 1
+                "value": 2
               }
             ]
           }
@@ -143,15 +152,16 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "mxl_flow_active{node=~\"$node\",flow_id=~\"$flow\"}",
-          "legendFormat": "{{node}} / {{flow_id}}"
+          "expr": "mxl_flow_active{node=~\"$node\",flow_id=~\"$flow\"} + mxl_flow_present{node=~\"$node\",flow_id=~\"$flow\"}",
+          "legendFormat": "{{node}} / {{flow_id}}",
+          "instant": true
         }
       ]
     },
     {
       "id": 2,
       "title": "Flows Present",
-      "description": "Whether the flow directory (*.mxl-flow) still exists in the node's domain. PRESENT means the directory is there, MISSING that it is gone. A departed flow keeps its series, at 0, until --flow-lifetime expires, so a short outage stays visible in the time range instead of leaving a gap. Present says nothing about data flowing; Active Flows does.",
+      "description": "Whether the flow directory (*.mxl-flow) still exists in the node's domain. PRESENT means the directory is there, ABSENT that it is gone. A departed flow keeps its series, at 0, until --flow-lifetime expires, so a flow that ends between two scrapes leaves a record rather than a gap. Present says nothing about data flowing; Active Flows does.",
       "type": "stat",
       "gridPos": {
         "h": 4,
@@ -170,7 +180,8 @@
           ]
         },
         "orientation": "auto",
-        "colorMode": "background"
+        "colorMode": "background",
+        "graphMode": "none"
       },
       "fieldConfig": {
         "defaults": {
@@ -179,8 +190,8 @@
               "type": "value",
               "options": {
                 "0": {
-                  "text": "MISSING",
-                  "color": "red"
+                  "text": "ABSENT",
+                  "color": "text"
                 },
                 "1": {
                   "text": "PRESENT",
@@ -193,8 +204,8 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
-                "value": 0
+                "color": "text",
+                "value": null
               },
               {
                 "color": "green",
@@ -208,7 +219,8 @@
         {
           "refId": "A",
           "expr": "mxl_flow_present{node=~\"$node\",flow_id=~\"$flow\"}",
-          "legendFormat": "{{node}} / {{flow_id}}"
+          "legendFormat": "{{node}} / {{flow_id}}",
+          "instant": true
         }
       ]
     },
@@ -543,7 +555,7 @@
     {
       "id": 15,
       "title": "Active Timeline",
-      "description": "ACTIVE/STALLED state of every flow over the selected range. Where the Active Flows stat shows the current value, this shows when a flow stopped and how long it stayed stopped.",
+      "description": "ACTIVE/STALLED/ABSENT state of every flow over the selected range. Where the Active Flows stat shows the current value, this shows when a flow stopped, how long it stayed stopped, and when it left the domain.",
       "type": "state-timeline",
       "gridPos": {
         "h": 6,
@@ -580,6 +592,15 @@
               "type": "value",
               "options": {
                 "0": {
+                  "text": "ABSENT",
+                  "color": "text"
+                }
+              }
+            },
+            {
+              "type": "value",
+              "options": {
+                "1": {
                   "text": "STALLED",
                   "color": "red"
                 }
@@ -588,7 +609,7 @@
             {
               "type": "value",
               "options": {
-                "1": {
+                "2": {
                   "text": "ACTIVE",
                   "color": "green"
                 }
@@ -599,12 +620,16 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
+                "color": "text",
                 "value": null
               },
               {
-                "color": "green",
+                "color": "red",
                 "value": 1
+              },
+              {
+                "color": "green",
+                "value": 2
               }
             ]
           }
@@ -613,7 +638,7 @@
       "targets": [
         {
           "refId": "A",
-          "expr": "mxl_flow_active{node=~\"$node\",flow_id=~\"$flow\"}",
+          "expr": "mxl_flow_active{node=~\"$node\",flow_id=~\"$flow\"} + mxl_flow_present{node=~\"$node\",flow_id=~\"$flow\"}",
           "legendFormat": "{{node}} / {{flow_id}}"
         }
       ]
@@ -621,7 +646,7 @@
     {
       "id": 16,
       "title": "Present Timeline",
-      "description": "PRESENT/MISSING state of every flow over the selected range. A flow whose directory is gone keeps its series until --flow-lifetime expires, so a restart reads as a bounded gap rather than a series that disappears.",
+      "description": "PRESENT/ABSENT state of every flow over the selected range. A flow whose directory is gone keeps its series until --flow-lifetime expires, so a restart reads as a bounded gap rather than a series that disappears.",
       "type": "state-timeline",
       "gridPos": {
         "h": 6,
@@ -658,8 +683,8 @@
               "type": "value",
               "options": {
                 "0": {
-                  "text": "MISSING",
-                  "color": "red"
+                  "text": "ABSENT",
+                  "color": "text"
                 }
               }
             },
@@ -677,7 +702,7 @@
             "mode": "absolute",
             "steps": [
               {
-                "color": "red",
+                "color": "text",
                 "value": null
               },
               {

--- a/charts/mxl-k8s/values.schema.json
+++ b/charts/mxl-k8s/values.schema.json
@@ -824,8 +824,8 @@
               "title": "domainPath"
             },
             "flowLifetime": {
-              "default": "24h",
-              "description": "How long a departed flow keeps being exported with mxl_flow_present at 0, so a flow that ends between two scrapes leaves a record rather than a gap.",
+              "default": "5m",
+              "description": "How long a departed flow keeps being exported with mxl_flow_present at 0, so a flow that ends between two scrapes leaves a record rather than a gap. One sweep of gateway.flags.domainGcInterval, so the metric set describes the domain as it is rather than as it was.",
               "required": [],
               "title": "flowLifetime"
             },

--- a/charts/mxl-k8s/values.yaml
+++ b/charts/mxl-k8s/values.yaml
@@ -725,8 +725,10 @@ exporter:
     scanPeriod: 5s
     # -- How long a departed flow keeps being exported with
     # mxl_flow_present at 0, so a flow that ends between two scrapes
-    # leaves a record rather than a gap.
-    flowLifetime: 24h
+    # leaves a record rather than a gap. One sweep of
+    # gateway.flags.domainGcInterval, so the metric set describes the
+    # domain as it is rather than as it was.
+    flowLifetime: 5m
     # @schema
     # enum: ["debug", "info", "warn", "error"]
     # @schema

--- a/examples/kind/monitoring-values.yaml
+++ b/examples/kind/monitoring-values.yaml
@@ -38,9 +38,10 @@ kubelet:
 
 prometheus:
   prometheusSpec:
-    # The exporter decides a flow is active by comparing the head index
-    # against the previous scrape, so the scrape interval is the
-    # resolution of every activity panel on the board.
+    # The exporter reads flow state off the flow header at each scrape,
+    # against the flow's own write clock, so the interval is not what
+    # decides activity but what decides the board's resolution: a stall
+    # shorter than one interval falls between two samples.
     scrapeInterval: 15s
     retention: 2h
     resources:

--- a/exporter/internal/config/config.go
+++ b/exporter/internal/config/config.go
@@ -33,6 +33,13 @@ type Config struct {
 	// after its directory is gone, with mxl_flow_present at 0. Without
 	// it a flow that ends between two scrapes leaves no trace of having
 	// stopped, only a gap.
+	//
+	// It buys an after-image, not a history. Every series a departed
+	// flow keeps is a series a consumer has to tell apart from a live
+	// one, so the default is one sweep of the gateway's domain garbage
+	// collector: long enough that the end of a flow is never missed,
+	// short enough that what the metrics describe is the domain as it
+	// is now.
 	FlowLifetime time.Duration
 
 	// Kubeconfig is an optional kubeconfig path; empty uses in-cluster.
@@ -58,7 +65,7 @@ func FromFlags(fs *flag.FlagSet, args []string) (*Config, error) {
 		"Address the health probe endpoint binds to.")
 	fs.DurationVar(&c.ScanPeriod, "scan-period", 5*time.Second,
 		"How often the domain directory is re-listed for flows that appeared or disappeared.")
-	fs.DurationVar(&c.FlowLifetime, "flow-lifetime", 24*time.Hour,
+	fs.DurationVar(&c.FlowLifetime, "flow-lifetime", 5*time.Minute,
 		"How long a departed flow keeps being exported with mxl_flow_present at 0.")
 	fs.StringVar(&c.Kubeconfig, "kubeconfig", os.Getenv("KUBECONFIG"),
 		"Path to a kubeconfig file. Empty uses the in-cluster config.")

--- a/exporter/internal/domain/active_test.go
+++ b/exporter/internal/domain/active_test.go
@@ -32,6 +32,13 @@ const activeTestFlowID = "5fbec3b1-1b0f-417d-9059-8b94a47197ed"
 // and returns the Domain with the flow scanned in.
 func newObservedFlow(t *testing.T) *Domain {
 	t.Helper()
+	return newObservedFlowWithLifetime(t, time.Minute)
+}
+
+// newObservedFlowWithLifetime is newObservedFlow with control over how
+// long the Domain keeps a flow that left it.
+func newObservedFlowWithLifetime(t *testing.T, lifetime time.Duration) *Domain {
+	t.Helper()
 	dir := t.TempDir()
 	inst, err := mxl.NewInstance(dir, "")
 	require.NoError(t, err)
@@ -46,7 +53,7 @@ func newObservedFlow(t *testing.T) *Domain {
 	require.NoError(t, err)
 	require.NoError(t, ga.Commit(ga.TotalSlices, 0))
 
-	d, err := Open(dir, time.Minute)
+	d, err := Open(dir, lifetime)
 	require.NoError(t, err)
 	t.Cleanup(func() { d.Close() })
 	require.NoError(t, d.Scan())

--- a/exporter/internal/domain/departed_test.go
+++ b/exporter/internal/domain/departed_test.go
@@ -1,0 +1,63 @@
+package domain
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// removeFlowDir takes the flow out of the domain the way libmxl's
+// garbage collector does, by unlinking its directory. The writer stays
+// open, so nothing about the flow header changes: only the directory
+// entry the domain lists is gone.
+func removeFlowDir(t *testing.T, d *Domain, id string) {
+	t.Helper()
+	require.NoError(t, os.RemoveAll(filepath.Join(d.Path(), id+flowDirSuffix)))
+	require.NoError(t, d.Scan())
+}
+
+func TestObserveNeverReportsADepartedFlowActive(t *testing.T) {
+	// mxl_flow_active and mxl_flow_present are read together, and their
+	// sum is what tells a flow being written from a writer that stopped
+	// from a flow that left the domain. That only separates the three if
+	// a departed flow reports inactive, and its last write says the
+	// opposite: the flow was written moments before it was removed, so
+	// the activity window it is judged against has not expired.
+	d := newObservedFlow(t)
+	require.True(t, d.Observe()[0].Active)
+
+	removeFlowDir(t, d, activeTestFlowID)
+
+	obs := d.Observe()
+	require.Len(t, obs, 1, "a departed flow keeps its series until its lifetime expires")
+	require.False(t, obs[0].Present)
+	require.False(t, obs[0].Active,
+		"a flow that is no longer in the domain cannot be active, however "+
+			"recent its last write; reporting it active would leave a gone "+
+			"flow indistinguishable from a live one")
+}
+
+func TestScanForgetsADepartedFlowAfterItsLifetime(t *testing.T) {
+	// The series a departed flow keeps are an after-image, so that a flow
+	// ending between two scrapes leaves a record rather than a gap. An
+	// after-image that never expires is not a record but a leak: every
+	// flow the node ever carried stays in the metric set, and anything
+	// reading it has to tell the domain as it is from the domain as it
+	// was.
+	d := newObservedFlowWithLifetime(t, 50*time.Millisecond)
+	require.Len(t, d.Observe(), 1)
+
+	removeFlowDir(t, d, activeTestFlowID)
+	require.Len(t, d.Observe(), 1, "the after-image outlives the flow directory")
+
+	require.Eventually(t, func() bool {
+		if err := d.Scan(); err != nil {
+			return false
+		}
+		return len(d.Observe()) == 0
+	}, 5*time.Second, 10*time.Millisecond,
+		"a flow gone for longer than the lifetime must leave the metric set")
+}

--- a/hack/kind-up.sh
+++ b/hack/kind-up.sh
@@ -225,9 +225,11 @@ if [ "$MONITORING" = "1" ]; then
   MONITORING_SET=(
     --set exporter.metrics.serviceMonitor.enabled=true
     # The ServiceMonitor's own interval wins over the Prometheus
-    # default, and it is the resolution of every activity panel: the
-    # exporter decides a flow is active by comparing consecutive
-    # scrapes.
+    # default, and it is the resolution of every flow panel. The
+    # exporter reads activity off the flow header at each scrape,
+    # against the flow's own write clock rather than against the
+    # previous scrape, so the interval decides how short a stall can be
+    # and still land on the board, not what counts as one.
     --set exporter.metrics.serviceMonitor.interval=15s
     --set "exporter.metrics.serviceMonitor.labels.release=${MONITORING_RELEASE}"
     # The gateway carries the mirror byte counters the Node Throughput
@@ -336,7 +338,7 @@ cat <<EOF
              so the board is reachable from another host
 
 The writer and reader are producing grains now, so the board has live
-data. Panels that compare a flow against the previous scrape need one
-scrape interval (15s) before they read anything but zero.
+data. The frame-rate panels are a rate over time and stay at zero until
+a few scrape intervals (15s each) have passed.
 EOF
 fi

--- a/test/integration/kind/cases/47-exporter-metrics.sh
+++ b/test/integration/kind/cases/47-exporter-metrics.sh
@@ -7,10 +7,10 @@
 # are identified by node, the producing node reports its flow as
 # Origin, and the consuming node reports the same flow as a mirror.
 #
-# Activity is only observable from the second scrape onward -- the
-# exporter decides it by comparing the head index against the previous
-# collection -- so every assertion about movement is made across two
-# scrapes rather than one.
+# Head index movement cannot be read from one sample, so the assertions
+# about it span two scrapes a window apart. Activity needs no such
+# window: the exporter judges it against the flow's own write clock and
+# reports it on the first scrape that finds the flow.
 #
 # Numbered with the steady-state cases: from 50 on the suite reschedules
 # producers, drains nodes and evicts consumers, and the demo pods this
@@ -94,9 +94,6 @@ echo "-> exporter on the writer node: ${writer_exp}"
 # and a writer that has only just started leaves its flow directory in
 # place before it produces, so present alone would let the head-index
 # window below open against a stalled flow.
-#
-# Activity needs two collections to be decidable at all, which this
-# loop supplies by scraping repeatedly.
 deadline=$(( $(date +%s) + DISCOVER_TIMEOUT_SECS ))
 present=""
 active=""


### PR DESCRIPTION
The flow board colours mxl_flow_active 0 and mxl_flow_present 0 red, and
the exporter holds both at 0 for 24h after a flow's directory leaves the
domain. A flow that ended therefore sits on the board for a day as
STALLED and MISSING, in the same red a wedged writer gets. Telling those
two apart is what the board is for.

The exporter's --flow-lifetime default drops from 24h to 5m, one sweep of
the gateway's domain garbage collector, which is what removes the
directory in the first place. The after-image still outlives any scrape
interval, so a flow ending between two scrapes is never missed, and the
metric set goes back to describing the domain as it is. Prometheus keeps
what it already scraped, so a past range reads the same as before; only
how long a departed flow produces new samples changes.

The board gains a third state. Active Flows and Active Timeline plot
mxl_flow_active + mxl_flow_present, which is 2 while the flow is being
written, 1 while its directory is in the domain and nothing writes to it,
and 0 once the directory is gone. Flows Present and Present Timeline keep
their gauge, rename MISSING to ABSENT and lose the red, because a flow
that ended is not a fault. The two stat panels query at the dashboard's
end time rather than reducing the range, so a flow the exporter has
forgotten leaves the tiles instead of being restored by lastNotNull.

The Active Flows description also stops claiming activity is a head-index
delta between scrapes; it has been the flow's own write clock since the
exporter stopped carrying state across calls.

---

This PR bundled four conventional commits behind one title. Under
`squash_merge_commit_message=COMMIT_MESSAGES` release-please emits one entry per
squash, from the title, so the exporter and chart fixes were absent from the
pending release notes. The block below restores them; release-please reads it
from this pull request over the API. See qvest-digital/mxl-k8s#290.

```
BEGIN_COMMIT_OVERRIDE
fix: report a flow that left the domain as gone, not stalled (#284)

fix(exporter): bound a departed flow to one domain GC sweep (#284)
fix(chart): separate flow ended from writer stopped (#284)
fix(chart): put flow_id where the metadata table is read from (#284)
END_COMMIT_OVERRIDE
```
