### PR TITLE
fix(exporter): log through the same logger as the other services

### DIFF
--- a/charts/mxl-k8s/README.md
+++ b/charts/mxl-k8s/README.md
@@ -194,6 +194,7 @@ Kubernetes: `>=1.28-0`
 | exporter.flags.healthProbeBindAddress | string | `":8081"` |  |
 | exporter.flags.metricsBindAddress | string | `":8080"` |  |
 | exporter.flags.scanPeriod | string | `"5s"` | How often the domain directory is re-listed for flows that appeared or disappeared. Scrapes read the cache this maintains. |
+| exporter.flags.zapLogLevel | string | `"info"` |  |
 | exporter.hostPath | object | `{"run":"/run/mxl","type":"Directory"}` | hostPath layout. The exporter mounts the runtime root read-only; it opens libmxl flow readers and never writes into the domain. |
 | exporter.image.digest | string | `""` | Image digest. Wins over tag when set. @schema pattern: ^$|^sha256:[0-9a-f]{64}$ @schema |
 | exporter.image.pullPolicy | string | `""` |  |

--- a/charts/mxl-k8s/values.schema.json
+++ b/charts/mxl-k8s/values.schema.json
@@ -848,6 +848,18 @@
               "description": "How often the domain directory is re-listed for flows that appeared or disappeared. Scrapes read the cache this maintains.",
               "required": [],
               "title": "scanPeriod"
+            },
+            "zapLogLevel": {
+              "default": "info",
+              "description": " enum: [\"debug\", \"info\", \"warn\", \"error\"] @schema",
+              "enum": [
+                "debug",
+                "info",
+                "warn",
+                "error"
+              ],
+              "required": [],
+              "title": "zapLogLevel"
             }
           },
           "required": [],

--- a/charts/mxl-k8s/values.yaml
+++ b/charts/mxl-k8s/values.yaml
@@ -727,6 +727,10 @@ exporter:
     # mxl_flow_present at 0, so a flow that ends between two scrapes
     # leaves a record rather than a gap.
     flowLifetime: 24h
+    # @schema
+    # enum: ["debug", "info", "warn", "error"]
+    # @schema
+    zapLogLevel: info
   # -- hostPath layout. The exporter mounts the runtime root read-only;
   # it opens libmxl flow readers and never writes into the domain.
   hostPath:

--- a/exporter/cmd/mxl-flow-exporter/main.go
+++ b/exporter/cmd/mxl-flow-exporter/main.go
@@ -6,13 +6,13 @@ import (
 	"context"
 	"errors"
 	"flag"
-	"log/slog"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
 
+	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/collectors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -21,6 +21,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 	"github.com/qvest-digital/mxl-k8s/exporter/internal/collector"
@@ -29,25 +30,35 @@ import (
 	"github.com/qvest-digital/mxl-k8s/exporter/internal/topology"
 )
 
-func main() {
-	log := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+var setupLog = ctrl.Log.WithName("setup")
 
-	cfg, err := config.FromFlags(flag.NewFlagSet(os.Args[0], flag.ExitOnError), os.Args[1:])
+func main() {
+	fs := flag.NewFlagSet("mxl-flow-exporter", flag.ContinueOnError)
+	zapOpts := zap.Options{Development: false}
+	zapOpts.BindFlags(fs)
+
+	cfg, err := config.FromFlags(fs, os.Args[1:])
 	if err != nil {
-		log.Error("configuration", "error", err)
+		// The flags carry the logger's own configuration, so a
+		// configuration error predates it. Installing a default logger
+		// first keeps the reason the process refused to start from being
+		// the one message it cannot emit.
+		ctrl.SetLogger(zap.New())
+		setupLog.Error(err, "configuration")
 		os.Exit(1)
 	}
+	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&zapOpts)))
 
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := run(ctx, cfg, log); err != nil {
-		log.Error("exporter", "error", err)
+	if err := run(ctx, cfg, ctrl.Log.WithName("exporter")); err != nil {
+		setupLog.Error(err, "exporter exited with error")
 		os.Exit(1)
 	}
 }
 
