### PR TITLE
feat(gateway): report RDMA devices missing from the provider probe

### DIFF
--- a/api/v1alpha1/conditions.go
+++ b/api/v1alpha1/conditions.go
@@ -29,6 +29,25 @@ const (
 	// providers that worked, so a consumer cannot tell "measured
 	// none" from "never measured" without this.
 	ConditionTypeProbed = "Probed"
+
+	// ConditionTypeRDMADevicesEnumerated reports whether the RDMA
+	// devices the host kernel exposes are accounted for by
+	// status.providers. Owned by the gateway capability publisher.
+	//
+	// libfabric builds a provider's device list once per process, on
+	// the first enumeration, and rebuilds it only for a caller that
+	// asks to rescan. libmxl-fabrics takes no flags on its
+	// enumeration entry point, so nothing here can ask. A gateway
+	// that first enumerated while the host's RDMA devices were
+	// unusable therefore reports none of them for the rest of its
+	// life, and every mirror it takes part in resolves to the tcp
+	// fallback while still reaching Ready.
+	//
+	// A False condition is a discrepancy, not a proven fault. An
+	// active port does not by itself make a device one the verbs
+	// provider will build an endpoint on, so the gateway reports the
+	// difference rather than acting on it.
+	ConditionTypeRDMADevicesEnumerated = "RDMADevicesEnumerated"
 )
 
 // Condition reason constants for MxlFlowMirror and MxlFlow status.
@@ -124,4 +143,21 @@ const (
 	// providers are left in place rather than cleared, so a
 	// transient failure does not strand every mirror on the node.
 	ReasonProbeFailed = "ProbeFailed"
+
+	// ReasonHostDevicesRepresented marks an MxlNodeCapabilities whose
+	// enumerated providers account for the host's RDMA devices. A
+	// host exposing none is represented by definition.
+	ReasonHostDevicesRepresented = "HostDevicesRepresented"
+
+	// ReasonHostDevicesUnenumerated marks an MxlNodeCapabilities
+	// where the host exposes an RDMA device with an active port and
+	// no RDMA-capable provider was enumerated. Restarting the gateway
+	// is what runs the enumeration again; nothing reachable from a
+	// running process rebuilds it.
+	ReasonHostDevicesUnenumerated = "HostDevicesUnenumerated"
+
+	// ReasonHostDevicesUnreadable marks an MxlNodeCapabilities whose
+	// host RDMA device list could not be read. The enumerated
+	// providers stand; only the cross-check is missing.
+	ReasonHostDevicesUnreadable = "HostDevicesUnreadable"
 )

--- a/docs/RDMA.md
+++ b/docs/RDMA.md
@@ -232,6 +232,45 @@ every count is zero whether or not the provider works, so
 consumers keep treating those entries as available. During a
 rolling upgrade both shapes are present in the cluster at once.
 
+The `RDMADevicesEnumerated` condition covers the one thing
+`deviceCount` cannot say for itself. libfabric builds a provider's
+device list once per process, on the first enumeration, and rebuilds
+it only for a caller that asks to rescan; the libmxl-fabrics
+enumeration entry point takes no flags, so nothing here can ask. A
+gateway that first enumerated while the host's RDMA devices were
+unusable -- the module not yet loaded, the port not yet up, the
+device node not yet mounted -- therefore publishes `deviceCount: 0`
+for the rest of its life, and that entry is indistinguishable from
+the one a node with no RDMA hardware produces. Every mirror the node
+takes part in resolves to tcp and still reaches `Ready`.
+
+The gateway cross-checks the probe against the RDMA devices the host
+kernel exposes, read from sysfs on each refresh rather than from the
+cached provider list:
+
+```console
+status:
+  conditions:
+    - type: RDMADevicesEnumerated
+      status: "False"
+      reason: HostDevicesUnenumerated
+      message: host exposes dev0 with an active port and no RDMA provider
+        enumerated a device; mirrors on this node resolve to a non-RDMA
+        provider until the gateway restarts
+```
+
+`False` is a discrepancy rather than a proven fault, and the gateway
+reports it rather than acting on it. An active port is necessary for
+the verbs provider to offer an endpoint but not sufficient -- it also
+needs an address on the matching interface -- so a node can hold this
+condition legitimately. Restarting the gateway pod is what runs the
+enumeration again; nothing reachable from a running process rebuilds
+it.
+
+The condition is absent on a gateway whose `--providers` admits no
+RDMA provider: such a node advertises none by instruction rather than
+by measurement, so the host device list contradicts nothing.
+
 `version` is unset on every entry: libmxl-fabrics exposes no
 per-provider version through its C API.
 
