### PR TITLE
fix(gateway): release a source reader when its flow has no writer

### DIFF
--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -1067,6 +1067,9 @@ func runSampleTransferLoop(
 		return
 	}
 	lastSent := head0
+	if tracker != nil {
+		tracker.recordHead(head0, time.Now())
+	}
 
 	t := time.NewTicker(interval)
 	defer t.Stop()
@@ -1084,6 +1087,14 @@ func runSampleTransferLoop(
 		if err != nil {
 			l.Error(err, "Runtime")
 			continue
+		}
+		// Recorded on the sample path for the same reason as on the
+		// grain path: observedState reads a nil headAdvancedAt as
+		// "never probed" and cannot report ReaderNotAdvancing without
+		// it, which left a stalled continuous flow with no state that
+		// asks for a reopen.
+		if tracker != nil {
+			tracker.recordHead(head, time.Now())
 		}
 		if head > lastSent {
 			// Fell behind: the samples between lastSent+1 and

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -11,6 +11,7 @@ import (
 
 	coordinationv1 "k8s.io/api/coordination/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -76,6 +77,15 @@ const readerAgedOutMarker = "out of range (too late)"
 // counter is cleared as soon as a grain transfers, so it counts
 // consecutive failed reopens rather than lifetime ones.
 const maxReaderRebuilds = 5
+
+// writerAbsentRetry is how long a mirror waits before asking again
+// whether its flow has a writer. It only paces the reopen of a mirror
+// whose producer is gone, so it is set for a cheap steady state rather
+// than a prompt one: the probe is an open plus a non-blocking flock,
+// and a producer that comes back on a fresh flow directory rotates the
+// Origin and wakes the reconciler through its watch well before this
+// fires.
+const writerAbsentRetry = 30 * time.Second
 
 // ReasonReaderRebuildCapReached marks a mirror whose source-side
 // reader stayed wedged across maxReaderRebuilds consecutive reopens.
@@ -441,6 +451,28 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	// its own watch, so a gated pass writes nothing.
 	if gated {
 		return ctrl.Result{RequeueAfter: remaining}, nil
+	}
+
+	// No reader is opened on a flow nothing writes. Without this the
+	// release the flusher performs is undone within the second:
+	// publishing SourceWriterGone wakes this reconciler through its own
+	// watch, which opens a fresh reader and pins the flow directory
+	// again. The condition is written once and the requeue carries the
+	// retry, because a producer that re-attaches to a directory that
+	// was never collected rotates nothing and fires no watch.
+	if r.writerGone(mirror.Spec.FlowID) {
+		if !sourceProgressReads(&mirror, mxlv1alpha1.ReasonSourceWriterGone) {
+			if err := r.publishSourceProgress(ctx, req.NamespacedName, sourceProgressState{
+				status:  metav1.ConditionFalse,
+				reason:  mxlv1alpha1.ReasonSourceWriterGone,
+				message: "flow has no live writer; leaving the source reader closed so the flow can be reclaimed",
+			}); err != nil {
+				l.Error(err, "publish SourceWriterGone")
+			}
+			l.Info("flow has no live writer; not opening a source reader",
+				"flowID", mirror.Spec.FlowID)
+		}
+		return ctrl.Result{RequeueAfter: writerAbsentRetry}, nil
 	}
 
 	entry, err := r.opener.open(mirror.Spec.FlowID, mirror.Status.TargetInfo, provider)
@@ -1317,15 +1349,17 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 		// is what ends it, and it is the same recovery an operator
 		// gets by deleting the mirror and letting the requestor
 		// recreate it.
-		// Before spending a reopen: a reader can only be wedged in a way
-		// reopening fixes if something is still writing the flow. When
-		// nothing is, the reopen is not merely futile, it is what keeps
-		// the flow alive -- libmxl reclaims a flow directory only when
-		// the departing writer can take an exclusive lock, and this
-		// reader's own handle denies it. The directory then survives,
-		// the local agent keeps publishing Origin and renewing the
-		// Lease, and the flow is never collected.
-		if state.rebuildReader && r.writerGone(entry.flowID) {
+		// Asked of every failing state rather than only the ones a
+		// reopen resolves: a reader on a flow nothing writes is what
+		// keeps that flow alive, however its own failure reads. libmxl
+		// reclaims a flow directory only once an exclusive lock on it
+		// can be taken, and this reader's handle denies it, so the
+		// directory survives, the local agent keeps publishing Origin
+		// and renewing the Lease, and the flow is never collected.
+		// TransfersNotLanding is the state a source reaches without
+		// asking for a reopen, and it pins the flow exactly as the
+		// wedge states do.
+		if state.status == metav1.ConditionFalse && r.writerGone(entry.flowID) {
 			state.status = metav1.ConditionFalse
 			state.reason = mxlv1alpha1.ReasonSourceWriterGone
 			state.message = "flow has no live writer; releasing the source reader so the flow can be reclaimed"
@@ -1414,6 +1448,16 @@ func (r *SourceReconciler) writerGone(flowID string) bool {
 		return false
 	}
 	return !live
+}
+
+// sourceProgressReads reports whether the mirror already carries the
+// given reason on its SourceProgress condition. Used to keep a mirror
+// parked on an absent writer from rewriting the same condition, and
+// emitting the same event, on every retry.
+func sourceProgressReads(mirror *mxlv1alpha1.MxlFlowMirror, reason string) bool {
+	cond := apimeta.FindStatusCondition(mirror.Status.Conditions,
+		mxlv1alpha1.ConditionTypeSourceProgress)
+	return cond != nil && cond.Reason == reason
 }
 
 // readerRebuildsExhausted reports whether key has used its reopen

--- a/gateway/internal/mirror/source_stall_test.go
+++ b/gateway/internal/mirror/source_stall_test.go
@@ -215,6 +215,50 @@ func TestRunTransferLoop_RecordsProbedHead(t *testing.T) {
 		"a head that never advances leaves nothing to transfer")
 }
 
+func TestRunSampleTransferLoop_RecordsProbedHead(t *testing.T) {
+	// observedState reads a nil headAdvancedAt as "never probed" and
+	// cannot report ReaderNotAdvancing without it, so a continuous
+	// flow whose producer stops had no state that asks for a reopen
+	// and no state the writer-liveness check ran on.
+	tracker := &recordingTracker{}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+
+	probes := make(chan uint64, 3)
+	probes <- 4800
+	probes <- 4800
+	close(probes)
+
+	go runSampleTransferLoop(ctx, done, "flow-audio",
+		func() (uint64, error) {
+			if h, ok := <-probes; ok {
+				return h, nil
+			}
+			cancel()
+			return 4800, nil
+		},
+		func(uint64, int) error {
+			t.Error("a head that never advances leaves nothing to transfer")
+			return nil
+		},
+		func() error { return nil },
+		480, 480, time.Millisecond, tracker)
+
+	<-done
+	heads := tracker.headSnapshot()
+	require.NotEmpty(t, heads, "the sample loop must report the head it already probes")
+	for _, h := range heads {
+		assert.Equal(t, uint64(4800), h)
+	}
+
+	// What the recorded head buys: the state machine can now see the
+	// stall the sample path could not previously express.
+	entry := stalledEntry(heads[0], ptrTime(time.Now().Add(-defaultReaderStallAfter-time.Second)), 0, time.Time{})
+	state := observedState(entry, defaultReaderStallAfter)
+	assert.Equal(t, mxlv1alpha1.ReasonReaderNotAdvancing, state.reason)
+	assert.True(t, state.rebuildReader)
+}
+
 func TestReconcile_PreservesLastSentAtAcrossReopen(t *testing.T) {
 	// publishSourceProgress omits lastSentAt when the entry carries
 	// none, and SSA releases an omitted field, so the apiserver

--- a/gateway/internal/mirror/source_writergone_test.go
+++ b/gateway/internal/mirror/source_writergone_test.go
@@ -1,0 +1,225 @@
+package mirror
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/record"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// notLandingEntry builds the entry state a source reaches when its
+// head moves and nothing arrives at the target: the one failure that
+// asks for no reopen, and the one a stalled continuous flow reaches.
+func notLandingEntry() *sourceEntry {
+	e := stalledEntry(42, ptrTime(time.Now()), 0, time.Time{})
+	e.openedAt = time.Now().Add(-defaultReaderStallAfter - time.Second)
+	e.flowID = "flow-1"
+	return e
+}
+
+func TestObservedState_TransfersNotLandingAsksForNoReopen(t *testing.T) {
+	// Pins the premise the release below rests on. If this state ever
+	// gains rebuildReader, the flusher test stops covering the gap it
+	// was written for.
+	state := observedState(notLandingEntry(), defaultReaderStallAfter)
+	require.Equal(t, mxlv1alpha1.ReasonTransfersNotLanding, state.reason)
+	assert.False(t, state.rebuildReader)
+}
+
+func TestRunFlusher_ReleasesReaderWhenWriterGoneWithoutARebuildState(t *testing.T) {
+	// A reader on a flow nothing writes is what keeps that flow from
+	// being reclaimed, and TransfersNotLanding is where a stalled
+	// source sits without asking for a reopen. Observed on a cluster:
+	// an audio mirror held a flow whose producer had been gone for ten
+	// hours, and the release never ran because it was gated on the
+	// reopen states.
+	scheme := newSourceTestScheme(t)
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", "flow-1", "info-1")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	entry := notLandingEntry()
+	r := &SourceReconciler{
+		Client:       c,
+		Scheme:       scheme,
+		NodeName:     "node-a",
+		sources:      map[types.NamespacedName]*sourceEntry{key: entry},
+		attempts:     attemptTable[sourceAddInputs]{},
+		rebuilds:     map[types.NamespacedName]uint32{},
+		writerLiveFn: func(string) (bool, error) { return false, nil },
+		rebuildFn: func(types.NamespacedName) {
+			t.Error("a flow with no writer must be released, not reopened")
+		},
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+		t.Fatal("the flusher must return so the entry can be closed")
+	}
+
+	require.Eventually(t, func() bool {
+		r.mu.Lock()
+		defer r.mu.Unlock()
+		return r.sources[key] == nil
+	}, 5*time.Second, time.Millisecond,
+		"the source reader must be closed so libmxl can reclaim the flow")
+
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &got))
+	require.Len(t, got.Status.Conditions, 1)
+	assert.Equal(t, mxlv1alpha1.ReasonSourceWriterGone, got.Status.Conditions[0].Reason)
+}
+
+func TestRunFlusher_KeepsReaderWhileTheWriterIsLive(t *testing.T) {
+	// The same state with a writer attached is the target's problem to
+	// resolve, so the source stays open and only reports.
+	scheme := newSourceTestScheme(t)
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", "flow-1", "info-1")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	entry := notLandingEntry()
+	r := &SourceReconciler{
+		Client:       c,
+		Scheme:       scheme,
+		NodeName:     "node-a",
+		sources:      map[types.NamespacedName]*sourceEntry{key: entry},
+		attempts:     attemptTable[sourceAddInputs]{},
+		rebuilds:     map[types.NamespacedName]uint32{},
+		writerLiveFn: func(string) (bool, error) { return true, nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+
+	require.Eventually(t, func() bool {
+		var m mxlv1alpha1.MxlFlowMirror
+		if err := c.Get(context.Background(), key, &m); err != nil {
+			return false
+		}
+		return len(m.Status.Conditions) == 1
+	}, 5*time.Second, time.Millisecond)
+
+	cancel()
+	<-done
+
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &got))
+	assert.Equal(t, mxlv1alpha1.ReasonTransfersNotLanding, got.Status.Conditions[0].Reason)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	assert.NotNil(t, r.sources[key], "a live writer's reader must stay open")
+}
+
+func TestReconcile_DoesNotOpenAReaderWhileTheWriterIsGone(t *testing.T) {
+	// Without this the release is undone within the second: the
+	// condition the flusher publishes wakes this reconciler, which
+	// opens a fresh reader and pins the flow directory again.
+	scheme := newSourceTestScheme(t)
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", "flow-1", "info-1")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	opener := &fakeOpener{
+		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+			t.Error("no reader may be opened on a flow with no writer")
+			return &sourceEntry{infoStr: "info-1"}, nil
+		},
+	}
+	events := record.NewFakeRecorder(10)
+	r := &SourceReconciler{
+		Client:        c,
+		Scheme:        scheme,
+		NodeName:      "node-a",
+		opener:        opener,
+		Recorder:      events,
+		FlushInterval: time.Hour,
+		sources:       map[types.NamespacedName]*sourceEntry{},
+		attempts:      attemptTable[sourceAddInputs]{},
+		writerLiveFn:  func(string) (bool, error) { return false, nil },
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	res, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, writerAbsentRetry, res.RequeueAfter,
+		"the mirror has to ask again, because a writer that re-attaches to a surviving flow directory rotates nothing")
+	assert.Zero(t, opener.calls.Load())
+
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &got))
+	require.Len(t, got.Status.Conditions, 1)
+	assert.Equal(t, mxlv1alpha1.ReasonSourceWriterGone, got.Status.Conditions[0].Reason)
+
+	// Parked, not rewriting: the retry re-reads its own condition
+	// rather than re-publishing it and emitting another event.
+	_, err = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Len(t, events.Events, 1, "a parked mirror must emit one event, not one per retry")
+}
+
+func TestReconcile_OpensAReaderOnceTheWriterIsBack(t *testing.T) {
+	scheme := newSourceTestScheme(t)
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", "flow-1", "info-1")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	opener := &fakeOpener{
+		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+			return &sourceEntry{infoStr: "info-1"}, nil
+		},
+	}
+	live := false
+	r := &SourceReconciler{
+		Client:        c,
+		Scheme:        scheme,
+		NodeName:      "node-a",
+		opener:        opener,
+		FlushInterval: time.Hour,
+		sources:       map[types.NamespacedName]*sourceEntry{},
+		attempts:      attemptTable[sourceAddInputs]{},
+		writerLiveFn:  func(string) (bool, error) { return live, nil },
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+	require.Zero(t, opener.calls.Load())
+
+	live = true
+	_, err = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+	t.Cleanup(func() { r.closeEntry(key) })
+	assert.Equal(t, int32(1), opener.calls.Load(),
+		"a returning producer must get its mirror back without an operator")
+}


