### PR TITLE
ci: bump the go-mxl builder and keep both its images tracked

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.15
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.1
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -163,7 +163,7 @@ jobs:
     if: needs.changes.outputs.exporter == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.15
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.1
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -308,7 +308,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.0.0-rc.15
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.1
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7

--- a/renovate.json
+++ b/renovate.json
@@ -47,6 +47,21 @@
       "allowedVersions": "!/\\.test/"
     },
     {
+      "description": "go-mxl publishes its builder and runtime images only as rc prereleases. Docker versioning reads everything after the first hyphen as a compatibility suffix and never offers an update that changes it, so 1.0.0-rc.15 was never offered 1.1.0-rc.1 and both the ci.yml container pins and the docker/ ARGs stood still while the modules moved. Semver orders the tags; ignoreUnstable has to go with it because no stable tag has ever been published. Grouped so the workflow that compiles the modules and the images that ship them move together.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "ghcr.io/qvest-digital/go-mxl-builder",
+        "ghcr.io/qvest-digital/go-mxl-runtime"
+      ],
+      "versioning": "semver",
+      "ignoreUnstable": false,
+      "groupName": "go-mxl images",
+      "semanticCommitType": "deps",
+      "semanticCommitScope": "images"
+    },
+    {
       "description": "Group GitHub Actions bumps into one PR",
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
The three ci.yml jobs that compile the cgo modules ran in
`go-mxl-builder:1.0.0-rc.15`, while `docker/gateway.Dockerfile`,
`docker/exporter.Dockerfile` and `docker/demo-tools.Dockerfile` build
against `GO_MXL_TAG` 1.1.0-rc.1 and both cgo modules require go-mxl
v1.1.0-rc.1. Test and release linked different libmxl and
libmxl-fabrics builds. Both lanes pass in the new image, which reports
libmxl 1.1.0.0:

    gateway/internal/mirror        ok
    gateway/internal/domaingc      ok
    gateway/internal/capabilities  ok
    exporter/internal/domain       ok
    exporter/internal/topology     ok

## Why the pins never moved on their own

Not a coverage gap. Renovate's github-actions manager already extracts a
job's `container:` image (depType `container`), and the dockerfile
manager already resolves `ARG GO_MXL_TAG` into the `FROM` line. The
blocker is versioning: Docker versioning treats everything after the
first hyphen as a compatibility suffix and never offers an update that
changes it, which is what keeps an `-alpine` user on `-alpine`. A pin at
`1.0.0-rc.15` carries the suffix `rc.15`, so `1.1.0-rc.1` is not a
candidate for it, and neither pin has moved since. Renovate has never
opened a pull request against `docker/` in this repository.

The rule added here switches both images to semver versioning, which is
the remedy the Renovate docs name for exactly this case, and sets
`ignoreUnstable: false` because neither image has ever published a
stable tag, so every candidate would otherwise be filtered out. They
share a group so the builder the workflow compiles in and the runtime
the images ship on move in one pull request.

## The rest of the audit

- `.github/workflows`: the only other image references are
  `image: ${{ fromJSON(needs.meta.outputs.images) }}`, built at run
  time and not a dependency. No image is referenced from inside a `run:`
  block, which is the one place the manager cannot see.
- `runs-on:` and `uses:` are extracted as `github-runner` and `action`,
  and Renovate has raised pull requests for both.
- `docker/`: `docker.io/library/golang:${GO_VERSION}-bookworm` resolves
  through the ARG and updates under docker versioning, which is correct
  for a `-bookworm` suffix. `debian:trixie-slim` and the two distroless
  bases carry no version to compare, so nothing is offered and nothing
  is missing.

`renovate-config-validator --strict` passes.
