### PR TITLE
fix(agent): keep an Origin a producer claimed

### DIFF
--- a/agent/internal/flowpublisher/publisher.go
+++ b/agent/internal/flowpublisher/publisher.go
@@ -117,12 +117,16 @@ func (p *Publisher) PublishAppeared(ctx context.Context, dirName string) error {
 	} else if isMirror {
 		phase = mxlv1alpha1.MxlFlowLocationReady
 	}
-	if err := p.upsertLocation(ctx, flowID, phase, &now, &now); err != nil {
+	// The phase actually written, not the one asked for: upsertLocation
+	// refuses to demote an Origin this node already claimed, so a
+	// mirror-target inference can come back out as Origin.
+	written, err := p.upsertLocation(ctx, flowID, phase, &now, &now)
+	if err != nil {
 		return err
 	}
 	// Only the producer side renews a Lease; a mirror target's local
 	// copy is not authoritative and must not claim Origin liveness.
-	if phase == mxlv1alpha1.MxlFlowLocationOrigin && p.Lease != nil {
+	if written == mxlv1alpha1.MxlFlowLocationOrigin && p.Lease != nil {
 		if err := p.Lease.Renew(ctx, flowID); err != nil {
 			l.Error(err, "renew origin lease", "flowID", flowID)
 		}
@@ -181,7 +185,7 @@ func (p *Publisher) ClaimOrigin(ctx context.Context, flowID string) error {
 	}
 
 	now := metav1.Now()
-	if err := p.upsertLocation(ctx, flowID, mxlv1alpha1.MxlFlowLocationOrigin, &now, &now); err != nil {
+	if _, err := p.upsertLocation(ctx, flowID, mxlv1alpha1.MxlFlowLocationOrigin, &now, &now); err != nil {
 		return err
 	}
 	l.Info("claimed Origin for locally attached producer", "flowID", flowID)
@@ -202,7 +206,7 @@ func (p *Publisher) PublishVanished(ctx context.Context, dirName string) error {
 	if !ok {
 		return nil
 	}
-	if err := p.upsertLocation(ctx, flowID, mxlv1alpha1.MxlFlowLocationStale, nil, nil); err != nil {
+	if _, err := p.upsertLocation(ctx, flowID, mxlv1alpha1.MxlFlowLocationStale, nil, nil); err != nil {
 		return err
 	}
 	if p.Lease != nil {
@@ -227,11 +231,18 @@ func (p *Publisher) PublishVanished(ctx context.Context, dirName string) error {
 // AppearedAt, which is what the source gateway keys rotation
 // detection on, and nil leaves whatever is already there. A Stale
 // phase clears it, so the next appearance reads as a rotation.
-func (p *Publisher) upsertLocation(ctx context.Context, flowID string, phase mxlv1alpha1.MxlFlowLocationPhase, observed, appeared *metav1.Time) error {
+//
+// Returns the phase this node's location carries once the update
+// lands, which is not always the one asked for -- see the Ready over
+// Origin guard below. An absent MxlFlow returns the empty phase.
+func (p *Publisher) upsertLocation(ctx context.Context, flowID string, phase mxlv1alpha1.MxlFlowLocationPhase, observed, appeared *metav1.Time) (mxlv1alpha1.MxlFlowLocationPhase, error) {
+	written := phase
 	err := retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		written = phase
 		var obj mxlv1alpha1.MxlFlow
 		if err := p.Client.Get(ctx, types.NamespacedName{Name: flowID}, &obj); err != nil {
 			if apierrors.IsNotFound(err) {
+				written = ""
 				return nil
 			}
 			return fmt.Errorf("get MxlFlow %s: %w", flowID, err)
@@ -241,7 +252,26 @@ func (p *Publisher) upsertLocation(ctx context.Context, flowID string, phase mxl
 		found := false
 		for i := range obj.Status.Locations {
 			if obj.Status.Locations[i].NodeName == p.NodeName {
-				obj.Status.Locations[i].Phase = phase
+				// Ready is inferred, Origin is observed. Ready comes
+				// from a mirror naming this node as its target, which
+				// cannot separate a directory a mirror is filling from
+				// one a local producer has since taken over; Origin
+				// comes from the shim reporting that producer opening
+				// the flow for writing. Letting the inference overrule
+				// the observation strands the flow: the mirror outlives
+				// the producer's arrival, so every re-publish demotes
+				// the node again -- InitialSync does one per flow on
+				// every agent start -- and the flow ends up with no
+				// Origin location anywhere, which resolveSourceNode
+				// cannot answer from and no consumer on any node
+				// recovers from. A vanished directory still demotes:
+				// Stale is observed too.
+				if phase == mxlv1alpha1.MxlFlowLocationReady &&
+					obj.Status.Locations[i].Phase == mxlv1alpha1.MxlFlowLocationOrigin {
+					written = mxlv1alpha1.MxlFlowLocationOrigin
+				} else {
+					obj.Status.Locations[i].Phase = phase
+				}
 				obj.Status.Locations[i].LastObserved = observed
 				switch {
 				case stale:
@@ -268,9 +298,9 @@ func (p *Publisher) upsertLocation(ctx context.Context, flowID string, phase mxl
 		return p.Client.Status().Update(ctx, &obj)
 	})
 	if err != nil {
-		return fmt.Errorf("update MxlFlow %s status: %w", flowID, err)
+		return "", fmt.Errorf("update MxlFlow %s status: %w", flowID, err)
 	}
-	return nil
+	return written, nil
 }
 
 // InitialSync walks the domain directory at startup and calls
@@ -359,7 +389,7 @@ func (p *Publisher) demoteVanishedLocalOrigins(ctx context.Context, onDisk map[s
 			if loc.Phase == mxlv1alpha1.MxlFlowLocationStale {
 				continue
 			}
-			if err := p.upsertLocation(ctx, flow.Spec.ID, mxlv1alpha1.MxlFlowLocationStale, nil, nil); err != nil {
+			if _, err := p.upsertLocation(ctx, flow.Spec.ID, mxlv1alpha1.MxlFlowLocationStale, nil, nil); err != nil {
 				log.FromContext(ctx).Error(err, "demote vanished local origin failed", "flowID", flow.Spec.ID)
 			}
 			if p.Lease != nil {

--- a/agent/internal/flowpublisher/publisher_test.go
+++ b/agent/internal/flowpublisher/publisher_test.go
@@ -288,6 +288,70 @@ func TestPublishAppeared_MirrorTargetMarksReadyNotOrigin(t *testing.T) {
 			"Origin would route downstream lookups at a mirror")
 }
 
+// The other half of the same classification. A producer rescheduled
+// onto a node that already mirrors its flow attaches to the directory
+// in place, so ClaimOrigin is the only record that this node produces
+// it -- and the mirror it attached to outlives that claim. Every
+// re-publish re-runs isMirrorTarget, which still says "mirror", and
+// demotes the node again; InitialSync does one per flow on every agent
+// start. The flow ends up with no Origin location anywhere, which
+// resolveSourceNode cannot answer from, and every consumer on every
+// other node gets FLOW_NOT_FOUND for good.
+func TestPublishAppeared_MirrorTargetDoesNotDemoteAClaimedOrigin(t *testing.T) {
+	scheme := newScheme(t)
+	domain := t.TempDir()
+	flowDir := filepath.Join(domain, validFlowID+".mxl-flow")
+	require.NoError(t, os.Mkdir(flowDir, 0o755))
+	require.NoError(t, os.WriteFile(
+		filepath.Join(flowDir, FlowDefName),
+		[]byte(`{"id":"`+validFlowID+`"}`), 0o644))
+
+	mirror := &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "some-mirror",
+			Namespace: "mxl-system",
+		},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     validFlowID,
+			SourceNode: "n0",
+			TargetNode: "n1",
+		},
+	}
+	claimed := &mxlv1alpha1.MxlFlow{
+		ObjectMeta: ObjectMeta(validFlowID),
+		Spec:       mxlv1alpha1.MxlFlowSpec{ID: validFlowID},
+		Status: mxlv1alpha1.MxlFlowStatus{
+			Locations: []mxlv1alpha1.MxlFlowLocation{{
+				NodeName:     "n1",
+				Phase:        mxlv1alpha1.MxlFlowLocationOrigin,
+				LastObserved: &metav1.Time{Time: metav1.Now().Time},
+				AppearedAt:   &metav1.Time{Time: metav1.Now().Time},
+			}},
+		},
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlow{}).
+		WithObjects(mirror, claimed).
+		Build()
+
+	lease := &fakeLease{}
+	p := &Publisher{Client: c, DomainPath: domain, NodeName: "n1", Lease: lease}
+	require.NoError(t, p.PublishAppeared(context.Background(), validFlowID+".mxl-flow"))
+
+	var got mxlv1alpha1.MxlFlow
+	require.NoError(t, c.Get(context.Background(),
+		types.NamespacedName{Name: validFlowID}, &got))
+	assert.Equal(t, mxlv1alpha1.MxlFlowLocationOrigin, localPhase(t, &got, "n1"),
+		"a producer attaching to the flow is observed evidence and a "+
+			"mirror naming this node is an inference; the inference must "+
+			"not overrule it")
+	assert.Equal(t, []string{validFlowID}, lease.renewed,
+		"the location still reads Origin, so consumers check its Lease; "+
+			"skipping the renewal here leaves the Origin looking stale "+
+			"until the renew loop's next tick")
+}
+
 func TestInitialSync_DemotesOriginForFlowsNoLongerOnDisk(t *testing.T) {
 	scheme := newScheme(t)
 	domain := t.TempDir()


### PR DESCRIPTION
A location published as Ready is inferred from an MxlFlowMirror naming
this node as its target, which cannot separate a directory a mirror is
filling from one a local producer has since taken over. Origin is
observed: the shim reports the producer opening the flow for writing and
ClaimOrigin records it.

Letting the inference overrule the observation strands the flow. A
producer rescheduled onto a node that already mirrors the flow it writes
attaches to the directory in place, so ClaimOrigin is the only record
that the node produces it, and the mirror it attached to outlives that
claim. Every subsequent PublishAppeared demotes the node again --
InitialSync does one per flow on every agent start -- until no location
anywhere carries Origin. resolveSourceNode answers from Origin locations
alone, so it returns not-found while status.originNode still names the
node correctly, and every consumer on every other node gets
FLOW_NOT_FOUND for that flow permanently.

upsertLocation now refuses to write Ready over an Origin for the same
node, and reports the phase the location carries afterwards so the Lease
renewal follows what was written rather than what was asked for. A
vanished directory still demotes: Stale is observed too.

The issue's second suggestion, falling back to status.originNode when no
location carries Origin, is deliberately left out. originNode is sticky
and a node holding only a mirror satisfies it, so the fallback would
source consumers from a derived copy -- the case the Ready phase exists
to prevent -- and turn a clear FLOW_NOT_FOUND into a frozen picture.

A flow already wedged does not recover from this: the producer attached
once and the shim raises no second notification. Restarting the producer
still repairs it.

Closes #303