### PR TITLE
fix(gateway): blocking MakeProgress for verbs, grain-rate audio tick

### DIFF
--- a/gateway/internal/mirror/iface.go
+++ b/gateway/internal/mirror/iface.go
@@ -58,8 +58,9 @@ type TransferFunc func(idx uint64, paced bool) (skipped bool, err error)
 type TransferSlicesFunc func(idx uint64, start, end uint16) error
 
 // ProgressFunc drives libmxl-fabrics's event/completion queues.
-// Production calls Initiator.MakeProgressNonBlocking; the loop
-// tolerates fabrics.ErrNotReady silently.
+// Production selects the blocking or non-blocking variant per
+// provider (see progressFuncFor); the loop tolerates
+// fabrics.ErrNotReady silently.
 type ProgressFunc func() error
 
 // ReadGrainFunc waits for the target side to report an arrived grain.

--- a/gateway/internal/mirror/progress_mode_test.go
+++ b/gateway/internal/mirror/progress_mode_test.go
@@ -1,0 +1,51 @@
+package mirror
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+	"github.com/qvest-digital/go-mxl/mxl"
+)
+
+// progressBlocking partitions the fabric providers by whether their
+// completion queue needs a blocking MakeProgress call. EFA drains its
+// CQ on the provider's own event queue, so a non-blocking poll is
+// correct. The verbs provider does not, and a non-blocking poll returns
+// before the NIC finishes the DMA -- so the send queue fills and the
+// next transfer call returns EAGAIN. TCP and SHM are loopback, where
+// blocking is harmless but buys nothing; the selection keeps them on
+// the blocking path because the cost is one short sleep and the
+// benefit is a drained CQ on every provider that is not EFA.
+func TestProgressBlocking_PartitionsEFAFromEverythingElse(t *testing.T) {
+	assert.False(t, progressBlocking(fabrics.ProviderEFA),
+		"EFA drains its completion queue on the provider's event queue; a blocking call adds latency without improving throughput")
+	for _, p := range []fabrics.Provider{
+		fabrics.ProviderVerbs,
+		fabrics.ProviderTCP,
+		fabrics.ProviderSHM,
+		fabrics.ProviderAny,
+	} {
+		assert.True(t, progressBlocking(p),
+			"provider %s needs a blocking MakeProgress so the CQ drains before the next transfer", p)
+	}
+}
+
+func TestDefaultSampleProgressInterval_48kHz(t *testing.T) {
+	// 48000/1 with a 480-sample batch: 480/48000 s = 10 ms.
+	got := defaultSampleProgressInterval(mxl.Rational{Num: 48000, Den: 1}, 480)
+	assert.Equal(t, 10*time.Millisecond, got,
+		"48 kHz with a 480-sample batch should yield a 10 ms interval")
+}
+
+func TestDefaultSampleProgressInterval_ZeroBatchFallsBack(t *testing.T) {
+	assert.Zero(t, defaultSampleProgressInterval(mxl.Rational{Num: 48000, Den: 1}, 0),
+		"a zero batch leaves the interval to the caller's fallback")
+}
+
+func TestDefaultSampleProgressInterval_ZeroRateFallsBack(t *testing.T) {
+	assert.Zero(t, defaultSampleProgressInterval(mxl.Rational{}, 480),
+		"a zero rate leaves the interval to the caller's fallback")
+}

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -761,7 +761,23 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 
 	progressInterval := o.ProgressInterval
 	if progressInterval <= 0 {
-		progressInterval = 2 * time.Millisecond
+		// A continuous (audio) flow's head advances by many samples
+		// per tick, so the loop calls TransferSamples once per tick
+		// for the whole (lastSent, head] delta. A 2 ms tick at 48 kHz
+		// means ~96 samples per call, ~500 calls/second -- five times
+		// the call rate of one batch per natural commit period. Each
+		// call is a cgo boundary crossing plus one RMA write, so the
+		// higher rate fills the send queue faster than the verbs
+		// completion queue drains it. Default the tick to the xferBatch
+		// period instead: ~10 ms at 48 kHz, ~100 calls/second, one call
+		// per natural batch -- matching the cadence the upstream
+		// reference transfer loop uses.
+		if audio && xferBatch > 0 {
+			progressInterval = defaultSampleProgressInterval(cfg.Common.GrainRate, xferBatch)
+		}
+		if progressInterval <= 0 {
+			progressInterval = 2 * time.Millisecond
+		}
 	}
 	// Zero means "not configured" and takes the default, which is
 	// itself negative; a negative fraction is how pacing is turned off,
@@ -781,7 +797,17 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 		}
 		return rt.HeadIndex, nil
 	}