@@ -455,7 +494,8 @@ those nodes belong in their own variant.
 | --- | --- |
 | `MxlFlowMirror` `Degraded` with `TargetProgress=False/OpenTargetFailed` | Gateway can't `fi_getinfo` the provider on the local NIC. Check `/dev/infiniband` is mounted and the host module is loaded. `status.targetAttemptCount` carries the length of the failure run. |
 | Mirror fails with `no usable fabric interface` | Every candidate was excluded. The error names the first exclusion and its reason; check the fabric flags against `kubectl get mxlnodecapabilities <node> -o yaml`. |
-| A node advertises `deviceCount: 0` for a provider whose hardware is installed | libmxl-fabrics did not enumerate a usable device. Check the host module and `/dev/infiniband` first, then whether the fabric flags exclude the interface it would have used. |
+| A node advertises `deviceCount: 0` for a provider whose hardware is installed | libmxl-fabrics did not enumerate a usable device. Check `RDMADevicesEnumerated` first: `False` means the host exposes an active device this process never enumerated, which only a gateway restart clears. Otherwise check the host module and `/dev/infiniband`, then whether the fabric flags exclude the interface it would have used. |
+| Every mirror on one node sits on tcp while its peers use verbs | The gateway enumerated before the node's RDMA device was usable, and libfabric does not rebuild a provider's device list within a process. `RDMADevicesEnumerated=False/HostDevicesUnenumerated` reports it; restart the gateway pod on that node. |
 | Every mirror sits on tcp after an upgrade | Nodes whose gateway has not rolled yet report no `Probed` condition. Check `kubectl get mxlnodecapabilities` for the ones still on the old shape. |
 | Gateway pods Pending with `Insufficient <resource>` | The DaemonSet requests a device-plugin resource on nodes that do not advertise it. Split those nodes into their own `gateway.variants` entry. |
 | Gateway pods stuck in `ContainerCreating` | The `/dev/infiniband` hostPath is absent and `rdma.infinibandHostPathType` is `Directory`. Either place the DaemonSet only on RDMA-capable nodes or set `rdma.mountInfiniband: false` and reach the device through a device plugin. |

