### PR TITLE
fix(gateway): read a flow libmxl cannot find as having no writer

### DIFF
--- a/gateway/internal/mirror/events_test.go
+++ b/gateway/internal/mirror/events_test.go
@@ -1,6 +1,7 @@
 package mirror
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -8,6 +9,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/record"
 
+	"github.com/qvest-digital/go-mxl/mxl"
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 )
 
@@ -99,4 +101,16 @@ func TestWriterGone_ReportsGoneOnlyWhenLibmxlSaysSo(t *testing.T) {
 	assert.True(t, r.writerGone("f1"),
 		"libmxl reporting no active writer is the authoritative answer, not "+
 			"an inference from a stalled head")
+}
+
+func TestWriterGone_ReadsAFlowLibmxlCannotFindAsGone(t *testing.T) {
+	// ErrFlowNotFound is an answer, not a failure to get one: a flow
+	// that is not in this node's domain has no writer here, and no
+	// reader can be opened on it either. Wrapped, because the seam
+	// reports the call it made.
+	r := &SourceReconciler{writerLiveFn: func(string) (bool, error) {
+		return false, fmt.Errorf("IsFlowActive: %w", mxl.ErrFlowNotFound)
+	}}
+	assert.True(t, r.writerGone("f1"),
+		"a flow that is not in the domain has no writer to wait for")
 }

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -1435,13 +1435,24 @@ func (r *SourceReconciler) bumpReaderRebuilds(key types.NamespacedName) uint32 {
 // writerGone reports whether the flow has no live writer. A nil seam,
 // or an error asking, answers false: the check exists to stop a futile
 // reopen, and failing to get an answer is not grounds for tearing down
-// a mirror that may be healthy.
+// a mirror that may be healthy. ErrFlowNotFound is the exception,
+// because it is an answer.
 func (r *SourceReconciler) writerGone(flowID string) bool {
 	if r.writerLiveFn == nil || flowID == "" {
 		return false
 	}
 	live, err := r.writerLiveFn(flowID)
 	if err != nil {
+		// The flow is not in this node's domain, so nothing here
+		// writes it and no reader can be opened on it. Answering
+		// "assume live" sends the mirror into an open that returns
+		// this same status, which the reconciler has nowhere to put
+		// but a returned error: a failure to retry rather than a state
+		// to publish, so the mirror carries no reason and the retry
+		// repeats for as long as it exists.
+		if errors.Is(err, mxl.ErrFlowNotFound) {
+			return true
+		}
 		ctrl.Log.WithName("source-flush").V(1).Info(
 			"writer liveness check failed; assuming the writer is live",
 			"flowID", flowID, "error", err.Error())

--- a/gateway/internal/mirror/source_writergone_test.go
+++ b/gateway/internal/mirror/source_writergone_test.go
@@ -2,6 +2,7 @@ package mirror
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -13,6 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/qvest-digital/go-mxl/fabrics"
+	"github.com/qvest-digital/go-mxl/mxl"
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 )
 
@@ -222,4 +224,69 @@ func TestReconcile_OpensAReaderOnceTheWriterIsBack(t *testing.T) {
 	t.Cleanup(func() { r.closeEntry(key) })
 	assert.Equal(t, int32(1), opener.calls.Load(),
 		"a returning producer must get its mirror back without an operator")
+}
+
+func TestReconcile_ParksAMirrorWhoseFlowIsNotInTheDomain(t *testing.T) {
+	// A mirror outlives the flow it names. When the origin cannot be
+	// resolved the rescan leaves an on-demand mirror pointed at its
+	// last known source, deliberately, so the consumer keeps its copy
+	// and the status says what is wrong. That source node is then
+	// asked for a flow it does not hold, and opening a reader on it
+	// returns ErrFlowNotFound every time.
+	//
+	// Returning that as a reconcile error retries it under the rate
+	// limiter and publishes nothing, so the mirror carries no reason
+	// for a reader that is never coming and the same failure repeats
+	// until something outside this reconciler deletes the mirror.
+	scheme := newSourceTestScheme(t)
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-a", "flow-1", "info-1")
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	// What libmxl answers on both paths for a flow that is not in the
+	// domain, wrapped the way the production callers wrap it.
+	opener := &fakeOpener{
+		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+			return nil, fmt.Errorf("NewReader: %w", mxl.ErrFlowNotFound)
+		},
+	}
+	events := record.NewFakeRecorder(10)
+	r := &SourceReconciler{
+		Client:        c,
+		Scheme:        scheme,
+		NodeName:      "node-a",
+		opener:        opener,
+		Recorder:      events,
+		FlushInterval: time.Hour,
+		sources:       map[types.NamespacedName]*sourceEntry{},
+		attempts:      attemptTable[sourceAddInputs]{},
+		writerLiveFn: func(string) (bool, error) {
+			return false, fmt.Errorf("IsFlowActive: %w", mxl.ErrFlowNotFound)
+		},
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	res, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err,
+		"a flow that is not here is a state to report, not a failure to retry")
+	assert.Equal(t, writerAbsentRetry, res.RequeueAfter,
+		"the mirror has to ask again: a producer landing on this node fires no event here")
+	assert.Zero(t, opener.calls.Load(),
+		"opening a reader on a flow libmxl cannot find can only fail")
+
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &got))
+	require.Len(t, got.Status.Conditions, 1)
+	assert.Equal(t, mxlv1alpha1.ReasonSourceWriterGone, got.Status.Conditions[0].Reason,
+		"the rescan leaves the mirror here on the promise that the status names the problem")
+
+	// The retry is the point of parking, so it must not resume the loop.
+	res, err = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Equal(t, writerAbsentRetry, res.RequeueAfter)
+	assert.Zero(t, opener.calls.Load())
+	assert.Len(t, events.Events, 1, "a parked mirror must emit one event, not one per retry")
 }


### PR DESCRIPTION
`writerGone` reads every error from the writer-liveness seam as a failed
lookup and answers "the writer is live". `IsFlowActive` returns
`ErrFlowNotFound` for a flow that is not in the node's domain, which is an
answer and not a failed lookup, so the gate that keeps a reader off a
producer-less flow does not fire for a flow that is not there at all. The
reconciler falls through to `open`, `NewReader` returns the same status,
and it comes back as a reconcile error:

```
Reconciler error ... open initiator: NewReader: mxl: flow not found
```

A returned error is retried under the rate limiter and publishes no
condition. Observed on a cluster: one mirror produced 103 identical
failures over 45 minutes, its status carried no reason for the reader that
never arrived, and the repetition stopped only when the mirror was deleted
for an unrelated reason.

That mirror was there on purpose. `ReconcileMirrors` leaves an on-demand
mirror pointed at its last known source when the origin cannot be
resolved, so the consumer keeps its copy, and the comment there names the
status the source side is expected to publish in exchange. This is the
input for which nothing was published.

One branch in `writerGone` settles it: `ErrFlowNotFound` means gone, so
the mirror parks on `SourceWriterGone` and retries on the existing
`writerAbsentRetry` timer instead of opening a reader that can only fail.
Every other error still answers "live", which the existing test pins.

Both new tests fail on `main` and pass with the change; the
reconcile-level one reproduces the error string above. The classification
is checked against libmxl at the pinned go-mxl version, where
`IsFlowActive` and `NewReader` both answer `ErrFlowNotFound` for a missing
flow and the production wrapping preserves `errors.Is`.