-	progressFn := initiator.MakeProgressNonBlocking
+	// EFA reports completions through its own event queue, so a
+	// non-blocking poll is the right call. The verbs provider does
+	// not: fi_cq_read returns -EAGAIN when no completion has landed,
+	// and the send queue fills before the next tick drains it.
+	// MakeProgressBlocking parks on the completion queue for a
+	// bounded timeout, giving the NIC time to finish the DMA and
+	// free the send slot. The timeout matches the target-side
+	// read timeout (targetReadTimeout) rather than the tick: a
+	// tick-aligned timeout would return before a slow completion
+	// landed, and the queue would fill anyway.
+	progressFn := progressFuncFor(initiator, provider)
 
 	if audio {
 		// Resolved on the first transfer and reused: the width is fixed
@@ -1047,8 +1073,8 @@ func runTransferLoop(
 // The cgo-dependent calls are injected as functions so the state
 // machine stays testable without libmxl-fabrics. Production binds
 // probeRuntime to mxl.Reader.Runtime().HeadIndex, transferSamples to
-// Initiator.TransferSamples, and makeProgress to
-// Initiator.MakeProgressNonBlocking.
+// Initiator.TransferSamples, and makeProgress to the provider-specific
+// variant selected by progressFuncFor.
 // sampleFrameBytes is the payload one sample of a continuous flow
 // occupies across all its channels.
 //
@@ -1848,6 +1874,59 @@ func (r *SourceReconciler) flowToMirrors(ctx context.Context, obj client.Object)
 // where the head is re-read and the wedge becomes visible as a stalled
 // lastSent.
 const maxSampleTransferRetries = 8
+
+// defaultProgressTimeout caps how long a blocking MakeProgress call
+// parks on the completion queue before returning. The verbs provider
+// needs this: fi_cq_read returns -EAGAIN when no completion has
+// landed, and a non-blocking poll returns before the NIC finishes
+// the DMA, so the send queue fills and the next TransferSamples
+// call returns EAGAIN. Blocking for the timeout gives the NIC time
+// to complete the write and free the send slot. EFA does not need
+// it: its completion queue drains on the provider's own event
+// queue, and a blocking poll adds latency without improving
+// throughput. The timeout matches targetReadTimeout rather than
+// the tick interval: a tick-aligned timeout would return before a
+// slow completion landed, and the queue would fill anyway.
+const defaultProgressTimeout = 10 * time.Millisecond
+
+// defaultSampleProgressInterval returns the progress interval a
+// continuous (audio) flow uses when the operator has not configured
+// one. It is the time spanned by one xferBatch of samples at the
+// flow's grain (sample) rate: ~10 ms at 48 kHz with a 480-sample
+// batch, matching the natural commit cadence the reference transfer
+// loop uses. Zero when the rate or batch is unusable, so the caller
+// falls back to the 2 ms video default.
+func defaultSampleProgressInterval(rate mxl.Rational, xferBatch uint64) time.Duration {
+	if xferBatch == 0 || rate.Den <= 0 || rate.Num <= 0 {
+		return 0
+	}
+	return time.Duration(int64(time.Second) * int64(rate.Den) * int64(xferBatch) / int64(rate.Num))
+}
+
+// progressBlocking reports whether the provider's completion queue
+// needs a blocking MakeProgress call. EFA drains its completion queue
+// on the provider's own event queue, so a non-blocking poll is
+// correct. The verbs provider does not: fi_cq_read returns -EAGAIN
+// when no completion has landed, and a non-blocking poll returns
+// before the NIC finishes the DMA, so the send queue fills and the
+// next transfer call returns EAGAIN. A blocking call parks on the
+// completion queue for defaultProgressTimeout, giving the NIC time
+// to complete the write and free the send slot.
+func progressBlocking(provider fabrics.Provider) bool {
+	return provider != fabrics.ProviderEFA
+}
+
+// progressFuncFor selects the MakeProgress variant the transfer loop
+// drives, keyed on the fabric provider. See progressBlocking for the
+// rationale.
+func progressFuncFor(initiator *fabrics.Initiator, provider fabrics.Provider) ProgressFunc {
+	if !progressBlocking(provider) {
+		return initiator.MakeProgressNonBlocking
+	}
+	return func() error {
+		return initiator.MakeProgress(defaultProgressTimeout)
+	}
+}
 
 // logSampleTransferFailure renders a TransferSamples failure at a level
 // that matches what it means. A full send queue that outlived its


### PR DESCRIPTION
The source-side transfer loop hardcoded `Initiator.MakeProgressNonBlocking` for every fabric provider. On the verbs provider a non-blocking poll returns before the NIC finishes the DMA, the completion queue stays empty, and the send queue fills. The next `TransferSamples` call hits a full send queue and returns EAGAIN; the retry loop calls `MakeProgressNonBlocking` up to 8 times but none wait for completions, so the queue never drains and the chunk is abandoned. At a 2 ms tick the audio path generates ~500 `TransferSamples` calls/second, each needing an RMA write the verbs NIC takes longer than 2 ms to complete on average -- so the send queue fills faster than it drains, and the loop skips samples and publishes `ReaderAgedOut` for a queue that was merely busy.

Two changes, both in `gateway/internal/mirror/source.go`:

1. **Per-provider progress function.** `progressFuncFor` selects `MakeProgressNonBlocking` for EFA (whose completion queue drains on the provider event queue) and `MakeProgressBlocking` with a 10 ms timeout for every other provider (verbs, TCP, SHM). The blocking call parks on the completion queue, giving the NIC time to finish the DMA and free the send slot. The timeout matches `targetReadTimeout` rather than the tick: a tick-aligned timeout would return before a slow completion landed.

2. **Grain-rate-aligned audio interval.** When the operator has not configured a `ProgressInterval`, the audio path defaults to the `xferBatch` period (~10 ms at 48 kHz) rather than the 2 ms video default. This reduces the `TransferSamples` call rate from ~500/second to ~100/second, one call per natural commit batch, matching the cadence the reference transfer loop uses.

The video (grain) path is not broken -- at 50 fps there is 20 ms between grains, so the send queue drains within the 2 ms tick -- but it picks up the blocking progress automatically since `progressFn` is shared by both loops. There is no downside: a 10 ms blocking poll on a provider whose completions arrive in under 2 ms returns immediately.