--- a/gateway/cmd/mxl-fabrics-gateway/main.go
+++ b/gateway/cmd/mxl-fabrics-gateway/main.go
@@ -29,6 +29,7 @@ import (
 	"github.com/qvest-digital/mxl-k8s/gateway/internal/domaingc"
 	"github.com/qvest-digital/mxl-k8s/gateway/internal/instance"
 	"github.com/qvest-digital/mxl-k8s/gateway/internal/mirror"
+	"github.com/qvest-digital/mxl-k8s/gateway/internal/rdma"
 )
 
 var (
@@ -158,6 +159,7 @@ func run(args []string) error {
 			Providers:   cfg.Providers,
 			Lister:      handles.Fabrics(),
 			Selector:    selector,
+			HostDevices: rdma.Inventory{},
 			BindAddress: cfg.BindAddress,
 			ProbePeriod: cfg.ProbePeriod,
 		}

--- a/gateway/internal/capabilities/publisher.go
+++ b/gateway/internal/capabilities/publisher.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"strings"
 	"time"
 
 	corev1 "k8s.io/api/core/v1"
@@ -27,6 +28,21 @@ import (
 // without a libmxl domain.
 type InterfaceLister interface {
 	Interfaces(query *fabrics.InterfaceConfig) ([]fabrics.InterfaceConfig, error)
+}
+
+// HostDeviceLister reports the RDMA devices the host kernel exposes
+// with at least one active port. Production binds it to an
+// rdma.Inventory; tests bind it to a stub.
+type HostDeviceLister interface {
+	ActiveDevices() ([]string, error)
+}
+
+// rdmaProviders are the providers that drive RDMA hardware, so the
+// ones whose absence the host device list can contradict. tcp and shm
+// need no device and never appear here.
+var rdmaProviders = []fabrics.Provider{
+	fabrics.ProviderEFA,
+	fabrics.ProviderVerbs,
 }
 
 // Publisher creates and refreshes the MxlNodeCapabilities CR for this
@@ -57,6 +73,13 @@ type Publisher struct {
 	// may carry MXL traffic on. The mirror setup path applies the
 	// same one, so nothing is advertised that a setup would refuse.
 	Selector fabric.Selector
+
+	// HostDevices reports the host's RDMA devices, which is the only
+	// thing that separates a provider that measured no hardware from
+	// one that enumerated before the hardware was usable. Both
+	// publish the same empty entry. Nil skips the cross-check and
+	// leaves the condition unset.
+	HostDevices HostDeviceLister
 
 	// BindAddress narrows the enumeration query the way a mirror
 	// setup narrows it, so a gateway pinned to one address does not
@@ -233,11 +256,118 @@ func (p *Publisher) Refresh(ctx context.Context) error {
 			"Fabric probe succeeded on %s: %d provider(s)", p.NodeName, len(probed))
 	}
 
+	// Log and event are transition-scoped; the state they announce
+	// lasts until the process restarts. The condition is what carries
+	// it for as long as it holds, which is why it is set even where
+	// nothing is emitted.
+	if cond, ok := p.hostDeviceCondition(probed); ok {
+		if meta.SetStatusCondition(&obj.Status.Conditions, cond) {
+			if cond.Status == metav1.ConditionTrue {
+				l.V(1).Info("host RDMA devices are represented in the probed providers",
+					"reason", cond.Reason, "detail", cond.Message)
+			} else {
+				l.Info("host RDMA devices are not represented in the probed providers",
+					"reason", cond.Reason, "detail", cond.Message)
+			}
+			if p.Recorder != nil {
+				eventType := corev1.EventTypeNormal
+				if cond.Status != metav1.ConditionTrue {
+					eventType = corev1.EventTypeWarning
+				}
+				p.Recorder.Eventf(&obj, eventType, cond.Reason,
+					"Host RDMA devices on %s: %s", p.NodeName, cond.Message)
+			}
+		}
+	}
+
 	if err := p.Client.Status().Update(ctx, &obj); err != nil {
 		return fmt.Errorf("update MxlNodeCapabilities status: %w", err)
 	}
 	l.V(1).Info("published node capabilities", "providers", providerSummary(probed))
 	return nil
+}
+
+// hostDeviceCondition compares the RDMA devices the host exposes
+// against the providers the probe reported, and returns the condition
+// to publish. The second return reports whether the comparison
+// applies at all.
+//
+// It applies only when a host device list is configured and the
+// provider bound admits a provider that drives RDMA hardware. A
+// gateway configured for tcp alone advertises no RDMA provider by
+// instruction rather than by measurement, and has nothing to
+// contradict.
+func (p *Publisher) hostDeviceCondition(probed []mxlv1alpha1.MxlFabricsProviderCapability) (metav1.Condition, bool) {
+	if p.HostDevices == nil {
+		return metav1.Condition{}, false
+	}
+	admitsRDMA := false
+	for _, provider := range rdmaProviders {
+		if p.allows(provider) {
+			admitsRDMA = true
+			break
+		}
+	}
+	if !admitsRDMA {
+		return metav1.Condition{}, false
+	}
+
+	devices, err := p.HostDevices.ActiveDevices()
+	if err != nil {
+		// Unknown rather than False: the providers stand on their own
+		// measurement, and only the cross-check went missing.
+		return metav1.Condition{
+			Type:    mxlv1alpha1.ConditionTypeRDMADevicesEnumerated,
+			Status:  metav1.ConditionUnknown,
+			Reason:  mxlv1alpha1.ReasonHostDevicesUnreadable,
+			Message: fmt.Sprintf("host RDMA device list unreadable: %v", err),
+		}, true
+	}
+
+	if enumerated := rdmaDeviceCount(probed); enumerated > 0 || len(devices) == 0 {
+		msg := fmt.Sprintf("%d host device(s) active, %d enumerated across %s",
+			len(devices), enumerated, providerNames(rdmaProviders))
+		return metav1.Condition{
+			Type:    mxlv1alpha1.ConditionTypeRDMADevicesEnumerated,
+			Status:  metav1.ConditionTrue,
+			Reason:  mxlv1alpha1.ReasonHostDevicesRepresented,
+			Message: msg,
+		}, true
+	}
+
+	return metav1.Condition{
+		Type:   mxlv1alpha1.ConditionTypeRDMADevicesEnumerated,
+		Status: metav1.ConditionFalse,
+		Reason: mxlv1alpha1.ReasonHostDevicesUnenumerated,
+		Message: fmt.Sprintf(
+			"host exposes %s with an active port and no RDMA provider enumerated a device; "+
+				"mirrors on this node resolve to a non-RDMA provider until the gateway restarts",
+			strings.Join(devices, ", ")),
+	}, true
+}
+
+// rdmaDeviceCount totals the devices reported across the providers
+// that drive RDMA hardware.
+func rdmaDeviceCount(probed []mxlv1alpha1.MxlFabricsProviderCapability) int {
+	total := 0
+	for _, capability := range probed {
+		for _, provider := range rdmaProviders {
+			if string(capability.Name) == provider.String() {
+				total += int(capability.DeviceCount)
+				break
+			}
+		}
+	}
+	return total
+}
+
+// providerNames renders providers for a condition message.
+func providerNames(providers []fabrics.Provider) string {
+	names := make([]string, 0, len(providers))
+	for _, provider := range providers {
+		names = append(names, provider.String())
+	}
+	return strings.Join(names, "/")
 }
 
 // probe enumerates the host's fabric interfaces and folds them into

--- a/gateway/internal/capabilities/publisher_test.go
+++ b/gateway/internal/capabilities/publisher_test.go
@@ -584,3 +584,153 @@ func TestRefresh_RecreatesADeletedResource(t *testing.T) {
 	require.NotNil(t, tcp)
 	assert.Equal(t, int32(1), tcp.DeviceCount)
 }
+
+// fakeHostDevices stands in for the host's RDMA device inventory.
+type fakeHostDevices struct {
+	out []string
+	err error
+}
+
+func (f fakeHostDevices) ActiveDevices() ([]string, error) { return f.out, f.err }
+
+// rdmaCondition returns the enumeration cross-check condition, or nil
+// when the publisher left it unset.
+func rdmaCondition(t *testing.T, p *Publisher) *metav1.Condition {
+	t.Helper()
+	got := getCR(t, p)
+	return meta.FindStatusCondition(got.Status.Conditions,
+		mxlv1alpha1.ConditionTypeRDMADevicesEnumerated)
+}
+
+// The defect this guards. libfabric builds a provider's device list
+// once per process and offers no rebuild through the libmxl-fabrics
+// API, so a gateway that enumerated before the host's RDMA devices
+// were usable reports none of them for the rest of its life. The
+// published entry is identical to the one a host with no RDMA
+// hardware produces, and every mirror silently resolves to a
+// non-RDMA provider.
+func TestRefresh_ReportsHostDevicesMissingFromTheProbe(t *testing.T) {
+	l := &fakeLister{out: []fabrics.InterfaceConfig{
+		iface(fabrics.ProviderTCP, "10.20.53.13", "eth0"),
+	}}
+	p := &Publisher{
+		Client:      newClient(t, existingCR()).Build(),
+		NodeName:    "n1",
+		Providers:   []fabrics.Provider{fabrics.ProviderAny},
+		Lister:      l,
+		HostDevices: fakeHostDevices{out: []string{"dev0"}},
+	}
+	require.NoError(t, p.Refresh(context.Background()))
+
+	cond := rdmaCondition(t, p)
+	require.NotNil(t, cond, "a provider that measured nothing while the host "+
+		"carries an active device is the whole condition")
+	assert.Equal(t, metav1.ConditionFalse, cond.Status)
+	assert.Equal(t, mxlv1alpha1.ReasonHostDevicesUnenumerated, cond.Reason)
+	assert.Contains(t, cond.Message, "dev0")
+}
+
+// A host with no RDMA hardware is represented by definition, and
+// must not be reported as a discrepancy: the fix would otherwise turn
+// a correct zero into a permanent fault on every node without RDMA.
+func TestRefresh_HostWithoutRDMADevicesIsRepresented(t *testing.T) {
+	l := &fakeLister{out: []fabrics.InterfaceConfig{
+		iface(fabrics.ProviderTCP, "10.20.53.13", "eth0"),
+	}}
+	p := &Publisher{
+		Client:      newClient(t, existingCR()).Build(),
+		NodeName:    "n1",
+		Providers:   []fabrics.Provider{fabrics.ProviderAny},
+		Lister:      l,
+		HostDevices: fakeHostDevices{},
+	}
+	require.NoError(t, p.Refresh(context.Background()))
+
+	cond := rdmaCondition(t, p)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, mxlv1alpha1.ReasonHostDevicesRepresented, cond.Reason)
+}
+
+// A probe that found the hardware is the healthy case.
+func TestRefresh_EnumeratedRDMADeviceIsRepresented(t *testing.T) {
+	l := &fakeLister{out: []fabrics.InterfaceConfig{
+		iface(fabrics.ProviderVerbs, "10.20.53.13", "mlx5_0"),
+		iface(fabrics.ProviderTCP, "10.20.53.13", "eth0"),
+	}}
+	p := &Publisher{
+		Client:      newClient(t, existingCR()).Build(),
+		NodeName:    "n1",
+		Providers:   []fabrics.Provider{fabrics.ProviderAny},
+		Lister:      l,
+		HostDevices: fakeHostDevices{out: []string{"dev0"}},
+	}
+	require.NoError(t, p.Refresh(context.Background()))
+
+	cond := rdmaCondition(t, p)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionTrue, cond.Status)
+	assert.Equal(t, mxlv1alpha1.ReasonHostDevicesRepresented, cond.Reason)
+}
+
+// A gateway configured for tcp alone advertises no RDMA provider by
+// instruction rather than by measurement, so the host device list
+// contradicts nothing and the condition does not apply.
+func TestRefresh_TCPOnlyBoundLeavesTheConditionUnset(t *testing.T) {
+	l := &fakeLister{out: []fabrics.InterfaceConfig{
+		iface(fabrics.ProviderTCP, "10.20.53.13", "eth0"),
+	}}
+	p := &Publisher{
+		Client:      newClient(t, existingCR()).Build(),
+		NodeName:    "n1",
+		Providers:   []fabrics.Provider{fabrics.ProviderTCP},
+		Lister:      l,
+		HostDevices: fakeHostDevices{out: []string{"dev0"}},
+	}
+	require.NoError(t, p.Refresh(context.Background()))
+
+	assert.Nil(t, rdmaCondition(t, p))
+}
+
+// Without a host device list there is nothing to compare against, and
+// claiming either answer would be a guess.
+func TestRefresh_NoHostDeviceListLeavesTheConditionUnset(t *testing.T) {
+	l := &fakeLister{out: []fabrics.InterfaceConfig{
+		iface(fabrics.ProviderTCP, "10.20.53.13", "eth0"),
+	}}
+	p := &Publisher{
+		Client:    newClient(t, existingCR()).Build(),
+		NodeName:  "n1",
+		Providers: []fabrics.Provider{fabrics.ProviderAny},
+		Lister:    l,
+	}
+	require.NoError(t, p.Refresh(context.Background()))
+
+	assert.Nil(t, rdmaCondition(t, p))
+}
+
+// The providers stand on their own measurement when only the
+// cross-check fails, so the condition goes Unknown rather than False
+// and the probe result is published either way.
+func TestRefresh_UnreadableHostDeviceListIsUnknown(t *testing.T) {
+	l := &fakeLister{out: []fabrics.InterfaceConfig{
+		iface(fabrics.ProviderTCP, "10.20.53.13", "eth0"),
+	}}
+	p := &Publisher{
+		Client:      newClient(t, existingCR()).Build(),
+		NodeName:    "n1",
+		Providers:   []fabrics.Provider{fabrics.ProviderAny},
+		Lister:      l,
+		HostDevices: fakeHostDevices{err: errors.New("boom")},
+	}
+	require.NoError(t, p.Refresh(context.Background()))
+
+	cond := rdmaCondition(t, p)
+	require.NotNil(t, cond)
+	assert.Equal(t, metav1.ConditionUnknown, cond.Status)
+	assert.Equal(t, mxlv1alpha1.ReasonHostDevicesUnreadable, cond.Reason)
+
+	got := getCR(t, p)
+	assert.True(t, meta.IsStatusConditionTrue(got.Status.Conditions,
+		mxlv1alpha1.ConditionTypeProbed), "the probe itself still succeeded")
+}

