### PR TITLE
docs: gate the shim mount on the file being there

### DIFF
--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -205,9 +205,9 @@ blocks on the agent's UDS until the mirror has materialised, and
 then lets the call complete.
 
 The agent writes the shim it carries to
-`/run/mxl/libmxl-intent.so` on every start, so the consumer
-preloads it out of the same mount it already needs for the agent's
-socket:
+`/run/mxl/libmxl-intent.so` on every start. The consumer mounts
+that file a second time, on its own path and as a `hostPath` of
+type `File`, and preloads it from there:
 
 ```yaml
 apiVersion: v1
@@ -221,24 +221,56 @@ spec:
       image: registry.example.com/my-consumer:1.2.3
       env:
         - name: LD_PRELOAD
-          value: /run/mxl/libmxl-intent.so
+          value: /run/mxl-shim/libmxl-intent.so
       securityContext:
         capabilities:
           add: ["IPC_LOCK", "SYS_RESOURCE"]
       volumeMounts:
         - name: mxl-run
           mountPath: /run/mxl
+        - name: mxl-shim
+          mountPath: /run/mxl-shim/libmxl-intent.so
+          readOnly: true
   volumes:
     - name: mxl-run
       hostPath:
         path: /run/mxl
         type: DirectoryOrCreate
+    - name: mxl-shim
+      hostPath:
+        path: /run/mxl/libmxl-intent.so
+        type: File
 ```
 
-The volume mount targets `/run/mxl` rather than just
-`/run/mxl/domain` so the domain directory, the agent's
-`/run/mxl/agent.sock` and the shim are all visible inside the pod,
-even if the socket is created after the pod schedules.
+The `mxl-run` mount targets `/run/mxl` rather than just
+`/run/mxl/domain` so the domain directory and the agent's
+`/run/mxl/agent.sock` are both visible inside the pod, even if the
+socket is created after the pod schedules. A shim call that finds
+no socket fails the open, which the consumer retries, so that one
+is self-healing.
+
+The second mount is not decoration, and `type: File` is the whole
+point of it. `/run` is tmpfs on most node images, so a reboot or a
+node replacement loses the shim and the agent DaemonSet races
+every workload pod on that node to write it back. The loader only
+*warns* about an `LD_PRELOAD` object it cannot open:
+
+```
+ERROR: ld.so: object '/run/mxl/libmxl-intent.so' from LD_PRELOAD
+cannot be preloaded (cannot open shared object file): ignored.
+```
+
+A pod that wins that race therefore starts with no interception at
+all and stays that way for as long as it runs: it reads the flows
+that are already local on its node and reports FLOW_NOT_FOUND for
+every other one, raising no intent, with nothing after that first
+line to connect the two. Declared as a `File`, the kubelet refuses
+to start the container until the path is one, so the pod waits in
+ContainerCreating with a `FailedMount` event naming it and comes
+up with interception intact once the agent has landed.
+
+Preloading straight out of the `/run/mxl` mount is what the older
+examples did. It works right up until a node reboots.
 
 `agent.flags.shimPath` moves the drop or, set empty, turns it off.
 

--- a/docs/architecture/03-node-anatomy.md
+++ b/docs/architecture/03-node-anatomy.md
@@ -105,12 +105,17 @@ table:
 
 The LD_PRELOAD shim reaches the consumer either off the node or out
 of the carrier image. The agent writes the copy it carries to
-`/run/mxl/libmxl-intent.so` on every start, inside the directory the
-consumer already mounts for the socket, so
-`LD_PRELOAD=/run/mxl/libmxl-intent.so` is the whole injection. The
-carrier image is the two-container pattern: an initContainer copies
-the same `.so` into a shared `emptyDir` and the main container
-preloads it from there. The default agent socket path can be
+`/run/mxl/libmxl-intent.so` on every start. The consumer mounts that
+file on a path of its own as a `hostPath` of type `File` and
+preloads from there, rather than naming it inside the `/run/mxl`
+directory mount: `/run` is tmpfs, so a node reboot loses the shim and
+the agent races the workload pods to write it back, and the loader
+treats an `LD_PRELOAD` object it cannot open as a warning. Declared
+as a `File`, the mount is what stops a pod from starting
+uninstrumented and staying that way for its whole life. The carrier
+image is the two-container pattern: an initContainer copies the same
+`.so` into a shared `emptyDir` and the main container preloads it
+from there, which is ordered by the kubelet and needs no gate. The default agent socket path can be
 overridden with `MXL_INTENT_SOCK`. The shim itself has no daemon, no
 Kubernetes client, and no state -- see
 [02-components](./02-components.md#shim).


### PR DESCRIPTION
The consumer wiring in `USAGE.md` and `03-node-anatomy.md` preloads
`libmxl-intent.so` straight out of the `/run/mxl` directory mount. That works
until a node reboots.

`/run` is tmpfs on most node images, so a reboot or a node replacement loses
the shim and the agent DaemonSet races every workload pod on that node to write
it back. The loader treats an `LD_PRELOAD` object it cannot open as a warning:

```
ERROR: ld.so: object '/run/mxl/libmxl-intent.so' from LD_PRELOAD cannot be
preloaded (cannot open shared object file): ignored.
```

A pod that wins that race starts with no interception at all and stays that way
for as long as it runs. It reads the flows already local to its node and
reports FLOW_NOT_FOUND for every other one, raising no intent the agent could
act on, with nothing after that first line to connect the two.

Seen on a cluster whose spot nodes recycled every twenty minutes or so: four
consumers on the two rebooted nodes carried that line, no intent request
reached the agent on either, and the two consumers on nodes that had not
rebooted were fine.

The pages now mount the same file separately as a `hostPath` of type `File` and
preload from that path. The kubelet refuses to start a container whose mount
source is not a file, so the pod waits in ContainerCreating with a
`FailedMount` event naming it and comes up correct once the agent has landed.
The carrier-image pattern needs no gate, since the kubelet already orders the
initContainer ahead of the main container.

The socket is called out as the case that does recover on its own: a shim call
that finds no socket fails the open, which the consumer retries.

Documentation only. No agent, shim or chart behaviour changes here.