-func run(ctx context.Context, cfg *config.Config, log *slog.Logger) error {
+func run(ctx context.Context, cfg *config.Config, log logr.Logger) error {
 	dom, err := domain.Open(cfg.DomainPath, cfg.FlowLifetime)
 	if err != nil {
 		return err
@@ -66,7 +77,7 @@ func run(ctx context.Context, cfg *config.Config, log *slog.Logger) error {
 	)
 	nodeReg.MustRegister(
 		collector.NewFlowCollector(dom),
-		collector.NewDomainCollector(dom, log),
+		collector.NewDomainCollector(dom, log.WithName("domain")),
 	)
 
 	if cfg.TopologyEnabled {
@@ -74,14 +85,14 @@ func run(ctx context.Context, cfg *config.Config, log *slog.Logger) error {
 		if err != nil {
 			return err
 		}
-		nodeReg.MustRegister(topology.New(reader, cfg.NodeName, log))
+		nodeReg.MustRegister(topology.New(reader, cfg.NodeName, log.WithName("topology")))
 	}
 
 	if err := dom.Scan(); err != nil {
 		// A node that has never carried a flow has no domain directory
 		// yet. Failing to boot on that would take the DaemonSet down
 		// on exactly the nodes with nothing to report.
-		log.Warn("initial domain scan", "domain", cfg.DomainPath, "error", err)
+		log.Error(err, "initial domain scan", "domain", cfg.DomainPath)
 	}
 	go scanLoop(ctx, dom, cfg.ScanPeriod, log)
 
@@ -91,7 +102,7 @@ func run(ctx context.Context, cfg *config.Config, log *slog.Logger) error {
 // startTopologyCache brings up a controller-runtime cache over
 // MxlFlow so a scrape reads from a watch-backed store instead of
 // listing against the API server.
-func startTopologyCache(ctx context.Context, cfg *config.Config, log *slog.Logger) (client.Reader, error) {
+func startTopologyCache(ctx context.Context, cfg *config.Config, log logr.Logger) (client.Reader, error) {
 	restCfg, err := ctrl.GetConfig()
 	if err != nil {
 		return nil, err
@@ -109,7 +120,7 @@ func startTopologyCache(ctx context.Context, cfg *config.Config, log *slog.Logge
 	}
 	go func() {
 		if err := c.Start(ctx); err != nil && !errors.Is(err, context.Canceled) {
-			log.Error("topology cache", "error", err)
+			log.Error(err, "topology cache")
 		}
 	}()
 	if !c.WaitForCacheSync(ctx) {
@@ -119,7 +130,7 @@ func startTopologyCache(ctx context.Context, cfg *config.Config, log *slog.Logge
 }
 
 // scanLoop re-lists the domain until ctx is done.
-func scanLoop(ctx context.Context, dom *domain.Domain, period time.Duration, log *slog.Logger) {
+func scanLoop(ctx context.Context, dom *domain.Domain, period time.Duration, log logr.Logger) {
 	t := time.NewTicker(period)
 	defer t.Stop()
 	for {
@@ -128,14 +139,14 @@ func scanLoop(ctx context.Context, dom *domain.Domain, period time.Duration, log
 			return
 		case <-t.C:
 			if err := dom.Scan(); err != nil {
-				log.Warn("scan domain", "error", err)
+				log.Error(err, "scan domain")
 			}
 		}
 	}
 }
 
 // serve runs the metrics and probe endpoints until ctx is done.
-func serve(ctx context.Context, cfg *config.Config, reg *prometheus.Registry, log *slog.Logger) error {
+func serve(ctx context.Context, cfg *config.Config, reg *prometheus.Registry, log logr.Logger) error {
 	metricsMux := http.NewServeMux()
 	metricsMux.Handle("/metrics", promhttp.HandlerFor(reg, promhttp.HandlerOpts{ErrorHandling: promhttp.ContinueOnError}))
 

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -12,7 +12,10 @@ require (
 	sigs.k8s.io/controller-runtime v0.24.1
 )
 
-require github.com/stretchr/testify v1.12.0
+require (
+	github.com/go-logr/logr v1.4.3
+	github.com/stretchr/testify v1.12.0
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
@@ -22,7 +25,7 @@ require (
 	github.com/evanphx/json-patch/v5 v5.9.11 // indirect
 	github.com/fsnotify/fsnotify v1.9.0 // indirect
 	github.com/fxamacker/cbor/v2 v2.9.0 // indirect
-	github.com/go-logr/logr v1.4.3 // indirect
+	github.com/go-logr/zapr v1.3.0 // indirect
 	github.com/go-openapi/jsonpointer v0.21.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
@@ -41,6 +44,8 @@ require (
 	github.com/prometheus/procfs v0.21.1 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.27.1 // indirect
 	go.yaml.in/yaml/v2 v2.4.4 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/net v0.57.0 // indirect

--- a/exporter/go.sum
+++ b/exporter/go.sum
@@ -95,14 +95,12 @@ github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
-github.com/stretchr/objx v0.5.2 h1:xuMeJ0Sdp5ZMRXx/aWO6RZxdr3beISkG5/G/aIRr3pY=
-github.com/stretchr/objx v0.5.2/go.mod h1:FRsXN1f5AsAjCGJKqEizvkpNtU+EGNCLh3NxZ/8L+MA=
+github.com/stretchr/objx v0.5.3 h1:jmXUvGomnU1o3W/V5h2VEradbpJDwGrzugQQvL0POH4=
+github.com/stretchr/objx v0.5.3/go.mod h1:rDQraq+vQZU7Fde9LOZLr8Tax6zZvy4kuNKF+QYS+U0=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
 github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
-github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
-github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/stretchr/testify v1.12.0 h1:K6Mr6jO9JICuend/5xzTM03ydSV3vdNRYAdPSukj8uI=
 github.com/stretchr/testify v1.12.0/go.mod h1:bOYBZb5qJ00vPzWfIqBUZPaxK8jWiXc6d3ErP4Ca9Gw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=

--- a/exporter/internal/collector/domain.go
+++ b/exporter/internal/collector/domain.go
@@ -1,8 +1,7 @@
 package collector
 
 import (
-	"log/slog"
-
+	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 
 	"github.com/qvest-digital/mxl-k8s/exporter/internal/domain"
@@ -33,11 +32,11 @@ type DomainSource interface {
 // DomainCollector exports the domain-wide counters.
 type DomainCollector struct {
 	src DomainSource
-	log *slog.Logger
+	log logr.Logger
 }
 
 // NewDomainCollector returns a collector over src.
-func NewDomainCollector(src DomainSource, log *slog.Logger) *DomainCollector {
+func NewDomainCollector(src DomainSource, log logr.Logger) *DomainCollector {
 	return &DomainCollector{src: src, log: log}
 }
 
@@ -68,7 +67,7 @@ func (c *DomainCollector) Collect(ch chan<- prometheus.Metric) {
 		// The domain directory can be absent on a node that has never
 		// carried a flow. Skipping the filesystem series leaves a gap
 		// rather than a wrong zero.
-		c.log.Warn("statfs domain", "domain", dom, "error", err)
+		c.log.Error(err, "statfs domain", "domain", dom)
 		return
 	}
 	ch <- prometheus.MustNewConstMetric(descFSTotal, prometheus.GaugeValue, float64(st.TotalBytes), dom)

--- a/exporter/internal/topology/collector.go
+++ b/exporter/internal/topology/collector.go
@@ -12,8 +12,8 @@ package topology
 
 import (
 	"context"
-	"log/slog"
 
+	"github.com/go-logr/logr"
 	"github.com/prometheus/client_golang/prometheus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -28,14 +28,14 @@ var descLocation = prometheus.NewDesc("mxl_flow_location_info",
 type Collector struct {
 	reader   client.Reader
 	nodeName string
-	log      *slog.Logger
+	log      logr.Logger
 }
 
 // New returns a collector reading MxlFlow through reader and reporting
 // only the entries for nodeName. Restricting to the local node is what
 // keeps every node's exporter from re-exporting the whole cluster's
 // flows as duplicate series.
-func New(reader client.Reader, nodeName string, log *slog.Logger) *Collector {
+func New(reader client.Reader, nodeName string, log logr.Logger) *Collector {
 	return &Collector{reader: reader, nodeName: nodeName, log: log}
 }
 
@@ -51,7 +51,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 		// Emitting nothing leaves a gap the dashboard shows as no
 		// data, which is honest; emitting zeros would read as "no
 		// producer anywhere".
-		c.log.Warn("list MxlFlow", "error", err)
+		c.log.Error(err, "list MxlFlow")
 		return
 	}
 	for i := range flows.Items {

--- a/exporter/internal/topology/collector_test.go
+++ b/exporter/internal/topology/collector_test.go
@@ -1,11 +1,10 @@
 package topology
 
 import (
-	"io"
-	"log/slog"
 	"strings"
 	"testing"
 
+	"github.com/go-logr/logr/testr"
 	"github.com/prometheus/client_golang/prometheus/testutil"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -30,7 +29,7 @@ func newCollector(t *testing.T, node string, objs ...*mxlv1alpha1.MxlFlow) *Coll
 	for _, o := range objs {
 		b = b.WithObjects(o)
 	}
-	return New(b.Build(), node, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	return New(b.Build(), node, testr.New(t))
 }
 
 // The producing node is the one whose location phase is Origin. That is


### PR DESCRIPTION
The exporter builds a controller-runtime cache to read MxlFlow but never
calls ctrl.SetLogger. controller-runtime answers that by printing
"log.SetLogger(...) was never called; logs will not be displayed" and a
full goroutine stack the first time anything logs through it, which is
the first scrape, and by discarding every line the cache, the reflector
and klog produce from then on. A watch that cannot start, a denied list
or an expired token leaves no trace at all, and the pod's logs are a
stack trace with one line of the exporter's own output above it.

The setup now matches the agent, gateway and operator: zap's flags bind
onto the exporter's flag set, the logger they configure is installed
through ctrl.SetLogger, and logr.Logger replaces slog through the
collectors. The domain and topology collectors log under their own
names, so a line says which part of the exporter produced it. A
configuration error predates the logger the flags configure, so that
path installs a default logger before reporting rather than exiting
without saying why.

The chart gains exporter.flags.zapLogLevel, which the other three
already carry.

Touches the same exporter.flags block as #284, so whichever merges
second needs a rebase.