--- a/gateway/internal/rdma/inventory.go
+++ b/gateway/internal/rdma/inventory.go
@@ -1,0 +1,116 @@
+// Package rdma reports the RDMA devices the host kernel exposes.
+//
+// It reads sysfs rather than asking libmxl-fabrics, because the two
+// answer different questions. A provider enumeration reports the
+// devices libfabric found when it first initialised that provider in
+// this process; sysfs reports what the kernel has now. Nothing else
+// distinguishes a host that carries no RDMA hardware from a process
+// that enumerated before the hardware it does carry became usable,
+// and the two produce the same empty provider entry.
+package rdma
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// DefaultSysPath is the sysfs directory holding one entry per RDMA
+// device. It is absent on a host with no RDMA hardware.
+const DefaultSysPath = "/sys/class/infiniband"
+
+// Inventory reads a host RDMA device list out of a sysfs tree.
+type Inventory struct {
+	// Path is the directory to read. Empty means DefaultSysPath.
+	Path string
+}
+
+// ActiveDevices returns the names of the RDMA devices that have at
+// least one port in the ACTIVE state, sorted.
+//
+// Port state is the coarsest filter that still means something: a
+// device whose every port is down carries no traffic, so a provider
+// reporting nothing for it is right rather than stale. The reverse
+// does not hold. An active port is necessary for the verbs provider
+// to offer an endpoint, not sufficient - it also needs an address on
+// the matching interface - so this bounds the question rather than
+// answering it, and a caller reports the difference rather than
+// treating it as a fault.
+//
+// A missing directory is not an error: that is how a host with no
+// RDMA hardware presents, and it is a legitimate answer of none.
+func (i Inventory) ActiveDevices() ([]string, error) {
+	root := i.Path
+	if root == "" {
+		root = DefaultSysPath
+	}
+
+	entries, err := os.ReadDir(root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("read %s: %w", root, err)
+	}
+
+	var active []string
+	for _, entry := range entries {
+		name := entry.Name()
+		ok, err := deviceHasActivePort(filepath.Join(root, name))
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			active = append(active, name)
+		}
+	}
+	sort.Strings(active)
+	return active, nil
+}
+
+// deviceHasActivePort reports whether any port of the device at dir
+// is ACTIVE.
+//
+// A device that has lost its ports directory between the listing and
+// this read is treated as having none rather than as an error: the
+// inventory describes a moving target, and a device disappearing
+// mid-read is the same answer as one that was never there.
+func deviceHasActivePort(dir string) (bool, error) {
+	portsDir := filepath.Join(dir, "ports")
+	ports, err := os.ReadDir(portsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("read %s: %w", portsDir, err)
+	}
+
+	for _, port := range ports {
+		raw, err := os.ReadFile(filepath.Join(portsDir, port.Name(), "state"))
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return false, fmt.Errorf("read %s state: %w", portsDir, err)
+		}
+		if portIsActive(string(raw)) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// portIsActive reads the port state file, whose contents are the
+// numeric state and its name separated by a colon, as in "4: ACTIVE".
+// Only the name is read: the numbering belongs to the kernel's enum
+// and carries no promise across versions, while the names are the
+// ones the InfiniBand specification defines.
+func portIsActive(raw string) bool {
+	_, name, found := strings.Cut(strings.TrimSpace(raw), ":")
+	if !found {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(name), "ACTIVE")
+}

--- a/gateway/internal/rdma/inventory_test.go
+++ b/gateway/internal/rdma/inventory_test.go
@@ -1,0 +1,115 @@
+package rdma
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeDevice lays out one RDMA device in a sysfs tree, with one port
+// per state given. The port state file carries the numeric state and
+// its name, as the kernel writes it.
+func writeDevice(t *testing.T, root, name string, states ...string) {
+	t.Helper()
+	for i, state := range states {
+		dir := filepath.Join(root, name, "ports", string(rune('1'+i)))
+		require.NoError(t, os.MkdirAll(dir, 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "state"), []byte(state), 0o644))
+	}
+}
+
+// A host with no RDMA hardware has no sysfs directory at all. That is
+// an answer of none rather than a failure to read, because reporting
+// it as an error would leave every such node permanently unable to
+// say anything about its own hardware.
+func TestAbsentDirectoryReportsNoDevices(t *testing.T) {
+	devices, err := Inventory{Path: filepath.Join(t.TempDir(), "nothing-here")}.ActiveDevices()
+
+	require.NoError(t, err)
+	assert.Empty(t, devices)
+}
+
+func TestActiveDevicesAreReportedSorted(t *testing.T) {
+	root := t.TempDir()
+	writeDevice(t, root, "dev1", "4: ACTIVE")
+	writeDevice(t, root, "dev0", "4: ACTIVE")
+
+	devices, err := Inventory{Path: root}.ActiveDevices()
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dev0", "dev1"}, devices)
+}
+
+// A device whose ports are all down carries no traffic, so a provider
+// that reports nothing for it has measured correctly. Counting it
+// would turn every idle port into a false discrepancy.
+func TestDeviceWithoutAnActivePortIsNotReported(t *testing.T) {
+	root := t.TempDir()
+	writeDevice(t, root, "dev0", "1: DOWN")
+	writeDevice(t, root, "dev1", "2: INIT", "3: ARMED")
+
+	devices, err := Inventory{Path: root}.ActiveDevices()
+
+	require.NoError(t, err)
+	assert.Empty(t, devices)
+}
+
+// One active port is enough: a multi-port device is usable through
+// whichever of its ports is up.
+func TestDeviceWithOneActivePortIsReported(t *testing.T) {
+	root := t.TempDir()
+	writeDevice(t, root, "dev0", "1: DOWN", "4: ACTIVE")
+
+	devices, err := Inventory{Path: root}.ActiveDevices()
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dev0"}, devices)
+}
+
+// The numeric prefix belongs to the kernel's enum and carries no
+// promise across versions, so the name after the colon is what is
+// read.
+func TestPortStateIsReadByNameNotNumber(t *testing.T) {
+	root := t.TempDir()
+	writeDevice(t, root, "dev0", "9: ACTIVE")
+
+	devices, err := Inventory{Path: root}.ActiveDevices()
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dev0"}, devices)
+}
+
+// An entry with no ports directory is not a device this can speak
+// for, and sysfs carries entries that are not devices at all.
+func TestEntryWithoutPortsIsSkipped(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.MkdirAll(filepath.Join(root, "not-a-device"), 0o755))
+	writeDevice(t, root, "dev0", "4: ACTIVE")
+
+	devices, err := Inventory{Path: root}.ActiveDevices()
+
+	require.NoError(t, err)
+	assert.Equal(t, []string{"dev0"}, devices)
+}
+
+func TestMalformedStateIsNotActive(t *testing.T) {
+	root := t.TempDir()
+	writeDevice(t, root, "dev0", "ACTIVE")
+	writeDevice(t, root, "dev1", "")
+
+	devices, err := Inventory{Path: root}.ActiveDevices()
+
+	require.NoError(t, err)
+	assert.Empty(t, devices)
+}
+
+func TestDefaultPathIsUsedWhenPathIsEmpty(t *testing.T) {
+	// Reading the real sysfs path must not fail on a host that has no
+	// RDMA hardware, which is where the tests run.
+	_, err := Inventory{}.ActiveDevices()
+
+	require.NoError(t, err)
+}


