### PR TITLE
build(deps): bump go-mxl to v1.1.0-rc.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.1
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.2
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -163,7 +163,7 @@ jobs:
     if: needs.changes.outputs.exporter == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.1
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.2
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -308,7 +308,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.1
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.2
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7

--- a/docker/demo-tools.Dockerfile
+++ b/docker/demo-tools.Dockerfile
@@ -12,7 +12,7 @@
 #   docker build -f docker/demo-tools.Dockerfile -t local/mxl-demo-tools:dev .
 
 # renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
-ARG GO_MXL_TAG=1.1.0-rc.1
+ARG GO_MXL_TAG=1.1.0-rc.2
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 ARG GO_MXL_TAG

--- a/docker/exporter.Dockerfile
+++ b/docker/exporter.Dockerfile
@@ -6,7 +6,7 @@
 # Build context: repo root.
 
 # renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
-ARG GO_MXL_TAG=1.1.0-rc.1
+ARG GO_MXL_TAG=1.1.0-rc.2
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 WORKDIR /workspace

--- a/docker/gateway.Dockerfile
+++ b/docker/gateway.Dockerfile
@@ -5,7 +5,7 @@
 # Build context: repo root.
 
 # renovate: datasource=docker depName=ghcr.io/qvest-digital/go-mxl-builder
-ARG GO_MXL_TAG=1.1.0-rc.1
+ARG GO_MXL_TAG=1.1.0-rc.2
 
 FROM ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG} AS builder
 WORKDIR /workspace

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/prometheus/client_golang v1.24.1
-	github.com/qvest-digital/go-mxl v1.1.0-rc.1
+	github.com/qvest-digital/go-mxl v1.1.0-rc.2
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.13 // x-release-please-version
 	golang.org/x/sys v0.47.0
 	k8s.io/apimachinery v0.37.0

--- a/exporter/go.sum
+++ b/exporter/go.sum
@@ -120,6 +120,8 @@ github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/qvest-digital/go-mxl v1.1.0-rc.1 h1:CUg29Q5c/JA6pqyA5gP3vu7JBr8lRXbOOxC+r0W572s=
 github.com/qvest-digital/go-mxl v1.1.0-rc.1/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.1.0-rc.2 h1:J1EiiOwy9cEZK1djv8uI3fFP2Oq228Y2Sft/y5sE6D4=
+github.com/qvest-digital/go-mxl v1.1.0-rc.2/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/gateway
 go 1.26.0
 
 require (
-	github.com/qvest-digital/go-mxl v1.1.0-rc.1
+	github.com/qvest-digital/go-mxl v1.1.0-rc.2
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.13 // x-release-please-version
 	github.com/stretchr/testify v1.12.1
 	go.uber.org/goleak v1.3.0

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -124,6 +124,8 @@ github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
 github.com/qvest-digital/go-mxl v1.1.0-rc.1 h1:CUg29Q5c/JA6pqyA5gP3vu7JBr8lRXbOOxC+r0W572s=
 github.com/qvest-digital/go-mxl v1.1.0-rc.1/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.1.0-rc.2 h1:J1EiiOwy9cEZK1djv8uI3fFP2Oq228Y2Sft/y5sE6D4=
+github.com/qvest-digital/go-mxl v1.1.0-rc.2/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=


### PR DESCRIPTION
The binding moves onto a libmxl build whose flow writers refuse a write
at or below the last committed index and clear the range a forward jump
skips, so a reader can no longer observe payload left behind by an
earlier pass of the ring. The discrete writer also stops advancing that
index when only part of a grain's slices were written.

The builder image tag moves with it. That image compiles libfabric and
rdma-core in rather than resolving them at run time, so the same bump
carries libfabric `v2.6.0` and rdma-core `v64.0`.

No API moved, so there are no call site changes: only the `require`
lines, their `go.sum` entries, the `GO_MXL_TAG` defaults and the CI
image reference.

Verified against the published `go-mxl-builder:1.1.0-rc.2`: all five
modules build, and `go test ./...` passes for api, gateway, exporter,
agent and operator. `pkg-config --modversion libfabric` reports `2.6.0`
in that image. The gateway suite also passes under `-race`.

`go get` was used rather than `go mod tidy`: tidy additionally prunes
three indirect requirements that are already unnecessary on `main`
before this change, which is unrelated churn.