### PR DESCRIPTION
A source reader on a flow nothing writes is what keeps that flow from
being reclaimed: libmxl frees a flow directory only once an exclusive
lock on it can be taken, and a reader's handle denies it, so the
directory survives, the local agent keeps publishing Origin and renewing
the Lease, and the flow is never collected. The gateway therefore asks
libmxl whether a writer is attached before leaving a reader in place,
but asked only for the two states that request a reader reopen. A
stalled source reaches TransfersNotLanding, which requests none, and a
mirror that lands there holds its flow for as long as it exists. In a
running deployment one held a flow whose producer had exited ten hours
earlier.

Neither of the two states was reachable for a continuous flow in any
case. observedState cannot report ReaderNotAdvancing without a recorded
head, and only the grain loop recorded the head it probes, so the sample
path had no way to express a stall at all.

Releasing the reader also has to survive the wake-up it causes: the
published condition triggers a reconcile, which opened a fresh reader
and pinned the directory again. The open path now refuses a flow with no
writer and parks the mirror on the condition. The retry is timer-driven
because a producer that re-attaches to a directory that was never
collected rotates no Origin and fires no watch.

BEGIN_COMMIT_OVERRIDE
fix(gateway): check writer liveness on every failing source state (#291)

fix(gateway): record the probed head on the sample path (#291)
END_COMMIT_OVERRIDE