### PR DESCRIPTION
## Library behaviour

libfabric builds a provider's device list once per process, during the first enumeration of that provider. `vrb_getinfo` guards it behind a function-local `static bool init_done`, and the only path that rebuilds the list is a caller passing `FI_RESCAN`. `mxlFabricsGetInterfaces` takes no flags parameter, so nothing above libmxl-fabrics can ask for a rescan.

Two consequences, both verified rather than assumed:

- A fresh `fabrics.Instance` does not escape the cache. Creating two instances in one process and enumerating through each runs the verbs provider's initialisation exactly once; the second enumeration reuses the first one's list. An in-process re-probe is therefore not available as a fix.
- A gateway that first enumerated while the host's RDMA devices were unusable -- module not loaded, port not up, device node not mounted -- reports `deviceCount: 0` for those providers for the rest of its life, however many times `--probe-period` fires afterwards.

## Resulting defect

The published entry for a provider that went unenumerated is byte-for-byte the entry a host with no RDMA hardware produces. `selection.Resolve` intersects the two nodes' advertised providers, so such a node collapses every intersection to tcp and each mirror is stamped `spec.provider: tcp` at creation. The mirror then reports `Ready` and transfers correctly over sockets. Nothing in the status distinguishes that from a node that has no RDMA hardware at all.

## Change

The gateway now reads the host's RDMA device list from sysfs on each refresh -- a source independent of libfabric's cached list -- and publishes the comparison as a new `RDMADevicesEnumerated` condition on `MxlNodeCapabilities`, with an event on transition.

It reports rather than self-heals, deliberately. An active port is necessary for the verbs provider to offer an endpoint but not sufficient (it also needs an address on the matching interface), so the process cannot prove a stale cache from what it can observe. Restarting the gateway is what re-runs the enumeration; making that decision automatically would crashloop any node whose device is active but legitimately unusable.

Scoped so it cannot produce a false fault:

- Absent when `--providers` admits no RDMA provider: such a node advertises none by instruction, not by measurement.
- Absent when no host device list is configured.
- `Unknown` when the list cannot be read, since the probe result stands on its own measurement.
- `True` when the host exposes no RDMA device, so a node without RDMA hardware is represented by definition rather than faulted.

A device is counted only when at least one of its ports is ACTIVE, read by state name rather than the kernel's enum numbering.

## Verification

`gateway` links libmxl and does not build under a bare `go test`, so the suites were run inside the pinned `go-mxl-builder` image from `Dockerfile`:

```
ok  github.com/qvest-digital/mxl-k8s/gateway/cmd/mxl-fabrics-gateway  0.017s
ok  github.com/qvest-digital/mxl-k8s/gateway/internal/capabilities    0.376s
ok  github.com/qvest-digital/mxl-k8s/gateway/internal/config          0.006s
ok  github.com/qvest-digital/mxl-k8s/gateway/internal/domaingc        0.391s
ok  github.com/qvest-digital/mxl-k8s/gateway/internal/fabric          0.005s
ok  github.com/qvest-digital/mxl-k8s/gateway/internal/mirror          1.637s
ok  github.com/qvest-digital/mxl-k8s/gateway/internal/rdma            0.006s

ok  github.com/qvest-digital/mxl-k8s/api/selection                    0.005s
ok  github.com/qvest-digital/mxl-k8s/api/v1alpha1                     0.005s
```

`agent` and `operator` build clean. `gofmt -l` and `go vet` are clean on the changed packages.

The new tests do not compile against the unmodified tree, and each guard was checked for teeth by mutation rather than by assumption:

| Mutation | Test that failed |
| --- | --- |
| condition forced True | `TestRefresh_ReportsHostDevicesMissingFromTheProbe` |
| drop the empty-host guard | `TestRefresh_HostWithoutRDMADevicesIsRepresented` |
| drop the RDMA-provider-bound guard | `TestRefresh_TCPOnlyBoundLeavesTheConditionUnset` |

The `kind` suite was not run here; CI covers it.