### PR TITLE
refactor(gateway): share one initiator per flow on the source side

### DIFF
--- a/docs/architecture/03-node-anatomy.md
+++ b/docs/architecture/03-node-anatomy.md
@@ -215,7 +215,16 @@ Three details from the diagram are worth pulling out:
   on-disk flow definition and any consumer `FlowReader` handles
   point at it. The new `TargetInfo` is published into status; the
   source side detects the rotation through its existing watch and
-  reopens its initiator.
+  swaps that one target on its initiator.
+- **One initiator per flow on the source side.** libmxl-fabrics
+  enqueues each `TransferGrain` / `TransferSamples` call to every
+  target added to an initiator, so a flow mirrored from this node to
+  several others is one `FlowReader`, one `Initiator` and one
+  transfer goroutine, with one `AddTarget` per mirror. Per-mirror
+  state is the target handle and the status counters; the reader,
+  the initiator and the loop are keyed on (flow, provider), because
+  an initiator is set up against one interface and that interface is
+  chosen per provider.
 
 There is no application-level backpressure on the source side: the
 transfer goroutine forwards every grain it sees in

--- a/gateway/internal/mirror/common.go
+++ b/gateway/internal/mirror/common.go
@@ -11,9 +11,13 @@
 //   - SourceReconciler is the sending half. For mirrors whose
 //     sourceNode is this gateway's node and that already carry a
 //     status.targetInfo, it opens a FlowReader on the local flow,
-//     builds a fabrics.Initiator + AddTarget(targetInfo), and runs a
-//     per-flow goroutine that calls TransferGrain on every grain the
-//     reader sees and MakeProgress on a tick.
+//     builds a fabrics.Initiator over it, and runs a per-flow
+//     goroutine that calls TransferGrain on every grain the reader
+//     sees and MakeProgress on a tick. The reader, the initiator and
+//     the goroutine are shared by every mirror of one flow on one
+//     provider: libmxl-fabrics enqueues a transfer to every target an
+//     initiator holds, so a mirror costs one AddTarget rather than a
+//     second copy of all three.
 //
 // The two reconcilers operate on disjoint mirror sets (one mirror has
 // a single targetNode and a single sourceNode, only one of which can

--- a/gateway/internal/mirror/iface.go
+++ b/gateway/internal/mirror/iface.go
@@ -17,18 +17,37 @@ import "github.com/qvest-digital/go-mxl/fabrics"
 // stay where they were, and only their parameter list changed.
 
 // initiatorOpener is the source reconciler's seam onto the
-// cgo-dependent libmxl-fabrics Initiator setup path. Production
-// binds it to libmxlOpener, which is a thin struct wrapping the
-// existing FlowReader + Initiator + AddTarget sequence.
-// Tests bind it to an inline fake whose open method returns canned
-// sourceEntry values without touching libmxl or libmxl-fabrics.
+// cgo-dependent libmxl-fabrics Initiator paths. Production binds it to
+// libmxlOpener, a thin struct wrapping the FlowReader + Initiator +
+// AddTarget calls. Tests bind it to an inline fake that returns canned
+// values without touching libmxl or libmxl-fabrics.
+//
+// The split between open and attach is the shape of the API it wraps:
+// an initiator fans a transfer out to every target added to it, so the
+// reader, the initiator and the transfer loop are per flow, and only
+// AddTarget is per mirror.
 //
 // The interface keeps the production binary free of a swappable
 // function pointer that a malicious or buggy caller could redirect
 // at runtime: the field on SourceReconciler is an interface value
 // the constructor sets once and never reassigns.
 type initiatorOpener interface {
-	open(flowID, targetInfoStr string, provider fabrics.Provider) (*sourceEntry, error)
+	// open builds the per-flow half: a FlowReader on flowID, an
+	// Initiator set up against it on an interface the provider can
+	// carry, and the transfer goroutine feeding one into the other. It
+	// adds no target, so nothing is transferred until attach runs.
+	open(flowID string, provider fabrics.Provider) (*sharedSource, error)
+
+	// attach adds one target to an already-open shared initiator and
+	// returns the handle detach needs. An AddTarget failure is wrapped
+	// in errAddTargetFailed so the reconciler can back off without
+	// rebuilding the reader.
+	attach(s *sharedSource, targetInfoStr string) (*fabrics.TargetInfo, error)
+
+	// detach removes one target and closes its handle, leaving the
+	// shared reader, initiator and transfer loop running for the
+	// targets that remain.
+	detach(s *sharedSource, info *fabrics.TargetInfo)
 }
 
 // RuntimeProbe asks the source-side flow reader for the current head

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -1,9 +1,11 @@
 package mirror
 
 import (
+	"cmp"
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -177,49 +179,136 @@ type SourceReconciler struct {
 	// question is not what they are exercising.
 	writerLiveFn func(flowID string) (bool, error)
 
-	mu       sync.Mutex
+	mu sync.Mutex
+	// sources holds the per-mirror half, keyed by MxlFlowMirror;
+	// shared holds the per-flow half every mirror of one flow on one
+	// provider transfers through.
 	sources  map[types.NamespacedName]*sourceEntry
+	shared   map[sourceKey]*sharedSource
 	attempts attemptTable[sourceAddInputs]
-	// rebuilds counts consecutive reader reopens per mirror. It
-	// outlives the sourceEntry the watchdog tears down, which is the
+	// rebuilds counts consecutive reader reopens per shared source. It
+	// outlives the sharedSource the watchdog tears down, which is the
 	// point: the budget has to survive the reopen it is bounding.
-	rebuilds map[types.NamespacedName]uint32
+	//
+	// Keyed by shared source rather than by mirror because that is what
+	// the watchdog now tears down. A per-mirror budget would let a flow
+	// mirrored to N nodes spend N times maxReaderRebuilds reopens on the
+	// one reader they share, so the cap that is meant to stop a gateway
+	// reopening a dead ring forever would scale with fan-out.
+	rebuilds map[sourceKey]uint32
 }
 
-// sourceEntry holds the live libmxl + fabrics handles and the
-// transfer-loop control plumbing for one source-side mirror.
-type sourceEntry struct {
+// sourceKey identifies one shared source: the libmxl FlowReader on a
+// flow and the libmxl-fabrics Initiator pinned to it.
+//
+// The provider is part of the key because an initiator is set up
+// against one interface, and resolveInterface picks that interface per
+// provider. Two mirrors of the same flow that ask for different
+// providers therefore cannot share an initiator, and get one shared
+// source each.
+type sourceKey struct {
+	flowID   string
+	provider fabrics.Provider
+}
+
+// sharedSource owns what the source side has per flow rather than per
+// mirror: one FlowReader on the local flow, one Initiator pinned to
+// it, and the transfer goroutine that pumps one into the other.
+//
+// libmxl-fabrics fans a transfer out to every target added to an
+// initiator: one TransferGrain or TransferSamples call enqueues the
+// payload to all of them. Mirroring one flow to N nodes is therefore N
+// AddTarget calls on one initiator, not N initiators. Opening one per
+// mirror read the same ring N times and posted N copies of every grain
+// to the NIC.
+type sharedSource struct {
+	key sourceKey
+
 	reader    *mxl.Reader
 	initiator *fabrics.Initiator
-	info      *fabrics.TargetInfo
-	// infoStr is the serialized TargetInfo the initiator was set up
-	// with. We keep it so a later reconcile can detect that the
-	// target has rotated its info (e.g. the target-side gateway pod
-	// restarted and re-opened the FlowWriter) and reopen the
-	// initiator against the fresh address before the source's writes
-	// keep getting refused.
+
+	// mirrors is the attached set, written under the reconciler's mutex.
+	// fanout is the same set as an immutable slice the transfer
+	// goroutine reads without taking any lock, so accounting a grain
+	// never contends with a reconcile and the transfer path never blocks
+	// on a mutex Reconcile also holds.
+	mirrors map[types.NamespacedName]*sourceEntry
+	fanout  atomic.Pointer[[]*sourceEntry]
+
+	// lastHead is the most recent head index the transfer loop probed
+	// off the FlowReader; headAdvancedAt is when that value last
+	// changed. Fanned out to every attached mirror so each flusher can
+	// tell a wedged reader from one still waiting on its first grain.
+	//
+	// openedAt is the wall-clock time this FlowReader was opened, and
+	// lastObservedOriginAt the MxlFlow status.locations entry's
+	// AppearedAt timestamp for r.NodeName at that moment. A subsequent
+	// reconcile that sees a newer timestamp tears the reader down and
+	// reopens it so the gateway tails the freshly rebound writer. May be
+	// nil (the location carried no AppearedAt at open time); see
+	// originRotated for how that case is handled. Per flow, not per
+	// mirror: the reader is what rotates.
+	openedAt             time.Time
+	lastObservedOriginAt atomic.Pointer[time.Time]
+
+	// rebuilding is set by the reader-stall watchdog before it hands
+	// the source to the reopen goroutine, so a second flusher tick --
+	// this mirror's or any other attached mirror's -- cannot spawn a
+	// competing rebuild for the same reader.
+	rebuilding atomic.Bool
+
+	// cancel stops the transfer goroutine; done is closed when it
+	// returns.
+	cancel context.CancelFunc
+	done   chan struct{}
+}
+
+// sourceEntry is one MxlFlowMirror's share of a sharedSource: the
+// fabrics target it added, and the counters its own status flusher and
+// the throughput collector read.
+//
+// The counters stay per mirror even though one transfer feeds them
+// all. That is not an approximation: a TransferGrain call really does
+// enqueue the grain to every added target, so every attached mirror
+// really did move those bytes and really is at that index. Collapsing
+// them onto the shared source would cost the per-peer label the
+// throughput collector separates its series by.
+type sourceEntry struct {
+	// key is this entry's MxlFlowMirror. A teardown that starts from
+	// the shared source needs it to find its way back to r.sources.
+	key types.NamespacedName
+
+	// shared is the (flow, provider) source this mirror is a target of.
+	shared *sharedSource
+
+	// info is the fabrics target added to the shared initiator for this
+	// mirror, and the handle RemoveTarget needs to take it off again.
+	info *fabrics.TargetInfo
+
+	// infoStr is the serialized TargetInfo the target was added with.
+	// We keep it so a later reconcile can detect that the target has
+	// rotated its info (e.g. the target-side gateway pod restarted and
+	// re-opened the FlowWriter) and re-add it against the fresh address
+	// before the source's writes keep getting refused.
 	infoStr string
 
-	// progress counts grains the transfer loop has successfully
-	// handed to TransferGrain. lastSentAt records the wall-clock
-	// time of the most recent successful transfer. Both feed the
-	// per-mirror status flusher.
+	// peerNode labels this mirror's byte counter, and is what keeps the
+	// label set unique when one node mirrors the same flow to several
+	// targets. Immutable for the life of the entry, so the collector
+	// reads it without the entry's atomics.
+	peerNode string
+
+	// progress counts grains the transfer loop has successfully handed
+	// to TransferGrain. lastSentAt records the wall-clock time of the
+	// most recent successful transfer. Both feed the status flusher.
 	progress   atomic.Uint64
 	lastSentAt atomic.Pointer[time.Time]
 
-	// bytes counts payload actually handed to the fabric for this
-	// mirror, read by the throughput collector at scrape time. A
-	// counter rather than a rate: the scrape interval is the
-	// collector's business, not the transfer loop's.
+	// bytes counts payload handed to the fabric for this mirror, read
+	// by the throughput collector at scrape time. A counter rather than
+	// a rate: the scrape interval is the collector's business, not the
+	// transfer loop's.
 	bytes atomic.Uint64
-
-	// flowID, peerNode and provider label that counter. Immutable for
-	// the life of the entry, so the collector reads them without the
-	// entry's atomics. peerNode is what keeps the label set unique
-	// when one node mirrors the same flow to several targets.
-	flowID   string
-	peerNode string
-	provider fabrics.Provider
 
 	// agedOutAt records the wall-clock of the most recent
 	// reader-aged-out skip the transfer loop has had to perform.
@@ -229,10 +318,8 @@ type sourceEntry struct {
 	// the ring.
 	agedOutAt atomic.Pointer[time.Time]
 
-	// lastHead is the most recent head index the transfer loop probed
-	// off the FlowReader; headAdvancedAt is when that value last
-	// changed. The flusher reads both to tell a wedged reader from one
-	// still waiting on its first grain.
+	// lastHead and headAdvancedAt carry the shared reader's head
+	// observations, fanned out on every probe.
 	lastHead       atomic.Uint64
 	headAdvancedAt atomic.Pointer[time.Time]
 
@@ -242,35 +329,83 @@ type sourceEntry struct {
 	addTargetAttempts atomic.Uint32
 	lastError         atomic.Pointer[string]
 
-	// lastObservedOriginAt records the MxlFlow status.locations
-	// entry's AppearedAt timestamp for r.NodeName at the moment
-	// the FlowReader was opened. A subsequent reconcile that sees
-	// a newer timestamp tears the reader down and reopens it so
-	// the gateway tails the freshly rebound writer. May be nil (the
-	// location carried no LastObserved at open time); see
-	// originRotated for how that case is handled.
-	lastObservedOriginAt atomic.Pointer[time.Time]
-
-	// openedAt is the wall-clock time this entry's FlowReader was
-	// opened. Read-only after construction, set before the entry is
-	// published into r.sources under r.mu -- safe to read from
-	// Reconcile without its own synchronization, same as infoStr.
+	// openedAt is the wall-clock time this mirror's target was added.
+	// Read-only after construction, set before the entry is published
+	// into r.sources under r.mu -- safe to read from Reconcile without
+	// its own synchronization, same as infoStr.
 	openedAt time.Time
-
-	// rebuilding is set by the reader-stall watchdog before it hands
-	// the entry to the reopen goroutine, so a second flusher tick
-	// cannot spawn a competing rebuild for the same entry.
-	rebuilding atomic.Bool
-
-	// cancel stops the per-flow transfer goroutine; done is closed
-	// when the goroutine returns.
-	cancel context.CancelFunc
-	done   chan struct{}
 
 	// flusherCancel stops the per-mirror status flusher; flusherDone
 	// is closed when it returns.
 	flusherCancel context.CancelFunc
 	flusherDone   chan struct{}
+}
+
+// sourceKey reports the shared source this mirror transfers through.
+func (e *sourceEntry) sourceKey() sourceKey {
+	if e.shared == nil {
+		return sourceKey{}
+	}
+	return e.shared.key
+}
+
+func (e *sourceEntry) flowID() string { return e.sourceKey().flowID }
+
+func (e *sourceEntry) provider() fabrics.Provider { return e.sourceKey().provider }
+
+// attach adds e to the fanout set. Callers hold the reconciler mutex.
+func (s *sharedSource) attach(e *sourceEntry) {
+	if s.mirrors == nil {
+		s.mirrors = make(map[types.NamespacedName]*sourceEntry)
+	}
+	s.mirrors[e.key] = e
+	s.republish()
+}
+
+// detach drops key from the fanout set and reports whether the set is
+// now empty, which is the only point at which the shared handles may
+// be closed. Callers hold the reconciler mutex.
+func (s *sharedSource) detach(key types.NamespacedName) bool {
+	delete(s.mirrors, key)
+	s.republish()
+	return len(s.mirrors) == 0
+}
+
+// detachAll empties the fanout set and returns what was in it, so a
+// caller tearing the whole source down can stop each mirror's flusher
+// and remove each mirror's target. Callers hold the reconciler mutex.
+func (s *sharedSource) detachAll() []*sourceEntry {
+	out := make([]*sourceEntry, 0, len(s.mirrors))
+	for _, e := range s.mirrors {
+		out = append(out, e)
+	}
+	slices.SortFunc(out, func(a, b *sourceEntry) int {
+		return cmp.Or(
+			cmp.Compare(a.key.Namespace, b.key.Namespace),
+			cmp.Compare(a.key.Name, b.key.Name),
+		)
+	})
+	s.mirrors = nil
+	s.republish()
+	return out
+}
+
+// republish rebuilds the immutable slice the transfer goroutine reads.
+func (s *sharedSource) republish() {
+	list := make([]*sourceEntry, 0, len(s.mirrors))
+	for _, e := range s.mirrors {
+		list = append(list, e)
+	}
+	s.fanout.Store(&list)
+}
+
+// attached returns the current fanout snapshot. Safe to call from the
+// transfer goroutine: the slice is never mutated once stored.
+func (s *sharedSource) attached() []*sourceEntry {
+	if p := s.fanout.Load(); p != nil {
+		return *p
+	}
+	return nil
 }
 
 // +kubebuilder:rbac:groups=mxl.qvest-digital.com,resources=mxlflowmirrors,verbs=get;list;watch;update;patch
@@ -338,9 +473,9 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	if mirror.Spec.SourceNode != r.NodeName {
 		// spec.sourceNode used to name this node and was mutated to
-		// another; the in-memory sources map keeps an RCInitiator open
+		// another; the in-memory sources map keeps an initiator open
 		// against a producer-less .mxl-flow until the pod is bounced.
-		// closeEntry is a no-op when key absent (def at line 592).
+		// closeEntry is a no-op when the key holds nothing.
 		r.closeEntry(req.NamespacedName)
 		return r.reapOrphanedFinalizer(ctx, &mirror)
 	}
@@ -384,41 +519,10 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	// originAt is the MxlFlow's most recent AppearedAt timestamp
 	// for the Origin location on this node. It is read once here so
-	// the fast-path comparison below and the openInitiator handoff
-	// both observe the same value, and a later rotation is detected
+	// the rotation comparison below and the openShared handoff both
+	// observe the same value, and a later rotation is detected
 	// even if the MxlFlow watch fires before status propagates.
 	originAt := r.observedOriginAt(ctx, mirror.Spec.FlowID)
-
-	// Already set up against this exact target info?
-	r.mu.Lock()
-	existing := r.sources[req.NamespacedName]
-	r.mu.Unlock()
-	if existing != nil {
-		// MxlFlow Origin location for this node has rotated since
-		// the FlowReader was opened (the writer-side agent
-		// re-registered the flow, typically after a pod restart).
-		// Tear down + reopen so the reader tails the fresh writer
-		// instead of holding a handle on a now-invalid ring.
-		if originRotated(existing.lastObservedOriginAt.Load(), originAt, existing.openedAt) {
-			l.Info("flow origin rotated, reopening reader")
-			r.closeEntry(req.NamespacedName)
-		} else if existing.infoStr == mirror.Status.TargetInfo {
-			return ctrl.Result{}, nil
-		} else {
-			// TargetInfo rotated under us (typically: target gateway
-			// restarted and rebuilt the writer on a fresh ephemeral
-			// port). Tear down the stale initiator so we re-open
-			// against the new address. The target side also lands
-			// here after recoverFromFatalError republishes
-			// status.targetInfo via SSA on its Ready transition --
-			// the infoStr comparison above is the source initiator's
-			// only wake-up signal for that rotation, so do not add a
-			// spec-only predicate to the MxlFlowMirror watch or
-			// recovery wakes will be silently dropped.
-			l.Info("target info rotated, rebuilding initiator")
-			r.closeEntry(req.NamespacedName)
-		}
-	}
 
 	provider, err := providerForSetup(&mirror)
 	if err != nil {
@@ -434,6 +538,75 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		}
 		l.Info("refusing source setup: mirror provider is unresolved", "error", err.Error())
 		return ctrl.Result{}, nil
+	}
+
+	// Resolved before the fast path rather than after it, because the
+	// provider is half the identity of the shared source this mirror
+	// belongs to.
+	skey := sourceKey{flowID: mirror.Spec.FlowID, provider: provider}
+
+	r.mu.Lock()
+	existing := r.sources[req.NamespacedName]
+	r.mu.Unlock()
+
+	// spec.provider rotated under a running mirror. An initiator is set
+	// up against one provider's interface and cannot serve another, so
+	// this mirror leaves the source it was sharing and joins the one
+	// for its new provider.
+	if existing != nil && existing.sourceKey() != skey {
+		l.Info("mirror provider rotated, moving to a fresh initiator")
+		r.closeEntry(req.NamespacedName)
+		existing = nil
+	}
+
+	r.mu.Lock()
+	shared := r.shared[skey]
+	r.mu.Unlock()
+
+	// The MxlFlow Origin location for this node has rotated since the
+	// FlowReader was opened (the writer-side agent re-registered the
+	// flow, typically after a pod restart). Tear down + reopen so the
+	// reader tails the fresh writer instead of holding a handle on a
+	// now-invalid ring.
+	//
+	// Judged against the shared source rather than against this
+	// mirror's entry, because the reader is what rotates: a mirror
+	// attaching to a source that was opened before the rotation would
+	// otherwise inherit the dead ring and never look again.
+	if shared != nil && originRotated(shared.lastObservedOriginAt.Load(), originAt, shared.openedAt) {
+		l.Info("flow origin rotated, reopening reader")
+		for _, k := range r.closeSharedSource(skey) {
+			if k == req.NamespacedName {
+				continue
+			}
+			// Every mirror that shared the reader lost it. Driving
+			// them here rather than waiting for a watch keeps the
+			// reopen self-contained, for the same reason
+			// rebuildWedgedReader drives its own: the events that
+			// would wake them stop precisely when the producer is in
+			// trouble.
+			r.reopenEvicted(ctx, k)
+		}
+		existing = nil
+	}
+
+	if existing != nil {
+		if existing.infoStr == mirror.Status.TargetInfo {
+			return ctrl.Result{}, nil
+		}
+		// TargetInfo rotated under us (typically: target gateway
+		// restarted and rebuilt the writer on a fresh ephemeral
+		// port). Take this mirror's target off the shared initiator
+		// so it is re-added against the new address; the other
+		// mirrors on this flow keep transferring throughout. The
+		// target side also lands here after recoverFromFatalError
+		// republishes status.targetInfo via SSA on its Ready
+		// transition -- the infoStr comparison above is the source
+		// initiator's only wake-up signal for that rotation, so do
+		// not add a spec-only predicate to the MxlFlowMirror watch or
+		// recovery wakes will be silently dropped.
+		l.Info("target info rotated, re-adding target")
+		r.closeEntry(req.NamespacedName)
 	}
 
 	// Seed the in-memory AddTarget attempts counter from the persisted
@@ -475,18 +648,33 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 		return ctrl.Result{RequeueAfter: writerAbsentRetry}, nil
 	}
 
-	entry, err := r.opener.open(mirror.Spec.FlowID, mirror.Status.TargetInfo, provider)
+	// Reuses the source the fast path looked up when it is still
+	// live, and opens one when this is the flow's first mirror or the
+	// origin rotation above tore the previous one down.
+	shared, err = r.openShared(skey, originAt)
 	if err != nil {
+		return ctrl.Result{}, fmt.Errorf("open initiator: %w", err)
+	}
+
+	// The only per-mirror libmxl-fabrics work there is. A source that
+	// already carries other mirrors of this flow takes just this call:
+	// no second reader, no second initiator, no second transfer loop.
+	info, err := r.opener.attach(shared, mirror.Status.TargetInfo)
+	if err != nil {
+		r.releaseIfUnused(shared)
 		if errors.Is(err, errAddTargetFailed) {
 			return r.handleAddTargetFailure(ctx, req.NamespacedName, inputs, err)
 		}
-		return ctrl.Result{}, fmt.Errorf("open initiator: %w", err)
+		return ctrl.Result{}, fmt.Errorf("add target: %w", err)
 	}
-	entry.openedAt = time.Now()
-	entry.peerNode = mirror.Spec.TargetNode
-	if originAt != nil {
-		t := *originAt
-		entry.lastObservedOriginAt.Store(&t)
+
+	entry := &sourceEntry{
+		key:      req.NamespacedName,
+		shared:   shared,
+		info:     info,
+		infoStr:  mirror.Status.TargetInfo,
+		peerNode: mirror.Spec.TargetNode,
+		openedAt: time.Now(),
 	}
 	// Carry the published lastSentAt onto the fresh entry: a rebuilt
 	// entry has no transfers of its own, and an omitted field is one
@@ -500,20 +688,83 @@ func (r *SourceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 	r.mu.Lock()
 	if dup := r.sources[req.NamespacedName]; dup != nil {
 		r.mu.Unlock()
-		closeSourceHandles(entry)
+		r.opener.detach(shared, info)
+		r.releaseIfUnused(shared)
 		return ctrl.Result{}, nil
 	}
 	r.sources[req.NamespacedName] = entry
+	shared.attach(entry)
 	delete(r.attempts, req.NamespacedName)
 	r.mu.Unlock()
 
-	r.startFlusher(req.NamespacedName, entry)
+	r.startFlusher(entry)
 
-	l.Info("initiator running",
+	l.Info("target added",
 		"flowID", mirror.Spec.FlowID,
 		"targetNode", mirror.Spec.TargetNode,
-		"provider", provider.String())
+		"provider", provider.String(),
+		"targets", len(shared.attached()))
 	return ctrl.Result{}, nil
+}
+
+// openShared returns the shared source for skey, opening one if this
+// is the first mirror to want it. The libmxl work happens outside the
+// reconciler's mutex, so a concurrent opener can win the race; the
+// loser closes what it built and takes the winner's source.
+func (r *SourceReconciler) openShared(skey sourceKey, originAt *time.Time) (*sharedSource, error) {
+	r.mu.Lock()
+	if r.shared == nil {
+		r.shared = make(map[sourceKey]*sharedSource)
+	}
+	s := r.shared[skey]
+	r.mu.Unlock()
+	if s != nil {
+		return s, nil
+	}
+
+	s, err := r.opener.open(skey.flowID, skey.provider)
+	if err != nil {
+		return nil, err
+	}
+	s.key = skey
+	s.openedAt = time.Now()
+	if originAt != nil {
+		t := *originAt
+		s.lastObservedOriginAt.Store(&t)
+	}
+
+	r.mu.Lock()
+	if dup := r.shared[skey]; dup != nil {
+		r.mu.Unlock()
+		closeShared(s)
+		return dup, nil
+	}
+	r.shared[skey] = s
+	r.mu.Unlock()
+	return s, nil
+}
+
+// releaseIfUnused closes a shared source no mirror is attached to.
+// The open path leaves one behind whenever the AddTarget that would
+// have been its first target fails, and a reader on a flow no mirror
+// transfers keeps libmxl from ever reclaiming that flow.
+func (r *SourceReconciler) releaseIfUnused(s *sharedSource) {
+	r.mu.Lock()
+	if len(s.mirrors) > 0 || r.shared[s.key] != s {
+		r.mu.Unlock()
+		return
+	}
+	delete(r.shared, s.key)
+	r.mu.Unlock()
+	closeShared(s)
+}
+
+// reopenEvicted drives a mirror whose shared source was torn down back
+// through Reconcile so it opens or re-attaches against a fresh reader.
+func (r *SourceReconciler) reopenEvicted(ctx context.Context, key types.NamespacedName) {
+	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err != nil {
+		ctrl.Log.WithName("source").Error(err, "reopen source mirror", "mirror", key)
+	}
 }
 
 // handleAddTargetFailure records the failed AddTarget attempt and
@@ -663,7 +914,7 @@ type libmxlOpener struct {
 	PacingChunks     int
 }
 
-func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provider) (*sourceEntry, error) {
+func (o *libmxlOpener) open(flowID string, provider fabrics.Provider) (*sharedSource, error) {
 	mxlInst := o.Handles.MXL()
 	if mxlInst == nil {
 		return nil, fmt.Errorf("mxl instance closed")
@@ -696,18 +947,6 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 		_ = reader.Close()
 		return nil, fmt.Errorf("Initiator.Setup: %w", err)
 	}
-	info, err := fabrics.ParseTargetInfo(targetInfoStr)
-	if err != nil {
-		_ = initiator.Close()
-		_ = reader.Close()
-		return nil, fmt.Errorf("ParseTargetInfo: %w", err)
-	}
-	if err := initiator.AddTarget(info); err != nil {
-		_ = info.Close()
-		_ = initiator.Close()
-		_ = reader.Close()
-		return nil, fmt.Errorf("%w: %w", errAddTargetFailed, err)
-	}
 
 	// A continuous (audio) flow moves samples, not grains; pick the
 	// transfer path from the flow's data format. maxBatch is the
@@ -717,7 +956,6 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 	// and also sizes the transfer tick and the catch-up bound.
 	cfg, err := reader.Config()
 	if err != nil {
-		_ = info.Close()
 		_ = initiator.Close()
 		_ = reader.Close()
 		return nil, fmt.Errorf("Reader.Config: %w", err)
@@ -727,7 +965,6 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 	if audio {
 		maxBatch, err = reader.GetMaxReadLengthSamples()
 		if err != nil {
-			_ = info.Close()
 			_ = initiator.Close()
 			_ = reader.Close()
 			return nil, fmt.Errorf("GetMaxReadLengthSamples: %w", err)
@@ -749,15 +986,12 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 
 	loopCtx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	entry := &sourceEntry{
+	s := &sharedSource{
+		key:       sourceKey{flowID: flowID, provider: provider},
 		reader:    reader,
 		initiator: initiator,
-		info:      info,
-		infoStr:   targetInfoStr,
 		cancel:    cancel,
 		done:      done,
-		flowID:    flowID,
-		provider:  provider,
 	}
 
 	progressInterval := o.ProgressInterval
@@ -822,17 +1056,20 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 			if frameBytes == 0 {
 				frameBytes = sampleFrameBytes(reader, headIndex)
 			}
-			entry.bytes.Add(uint64(count) * frameBytes)
+			s.addBytes(uint64(count) * frameBytes)
 			return nil
 		}
-		go runSampleTransferLoop(loopCtx, done, flowID, runtimeFn, transferSamplesFn, progressFn, xferBatch, progressInterval, entry)
+		go runSampleTransferLoop(loopCtx, done, flowID, runtimeFn, transferSamplesFn, progressFn, xferBatch, progressInterval, s)
 	} else {
-		// The pacer is keyed on flow plus target so two mirrors of one
-		// flow, and mirrors of different flows, get different phase
-		// offsets. Flows sharing an edit rate advance their heads on
-		// the same MXL clock instants, so without the offset every
-		// mirror on this node would hand its chunks over in lockstep.
-		p := newPacer(cfg.Common.GrainRate, pacingFraction, pacingChunks, flowID+"\x00"+targetInfoStr)
+		// The pacer is keyed on flow plus provider so two shared
+		// sources -- of the same flow on different providers, or of
+		// different flows -- get different phase offsets. Flows sharing
+		// an edit rate advance their heads on the same MXL clock
+		// instants, so without the offset every source on this node
+		// would hand its chunks over in lockstep. Keyed per flow rather
+		// than per target because there is now one transfer stream per
+		// flow, whatever its fan-out.
+		p := newPacer(cfg.Common.GrainRate, pacingFraction, pacingChunks, flowID+"\x00"+provider.String())
 		l := ctrl.Log.WithName("transfer").WithValues("flowID", flowID)
 		transferSlices := func(idx uint64, start, end uint16) error {
 			return initiator.TransferGrain(idx, start, end)
@@ -862,20 +1099,55 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 				if err := initiator.TransferGrain(idx, 0, grain.TotalSlices); err != nil {
 					return false, err
 				}
-				entry.bytes.Add(uint64(grain.GrainSize))
+				s.addBytes(uint64(grain.GrainSize))
 				return false, nil
 			}
 			if err := transferPaced(loopCtx, realClock{}, p.plan(grain.TotalSlices), idx,
 				transferSlices, betweenChunks); err != nil {
 				return false, err
 			}
-			entry.bytes.Add(uint64(grain.GrainSize))
+			s.addBytes(uint64(grain.GrainSize))
 			return false, nil
 		}
-		go runTransferLoop(loopCtx, done, flowID, runtimeFn, transferFn, progressFn, progressInterval, entry)
+		go runTransferLoop(loopCtx, done, flowID, runtimeFn, transferFn, progressFn, progressInterval, s)
 	}
 
-	return entry, nil
+	return s, nil
+}
+
+// attach parses the target's serialized info and adds it to the shared
+// initiator. This is the whole of the per-mirror libmxl-fabrics work:
+// libmxl-fabrics enqueues every subsequent transfer to all targets an
+// initiator holds, so a second mirror of a flow costs one AddTarget
+// rather than a second reader, initiator and transfer loop.
+func (o *libmxlOpener) attach(s *sharedSource, targetInfoStr string) (*fabrics.TargetInfo, error) {
+	info, err := fabrics.ParseTargetInfo(targetInfoStr)
+	if err != nil {
+		return nil, fmt.Errorf("ParseTargetInfo: %w", err)
+	}
+	if err := s.initiator.AddTarget(info); err != nil {
+		_ = info.Close()
+		return nil, fmt.Errorf("%w: %w", errAddTargetFailed, err)
+	}
+	return info, nil
+}
+
+// detach takes one target off the shared initiator and closes its
+// info handle. The initiator, its reader and the transfer loop stay
+// up for whatever targets remain.
+func (o *libmxlOpener) detach(s *sharedSource, info *fabrics.TargetInfo) {
+	if info == nil {
+		return
+	}
+	if s != nil && s.initiator != nil {
+		if err := s.initiator.RemoveTarget(info); err != nil {
+			// The target is going away either way: a failure here is
+			// worth recording but leaves nothing for a caller to do.
+			ctrl.Log.WithName("source").V(1).Info("RemoveTarget",
+				"flowID", s.key.flowID, "error", err.Error())
+		}
+	}
+	_ = info.Close()
 }
 
 const (
@@ -896,9 +1168,16 @@ const (
 // sides of a mirror describe a wedge over the same period.
 const defaultReaderStallAfter = 20 * time.Second
 
-// progressTracker is the subset of sourceEntry the transfer loop
-// updates. Defined as an interface so tests can inject a stub
-// without constructing a full sourceEntry.
+// progressTracker is the subset of a source the transfer loop updates.
+// Defined as an interface so tests can inject a stub without
+// constructing a full entry.
+//
+// Production binds it to the sharedSource, which fans every call out
+// to the mirrors currently attached to it. That is not an
+// approximation: one TransferGrain or TransferSamples call enqueues
+// the payload to every target the initiator holds, so every attached
+// mirror really did move it and really is at that index, and the
+// per-mirror status conditions and byte counters stay exact.
 type progressTracker interface {
 	recordTransfer(idx uint64, at time.Time)
 	recordAgedOut(at time.Time)
@@ -926,6 +1205,33 @@ func (e *sourceEntry) recordHead(head uint64, at time.Time) {
 	e.lastHead.Store(head)
 	t := at
 	e.headAdvancedAt.Store(&t)
+}
+
+func (s *sharedSource) recordTransfer(idx uint64, at time.Time) {
+	for _, e := range s.attached() {
+		e.recordTransfer(idx, at)
+	}
+}
+
+func (s *sharedSource) recordAgedOut(at time.Time) {
+	for _, e := range s.attached() {
+		e.recordAgedOut(at)
+	}
+}
+
+func (s *sharedSource) recordHead(head uint64, at time.Time) {
+	for _, e := range s.attached() {
+		e.recordHead(head, at)
+	}
+}
+
+// addBytes credits one transfer's payload to every attached mirror.
+// Kept off progressTracker because it is added at the call site that
+// knows the payload size rather than by the loop.
+func (s *sharedSource) addBytes(n uint64) {
+	for _, e := range s.attached() {
+		e.bytes.Add(n)
+	}
 }
 
 // runTransferLoop pumps grains that appear on the source flow into
@@ -1238,38 +1544,130 @@ func isReaderAgedOut(err error) bool {
 	return err != nil && strings.Contains(err.Error(), readerAgedOutMarker)
 }
 
+// closeEntry detaches one mirror: RemoveTarget for its target only,
+// its status flusher stopped, and the reader, initiator and transfer
+// goroutine left running for whatever other mirrors of the flow are
+// still attached. Only the last mirror to leave closes the shared
+// half. A no-op when key holds nothing.
 func (r *SourceReconciler) closeEntry(key types.NamespacedName) {
 	r.mu.Lock()
 	entry := r.sources[key]
 	delete(r.sources, key)
+	var orphan *sharedSource
+	if entry != nil && entry.shared != nil {
+		s := entry.shared
+		if s.detach(key) && r.shared[s.key] == s {
+			delete(r.shared, s.key)
+			orphan = s
+		}
+	}
 	r.mu.Unlock()
 	if entry == nil {
 		return
 	}
-	closeSourceHandles(entry)
+	// Both outside r.mu: stopFlusher waits on a goroutine that takes
+	// r.mu itself, and detach crosses into libmxl-fabrics.
+	stopFlusher(entry)
+	r.detachTarget(entry)
+	closeShared(orphan)
 }
 
-func closeSourceHandles(e *sourceEntry) {
+// closeSharedSource tears the whole shared source down -- every
+// target, the transfer goroutine, the initiator and the reader -- and
+// returns the mirrors that were attached so the caller can drive them
+// back through Reconcile against a fresh reader. Used by the paths
+// that invalidate the reader itself: an origin rotation and the
+// reader-stall rebuild.
+func (r *SourceReconciler) closeSharedSource(skey sourceKey) []types.NamespacedName {
+	r.mu.Lock()
+	s := r.shared[skey]
+	if s == nil {
+		r.mu.Unlock()
+		return nil
+	}
+	delete(r.shared, skey)
+	entries := s.detachAll()
+	keys := make([]types.NamespacedName, 0, len(entries))
+	for _, e := range entries {
+		if r.sources[e.key] == e {
+			delete(r.sources, e.key)
+		}
+		keys = append(keys, e.key)
+	}
+	r.mu.Unlock()
+
+	// The loop stops before the targets come off, so it never ticks
+	// against an initiator holding none: libmxl-fabrics reports that as
+	// an error on every MakeProgress call.
+	s.stopLoop()
+	for _, e := range entries {
+		stopFlusher(e)
+		r.detachTarget(e)
+	}
+	closeShared(s)
+	return keys
+}
+
+// closeMirrorSource tears down the shared source key transfers
+// through and returns every mirror that was on it, key included.
+func (r *SourceReconciler) closeMirrorSource(key types.NamespacedName) []types.NamespacedName {
+	r.mu.Lock()
+	entry := r.sources[key]
+	r.mu.Unlock()
+	if entry == nil || entry.shared == nil {
+		r.closeEntry(key)
+		return []types.NamespacedName{key}
+	}
+	keys := r.closeSharedSource(entry.shared.key)
+	if !slices.Contains(keys, key) {
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// detachTarget removes one mirror's target from the shared initiator.
+func (r *SourceReconciler) detachTarget(e *sourceEntry) {
+	if e.info == nil || r.opener == nil {
+		return
+	}
+	r.opener.detach(e.shared, e.info)
+}
+
+// stopFlusher stops one mirror's status flusher and waits for it.
+func stopFlusher(e *sourceEntry) {
 	if e.flusherCancel != nil {
 		e.flusherCancel()
 	}
 	if e.flusherDone != nil {
 		<-e.flusherDone
 	}
-	if e.cancel != nil {
-		e.cancel()
+}
+
+// stopLoop cancels the transfer goroutine and waits for it to return.
+// Idempotent: a second call cancels an already-canceled context and
+// receives from an already-closed channel.
+func (s *sharedSource) stopLoop() {
+	if s.cancel != nil {
+		s.cancel()
 	}
-	if e.done != nil {
-		<-e.done
+	if s.done != nil {
+		<-s.done
 	}
-	if e.info != nil {
-		_ = e.info.Close()
+}
+
+// closeShared stops the transfer goroutine and releases the libmxl
+// and libmxl-fabrics handles one flow's source is built on. Only ever
+// called once no mirror is attached.
+func closeShared(s *sharedSource) {
+	if s == nil {
+		return
 	}
-	if e.initiator != nil {
-		_ = e.initiator.Close()
+	s.stopLoop()
+	if s.initiator != nil {
+		_ = s.initiator.Close()
 	}
-	if e.reader != nil {
-		_ = e.reader.Close()
+	if s.reader != nil {
+		_ = s.reader.Close()
 	}
 }
 
@@ -1352,7 +1750,7 @@ func (r *SourceReconciler) publishSourceProgress(ctx context.Context, key types.
 // ticks at r.FlushInterval and publishes SourceProgress only when
 // the observed state has transitioned, so a steady-state mirror
 // produces zero status writes.
-func (r *SourceReconciler) startFlusher(key types.NamespacedName, entry *sourceEntry) {
+func (r *SourceReconciler) startFlusher(entry *sourceEntry) {
 	if entry.flusherCancel != nil {
 		return
 	}
@@ -1364,14 +1762,15 @@ func (r *SourceReconciler) startFlusher(key types.NamespacedName, entry *sourceE
 	done := make(chan struct{})
 	entry.flusherCancel = cancel
 	entry.flusherDone = done
-	go r.runFlusher(ctx, done, key, entry, interval)
+	go r.runFlusher(ctx, done, entry, interval)
 }
 
 // runFlusher is the per-mirror status flusher loop. Tracks the most
 // recently published condition so a steady stream of grains does
 // not turn into a steady stream of API writes.
-func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, key types.NamespacedName, entry *sourceEntry, interval time.Duration) {
+func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, entry *sourceEntry, interval time.Duration) {
 	defer close(done)
+	key := entry.key
 	t := time.NewTicker(interval)
 	defer t.Stop()
 
@@ -1406,7 +1805,7 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 		// TransfersNotLanding is the state a source reaches without
 		// asking for a reopen, and it pins the flow exactly as the
 		// wedge states do.
-		if state.status == metav1.ConditionFalse && r.writerGone(entry.flowID) {
+		if state.status == metav1.ConditionFalse && r.writerGone(entry.flowID()) {
 			state.status = metav1.ConditionFalse
 			state.reason = mxlv1alpha1.ReasonSourceWriterGone
 			state.message = "flow has no live writer; releasing the source reader so the flow can be reclaimed"
@@ -1416,7 +1815,7 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 			}
 			ctrl.Log.WithName("source-flush").Info(
 				"flow has no live writer; releasing source reader",
-				"mirror", key, "flowID", entry.flowID)
+				"mirror", key, "flowID", entry.flowID())
 			// Returning first for the same reason the reopen path does:
 			// closeSourceHandles waits on flusherDone, which this
 			// goroutine closes.
@@ -1426,12 +1825,12 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 
 		if state.rebuildReader {
 			switch {
-			case r.readerRebuildsExhausted(key):
+			case r.readerRebuildsExhausted(entry.sourceKey()):
 				state.reason = ReasonReaderRebuildCapReached
 				state.message = fmt.Sprintf("%s; unresolved across %d reopens",
 					state.message, maxReaderRebuilds)
-			case entry.rebuilding.CompareAndSwap(false, true):
-				attempt := r.bumpReaderRebuilds(key)
+			case entry.beginRebuild():
+				attempt := r.bumpReaderRebuilds(entry.sourceKey())
 				if err := r.publishSourceProgress(ctx, key, state); err != nil {
 					ctrl.Log.WithName("source-flush").Error(err, "publish",
 						"mirror", key, "reason", state.reason)
@@ -1451,7 +1850,7 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 		}
 		if state.status == metav1.ConditionTrue &&
 			state.reason == mxlv1alpha1.ReasonRecovered {
-			r.clearReaderRebuilds(key)
+			r.clearReaderRebuilds(entry.sourceKey())
 		}
 
 		if !first && sourceStateEqual(state, last) {
@@ -1467,16 +1866,27 @@ func (r *SourceReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 	}
 }
 
-// bumpReaderRebuilds records one more consecutive reopen for key and
-// returns the new count.
-func (r *SourceReconciler) bumpReaderRebuilds(key types.NamespacedName) uint32 {
+// bumpReaderRebuilds records one more consecutive reopen of the shared
+// source and returns the new count.
+func (r *SourceReconciler) bumpReaderRebuilds(skey sourceKey) uint32 {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	if r.rebuilds == nil {
-		r.rebuilds = make(map[types.NamespacedName]uint32)
+		r.rebuilds = make(map[sourceKey]uint32)
 	}
-	r.rebuilds[key]++
-	return r.rebuilds[key]
+	r.rebuilds[skey]++
+	return r.rebuilds[skey]
+}
+
+// beginRebuild claims the reader rebuild for this mirror's shared
+// source, so a second flusher tick -- this mirror's or that of any
+// other mirror attached to the same reader -- cannot spawn a competing
+// reopen of the one reader they share.
+func (e *sourceEntry) beginRebuild() bool {
+	if e.shared == nil {
+		return true
+	}
+	return e.shared.rebuilding.CompareAndSwap(false, true)
 }
 
 // writerGone reports whether the flow has no live writer. A nil seam,
@@ -1518,21 +1928,21 @@ func sourceProgressReads(mirror *mxlv1alpha1.MxlFlowMirror, reason string) bool 
 	return cond != nil && cond.Reason == reason
 }
 
-// readerRebuildsExhausted reports whether key has used its reopen
-// budget.
-func (r *SourceReconciler) readerRebuildsExhausted(key types.NamespacedName) bool {
+// readerRebuildsExhausted reports whether the shared source has used
+// its reopen budget.
+func (r *SourceReconciler) readerRebuildsExhausted(skey sourceKey) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.rebuilds[key] >= maxReaderRebuilds
+	return r.rebuilds[skey] >= maxReaderRebuilds
 }
 
-// clearReaderRebuilds returns key's full reopen budget. Called once
-// grains flow again, so a mirror that wedges later is not judged on
-// a stall it already recovered from.
-func (r *SourceReconciler) clearReaderRebuilds(key types.NamespacedName) {
+// clearReaderRebuilds returns the shared source's full reopen budget.
+// Called once grains flow again, so a reader that wedges later is not
+// judged on a stall it already recovered from.
+func (r *SourceReconciler) clearReaderRebuilds(skey sourceKey) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	delete(r.rebuilds, key)
+	delete(r.rebuilds, skey)
 }
 
 func (r *SourceReconciler) dispatchReaderRebuild(key types.NamespacedName) {
@@ -1554,10 +1964,16 @@ func (r *SourceReconciler) dispatchReaderRebuild(key types.NamespacedName) {
 // would otherwise wake the reconciler (origin Lease renewals, MxlFlow
 // status writes) all stop precisely when the producer is in trouble.
 func (r *SourceReconciler) rebuildWedgedReader(ctx context.Context, key types.NamespacedName) {
-	r.closeEntry(key)
-	if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: key}); err != nil {
-		ctrl.Log.WithName("source-flush").Error(err, "reopen source reader",
-			"mirror", key)
+	// The whole shared source goes, not just this mirror's target: the
+	// wedge is in the reader, and every mirror of the flow transfers
+	// through that one reader. Each of them is then driven back through
+	// Reconcile, which re-opens the source once and re-adds the rest of
+	// the targets to it.
+	for _, k := range r.closeMirrorSource(key) {
+		if _, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: k}); err != nil {
+			ctrl.Log.WithName("source-flush").Error(err, "reopen source reader",
+				"mirror", k)
+		}
 	}
 }
 
@@ -1742,11 +2158,14 @@ func (r *SourceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	if r.sources == nil {
 		r.sources = make(map[types.NamespacedName]*sourceEntry)
 	}
+	if r.shared == nil {
+		r.shared = make(map[sourceKey]*sharedSource)
+	}
 	if r.attempts == nil {
 		r.attempts = make(attemptTable[sourceAddInputs])
 	}
 	if r.rebuilds == nil {
-		r.rebuilds = make(map[types.NamespacedName]uint32)
+		r.rebuilds = make(map[sourceKey]uint32)
 	}
 	if r.APIReader == nil {
 		r.APIReader = mgr.GetAPIReader()

--- a/gateway/internal/mirror/source_addbackoff_test.go
+++ b/gateway/internal/mirror/source_addbackoff_test.go
@@ -36,7 +36,7 @@ func newAddBackoffFixture(t *testing.T, targetInfo string) *addBackoffFixture {
 		Build()
 
 	opener := &fakeOpener{
-		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+		attachFn: func(*sharedSource, string) (*fabrics.TargetInfo, error) {
 			return nil, errors.Join(errAddTargetFailed, errors.New("connect: target offline"))
 		},
 	}
@@ -78,7 +78,7 @@ func TestSource_AddTargetBackoffGatesRepeatedAttempts(t *testing.T) {
 	res, err := f.r.Reconcile(ctx, f.req)
 	require.NoError(t, err)
 	require.Positive(t, res.RequeueAfter)
-	require.Equal(t, int32(1), f.opener.calls.Load())
+	require.Equal(t, int32(1), f.opener.opens.Load())
 
 	settled := f.mirror(t)
 	require.Equal(t, int32(1), settled.Status.AttemptCount)
@@ -89,8 +89,8 @@ func TestSource_AddTargetBackoffGatesRepeatedAttempts(t *testing.T) {
 		assert.Positive(t, res.RequeueAfter)
 	}
 
-	assert.Equal(t, int32(1), f.opener.calls.Load(),
-		"inside the backoff the initiator must not be rebuilt")
+	assert.Equal(t, int32(1), f.opener.opens.Load(),
+		"inside the backoff the reader and initiator must not be rebuilt")
 
 	after := f.mirror(t)
 	assert.Equal(t, int32(1), after.Status.AttemptCount,
@@ -102,7 +102,7 @@ func TestSource_AddTargetBackoffGatesRepeatedAttempts(t *testing.T) {
 	f.advance(backoffFor(1))
 	_, err = f.r.Reconcile(ctx, f.req)
 	require.NoError(t, err)
-	assert.Equal(t, int32(2), f.opener.calls.Load(),
+	assert.Equal(t, int32(2), f.opener.opens.Load(),
 		"the retry must happen once the backoff has elapsed")
 	assert.Equal(t, int32(2), f.mirror(t).Status.AttemptCount)
 }
@@ -117,11 +117,11 @@ func TestSource_AddTargetBackoffReleasedWhenTargetInfoRotates(t *testing.T) {
 
 	_, err := f.r.Reconcile(ctx, f.req)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), f.opener.calls.Load())
+	require.Equal(t, int32(1), f.opener.opens.Load())
 
 	_, err = f.r.Reconcile(ctx, f.req)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), f.opener.calls.Load(),
+	require.Equal(t, int32(1), f.opener.opens.Load(),
 		"the same endpoint inside the backoff stays gated")
 
 	m := f.mirror(t)
@@ -130,6 +130,6 @@ func TestSource_AddTargetBackoffReleasedWhenTargetInfoRotates(t *testing.T) {
 
 	_, err = f.r.Reconcile(ctx, f.req)
 	require.NoError(t, err)
-	assert.Equal(t, int32(2), f.opener.calls.Load(),
+	assert.Equal(t, int32(2), f.opener.opens.Load(),
 		"a rotated TargetInfo must be attempted at once")
 }

--- a/gateway/internal/mirror/source_rotation_test.go
+++ b/gateway/internal/mirror/source_rotation_test.go
@@ -48,8 +48,8 @@ func TestReconcile_FlowOriginRotation_DetectedAfterStaleOpen(t *testing.T) {
 		Build()
 
 	opener := &fakeOpener{
-		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
-			return &sourceEntry{infoStr: "info-1"}, nil
+		openFn: func(string, fabrics.Provider) (*sharedSource, error) {
+			return &sharedSource{}, nil
 		},
 	}
 	r := &SourceReconciler{
@@ -69,7 +69,7 @@ func TestReconcile_FlowOriginRotation_DetectedAfterStaleOpen(t *testing.T) {
 	// records no origin observation.
 	_, err := r.Reconcile(context.Background(), req)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), opener.calls.Load())
+	require.Equal(t, int32(1), opener.opens.Load())
 	t.Cleanup(func() { r.closeEntry(key) })
 
 	// Writer restarts: the agent publishes Origin with a fresh
@@ -83,7 +83,7 @@ func TestReconcile_FlowOriginRotation_DetectedAfterStaleOpen(t *testing.T) {
 
 	_, err = r.Reconcile(context.Background(), req)
 	require.NoError(t, err)
-	assert.Equal(t, int32(2), opener.calls.Load(),
+	assert.Equal(t, int32(2), opener.opens.Load(),
 		"an Origin observation newer than the running reader must reopen "+
 			"it even when the reader was opened during a Stale/nil window: "+
 			"a nil baseline that never re-arms leaves the reader on a dead "+

--- a/gateway/internal/mirror/source_shared_test.go
+++ b/gateway/internal/mirror/source_shared_test.go
@@ -1,0 +1,455 @@
+package mirror
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/qvest-digital/go-mxl/fabrics"
+	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
+)
+
+// runningSource is a sharedSource whose transfer goroutine is a stand
+// -in that only waits for its context, so a test can tell a loop that
+// is still running from one that has been stopped without linking
+// libmxl.
+func runningSource() *sharedSource {
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		<-ctx.Done()
+	}()
+	return &sharedSource{cancel: cancel, done: done}
+}
+
+func loopRunning(s *sharedSource) bool {
+	select {
+	case <-s.done:
+		return false
+	default:
+		return true
+	}
+}
+
+// fanoutMirror is one MxlFlowMirror of flowID sourced from node-a,
+// carrying its own target node, provider and published target info.
+func fanoutMirror(name, flowID, targetNode, targetInfo string, provider mxlv1alpha1.MxlFabricsProvider) *mxlv1alpha1.MxlFlowMirror {
+	return &mxlv1alpha1.MxlFlowMirror{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       name,
+			Namespace:  "ns1",
+			Finalizers: []string{SourceFinalizerName},
+		},
+		Spec: mxlv1alpha1.MxlFlowMirrorSpec{
+			FlowID:     flowID,
+			SourceNode: "node-a",
+			TargetNode: targetNode,
+			Provider:   provider,
+		},
+		Status: mxlv1alpha1.MxlFlowMirrorStatus{TargetInfo: targetInfo},
+	}
+}
+
+// fanoutFixture reconciles a set of mirrors of one flow through a
+// reconciler whose opener is the inline fake, and hands the test the
+// pieces it asserts on.
+type fanoutFixture struct {
+	r      *SourceReconciler
+	opener *fakeOpener
+	c      client.Client
+	scheme *runtime.Scheme
+}
+
+func newFanoutFixture(t *testing.T, mirrors ...*mxlv1alpha1.MxlFlowMirror) *fanoutFixture {
+	t.Helper()
+	scheme := newSourceTestScheme(t)
+	objs := make([]client.Object, 0, len(mirrors))
+	for _, m := range mirrors {
+		objs = append(objs, m)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(objs...).
+		Build()
+
+	opener := &fakeOpener{
+		openFn: func(string, fabrics.Provider) (*sharedSource, error) {
+			return runningSource(), nil
+		},
+	}
+	r := &SourceReconciler{
+		Client:        c,
+		Scheme:        scheme,
+		NodeName:      "node-a",
+		opener:        opener,
+		FlushInterval: time.Hour,
+		sources:       map[types.NamespacedName]*sourceEntry{},
+		shared:        map[sourceKey]*sharedSource{},
+		attempts:      attemptTable[sourceAddInputs]{},
+		rebuilds:      map[sourceKey]uint32{},
+	}
+	f := &fanoutFixture{r: r, opener: opener, c: c, scheme: scheme}
+	t.Cleanup(f.closeAll)
+	return f
+}
+
+// closeAll tears every live entry down, so the stand-in transfer
+// goroutines do not outlive the test and trip goleak.
+func (f *fanoutFixture) closeAll() {
+	f.r.mu.Lock()
+	keys := make([]types.NamespacedName, 0, len(f.r.sources))
+	for k := range f.r.sources {
+		keys = append(keys, k)
+	}
+	f.r.mu.Unlock()
+	for _, k := range keys {
+		f.r.closeEntry(k)
+	}
+	f.r.mu.Lock()
+	shared := make([]*sharedSource, 0, len(f.r.shared))
+	for _, s := range f.r.shared {
+		shared = append(shared, s)
+	}
+	f.r.shared = map[sourceKey]*sharedSource{}
+	f.r.mu.Unlock()
+	for _, s := range shared {
+		closeShared(s)
+	}
+}
+
+func (f *fanoutFixture) reconcile(t *testing.T, name string) {
+	t.Helper()
+	key := types.NamespacedName{Namespace: "ns1", Name: name}
+	_, err := f.r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+}
+
+func (f *fanoutFixture) delete(t *testing.T, name string) {
+	t.Helper()
+	key := types.NamespacedName{Namespace: "ns1", Name: name}
+	var m mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, f.c.Get(context.Background(), key, &m))
+	require.NoError(t, f.c.Delete(context.Background(), &m))
+	_, err := f.r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+}
+
+func (f *fanoutFixture) sharedFor(flowID string, provider fabrics.Provider) *sharedSource {
+	f.r.mu.Lock()
+	defer f.r.mu.Unlock()
+	return f.r.shared[sourceKey{flowID: flowID, provider: provider}]
+}
+
+func (f *fanoutFixture) entry(name string) *sourceEntry {
+	f.r.mu.Lock()
+	defer f.r.mu.Unlock()
+	return f.r.sources[types.NamespacedName{Namespace: "ns1", Name: name}]
+}
+
+func TestSource_MirrorsOfOneFlowShareOneReaderAndInitiator(t *testing.T) {
+	// libmxl-fabrics enqueues a transfer to every target added to an
+	// initiator, so a flow mirrored to N nodes is N AddTarget calls on
+	// one initiator. Opening one initiator per mirror instead read the
+	// same ring N times, ran N transfer loops, and posted N copies of
+	// every grain to the NIC -- work that grew with fan-out for no
+	// payload that reached a peer any sooner.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-1", "node-b", "info-b", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m2", "flow-1", "node-c", "info-c", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m3", "flow-1", "node-d", "info-d", mxlv1alpha1.ProviderTCP),
+	)
+	for _, n := range []string{"m1", "m2", "m3"} {
+		f.reconcile(t, n)
+	}
+
+	assert.Equal(t, int32(1), f.opener.opens.Load(),
+		"three mirrors of one flow must share one reader and one initiator")
+	assert.Equal(t, int32(3), f.opener.attaches.Load(),
+		"each mirror still contributes its own target")
+	assert.ElementsMatch(t, []string{"info-b", "info-c", "info-d"}, f.opener.addedTargets())
+
+	s := f.sharedFor("flow-1", fabrics.ProviderTCP)
+	require.NotNil(t, s)
+	assert.Len(t, s.attached(), 3,
+		"every mirror must be in the fanout set the transfer loop accounts to")
+}
+
+func TestSource_MirrorsOfOneFlowOnDifferentProvidersDoNotShare(t *testing.T) {
+	// An initiator is set up against one interface, chosen per
+	// provider, so a tcp mirror and a verbs mirror of the same flow
+	// cannot be served by one initiator however alike they look.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-1", "node-b", "info-b", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m2", "flow-1", "node-c", "info-c", mxlv1alpha1.ProviderVerbs),
+	)
+	f.reconcile(t, "m1")
+	f.reconcile(t, "m2")
+
+	assert.Equal(t, int32(2), f.opener.opens.Load(),
+		"two providers cannot share one initiator's interface")
+	require.NotNil(t, f.sharedFor("flow-1", fabrics.ProviderTCP))
+	require.NotNil(t, f.sharedFor("flow-1", fabrics.ProviderVerbs))
+}
+
+func TestSource_DeletingOneMirrorLeavesTheOthersTransferring(t *testing.T) {
+	// The failure this guards against is the worst one the sharing
+	// introduces: a teardown that reaches past the mirror being
+	// deleted and closes the reader every other mirror of the flow is
+	// transferring through.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-1", "node-b", "info-b", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m2", "flow-1", "node-c", "info-c", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m3", "flow-1", "node-d", "info-d", mxlv1alpha1.ProviderTCP),
+	)
+	for _, n := range []string{"m1", "m2", "m3"} {
+		f.reconcile(t, n)
+	}
+	s := f.sharedFor("flow-1", fabrics.ProviderTCP)
+	require.NotNil(t, s)
+
+	f.delete(t, "m2")
+
+	assert.Equal(t, []string{"info-c"}, f.opener.removedTargets(),
+		"only the deleted mirror's target may be removed from the initiator")
+	assert.Equal(t, int32(1), f.opener.opens.Load(),
+		"a detach must not rebuild anything")
+	assert.Same(t, s, f.sharedFor("flow-1", fabrics.ProviderTCP),
+		"the shared source must survive one of its mirrors going away")
+	assert.True(t, loopRunning(s),
+		"the transfer loop still has two targets to feed")
+	assert.Nil(t, f.entry("m2"))
+	assert.NotNil(t, f.entry("m1"))
+	assert.NotNil(t, f.entry("m3"))
+	assert.Len(t, s.attached(), 2)
+}
+
+func TestSource_LastMirrorLeavingClosesTheSharedSource(t *testing.T) {
+	// The other half of the same rule: a reader kept open on a flow no
+	// mirror transfers is what stops libmxl reclaiming that flow.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-1", "node-b", "info-b", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m2", "flow-1", "node-c", "info-c", mxlv1alpha1.ProviderTCP),
+	)
+	f.reconcile(t, "m1")
+	f.reconcile(t, "m2")
+	s := f.sharedFor("flow-1", fabrics.ProviderTCP)
+	require.NotNil(t, s)
+
+	f.delete(t, "m1")
+	require.True(t, loopRunning(s))
+
+	f.delete(t, "m2")
+	assert.Nil(t, f.sharedFor("flow-1", fabrics.ProviderTCP),
+		"the last mirror to leave must release the shared source")
+	assert.False(t, loopRunning(s),
+		"the transfer goroutine must stop once nothing is attached")
+	assert.ElementsMatch(t, []string{"info-b", "info-c"}, f.opener.removedTargets())
+}
+
+func TestSource_AccountingLandsPerMirrorAcrossTheFanout(t *testing.T) {
+	// One TransferGrain call really does enqueue the grain to every
+	// target the initiator holds, so every attached mirror really did
+	// move those bytes and really is at that index. Folding the
+	// counters onto the flow instead would drop the peer_node label
+	// the throughput series are told apart by, and leave every mirror
+	// but the first with a status that never reports progress.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-a", "n02", "info-b", mxlv1alpha1.ProviderVerbs),
+		fanoutMirror("m2", "flow-a", "n03", "info-c", mxlv1alpha1.ProviderVerbs),
+	)
+	f.reconcile(t, "m1")
+	f.reconcile(t, "m2")
+
+	s := f.sharedFor("flow-a", fabrics.ProviderVerbs)
+	require.NotNil(t, s)
+
+	sentAt := time.Now()
+	s.recordHead(41, sentAt)
+	s.recordTransfer(42, sentAt)
+	s.addBytes(1000)
+
+	for _, n := range []string{"m1", "m2"} {
+		e := f.entry(n)
+		require.NotNil(t, e, n)
+		assert.Equal(t, uint64(1), e.progress.Load(), n)
+		assert.Equal(t, uint64(1000), e.bytes.Load(), n)
+		assert.Equal(t, uint64(41), e.lastHead.Load(), n)
+		require.NotNil(t, e.lastSentAt.Load(), n)
+	}
+
+	col := &ThroughputCollector{NodeName: "n01", Source: f.r}
+	require.NoError(t, testutil.CollectAndCompare(col, strings.NewReader(`
+# HELP mxl_gateway_mirror_transmitted_bytes_total Payload bytes handed to the fabric for a mirror this node is the source of.
+# TYPE mxl_gateway_mirror_transmitted_bytes_total counter
+mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node="n02",provider="verbs"} 1000
+mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node="n03",provider="verbs"} 1000
+`)), "the shared transfer must still be attributed per peer")
+}
+
+func TestSource_AgedOutSkipReachesEveryAttachedMirror(t *testing.T) {
+	// The skip is a property of the reader, and the reader is shared,
+	// so a mirror that is not the one whose flusher happens to look
+	// first must still see it -- otherwise ReaderAgedOut, and the
+	// reopen it asks for, would only ever be published for one of the
+	// mirrors on a wedged flow.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-1", "node-b", "info-b", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m2", "flow-1", "node-c", "info-c", mxlv1alpha1.ProviderTCP),
+	)
+	f.reconcile(t, "m1")
+	f.reconcile(t, "m2")
+
+	s := f.sharedFor("flow-1", fabrics.ProviderTCP)
+	require.NotNil(t, s)
+	s.recordAgedOut(time.Now())
+
+	for _, n := range []string{"m1", "m2"} {
+		e := f.entry(n)
+		require.NotNil(t, e, n)
+		require.NotNil(t, e.agedOutAt.Load(), n)
+	}
+}
+
+func TestSource_TargetInfoRotationDoesNotDisturbTheOtherMirrors(t *testing.T) {
+	// A target gateway restarting republishes its info on a fresh
+	// address. Rebuilding the whole source for that would drop every
+	// other mirror of the flow, so the rotation is a RemoveTarget plus
+	// an AddTarget on the initiator they all share.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-1", "node-b", "info-b", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m2", "flow-1", "node-c", "info-c", mxlv1alpha1.ProviderTCP),
+	)
+	f.reconcile(t, "m1")
+	f.reconcile(t, "m2")
+	s := f.sharedFor("flow-1", fabrics.ProviderTCP)
+	require.NotNil(t, s)
+	m1Entry := f.entry("m1")
+	require.NotNil(t, m1Entry)
+
+	ctx := context.Background()
+	key := types.NamespacedName{Namespace: "ns1", Name: "m2"}
+	var m mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, f.c.Get(ctx, key, &m))
+	m.Status.TargetInfo = "info-c2"
+	require.NoError(t, f.c.Status().Update(ctx, &m))
+	f.reconcile(t, "m2")
+
+	assert.Equal(t, int32(1), f.opener.opens.Load(),
+		"a rotated target info must not rebuild the reader the other mirrors read")
+	assert.Equal(t, []string{"info-c"}, f.opener.removedTargets(),
+		"only the rotating mirror's stale target may be removed")
+	assert.Equal(t, []string{"info-b", "info-c", "info-c2"}, f.opener.addedTargets())
+	assert.Same(t, s, f.sharedFor("flow-1", fabrics.ProviderTCP))
+	assert.True(t, loopRunning(s))
+	assert.Same(t, m1Entry, f.entry("m1"),
+		"the untouched mirror must keep the entry it was transferring through")
+	assert.Equal(t, "info-c2", f.entry("m2").infoStr)
+}
+
+func TestSource_ReaderRebuildReopensTheSourceForEveryAttachedMirror(t *testing.T) {
+	// The stall watchdog tears down the reader, and the reader is
+	// shared, so every mirror on it loses its target. Leaving them to
+	// a watch would strand them: the events that would wake them --
+	// origin lease renewals, MxlFlow status writes -- stop precisely
+	// when the producer is in trouble.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-1", "node-b", "info-b", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m2", "flow-1", "node-c", "info-c", mxlv1alpha1.ProviderTCP),
+	)
+	f.reconcile(t, "m1")
+	f.reconcile(t, "m2")
+	first := f.sharedFor("flow-1", fabrics.ProviderTCP)
+	require.NotNil(t, first)
+
+	f.r.rebuildWedgedReader(context.Background(),
+		types.NamespacedName{Namespace: "ns1", Name: "m1"})
+
+	assert.Equal(t, int32(2), f.opener.opens.Load(),
+		"the wedged reader must be reopened exactly once for the whole flow")
+	assert.False(t, loopRunning(first), "the wedged transfer loop must be stopped")
+	second := f.sharedFor("flow-1", fabrics.ProviderTCP)
+	require.NotNil(t, second)
+	assert.NotSame(t, first, second)
+	assert.Len(t, second.attached(), 2,
+		"both mirrors must be re-added to the fresh initiator")
+	assert.Equal(t, []string{"info-b", "info-c", "info-b", "info-c"}, f.opener.addedTargets())
+}
+
+func TestSource_ReaderRebuildBudgetIsSpentPerSharedSource(t *testing.T) {
+	// The budget bounds reopens of a reader, and one reader now
+	// carries every mirror of the flow. Counting it per mirror would
+	// hand a flow mirrored to N nodes N times the cap on the one
+	// reader they share, which is the cap not applying at all.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-1", "node-b", "info-b", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m2", "flow-1", "node-c", "info-c", mxlv1alpha1.ProviderTCP),
+	)
+	f.reconcile(t, "m1")
+	f.reconcile(t, "m2")
+
+	skey := sourceKey{flowID: "flow-1", provider: fabrics.ProviderTCP}
+	require.Equal(t, uint32(1), f.r.bumpReaderRebuilds(f.entry("m1").sourceKey()))
+	require.Equal(t, uint32(2), f.r.bumpReaderRebuilds(f.entry("m2").sourceKey()),
+		"a reopen asked for by either mirror spends the same reader's budget")
+
+	f.r.mu.Lock()
+	got := f.r.rebuilds[skey]
+	f.r.mu.Unlock()
+	assert.Equal(t, uint32(2), got)
+}
+
+func TestSource_FailedAddTargetReleasesTheReaderItOpened(t *testing.T) {
+	// A source that opened a reader and then could not add its first
+	// target holds a flow open for a mirror that is transferring
+	// nothing, and libmxl reclaims a flow only once no handle denies
+	// it the lock.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-1", "node-b", "info-b", mxlv1alpha1.ProviderTCP),
+	)
+	f.opener.attachFn = func(*sharedSource, string) (*fabrics.TargetInfo, error) {
+		return nil, fmt.Errorf("%w: connect refused", errAddTargetFailed)
+	}
+
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	res, err := f.r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
+	require.NoError(t, err)
+	assert.Positive(t, res.RequeueAfter)
+	assert.Nil(t, f.sharedFor("flow-1", fabrics.ProviderTCP),
+		"a source with no target must not keep the flow's reader open")
+}
+
+func TestSource_FailedAddTargetLeavesAnInUseSourceAlone(t *testing.T) {
+	// The same release must not reach a source another mirror is
+	// already transferring through.
+	f := newFanoutFixture(t,
+		fanoutMirror("m1", "flow-1", "node-b", "info-b", mxlv1alpha1.ProviderTCP),
+		fanoutMirror("m2", "flow-1", "node-c", "info-c", mxlv1alpha1.ProviderTCP),
+	)
+	f.reconcile(t, "m1")
+	s := f.sharedFor("flow-1", fabrics.ProviderTCP)
+	require.NotNil(t, s)
+
+	f.opener.attachFn = func(*sharedSource, string) (*fabrics.TargetInfo, error) {
+		return nil, fmt.Errorf("%w: connect refused", errAddTargetFailed)
+	}
+	f.reconcile(t, "m2")
+
+	assert.Same(t, s, f.sharedFor("flow-1", fabrics.ProviderTCP),
+		"one mirror's AddTarget failure must not close the reader another is using")
+	assert.True(t, loopRunning(s))
+	assert.Len(t, s.attached(), 1)
+}

--- a/gateway/internal/mirror/source_stall_test.go
+++ b/gateway/internal/mirror/source_stall_test.go
@@ -20,7 +20,9 @@ import (
 // and which has delivered transfers grains, the last of them at
 // sentAt. A zero sentAt leaves the entry with no delivery on record.
 func stalledEntry(head uint64, headAt *time.Time, transfers uint64, sentAt time.Time) *sourceEntry {
-	e := &sourceEntry{}
+	// Attached to a handle-less shared source: the flusher reads the
+	// reader rebuild budget and the writer-liveness seam through it.
+	e := &sourceEntry{shared: &sharedSource{key: testFlowKey}}
 	e.lastHead.Store(head)
 	if headAt != nil {
 		t := *headAt
@@ -290,8 +292,8 @@ func TestReconcile_PreservesLastSentAtAcrossReopen(t *testing.T) {
 		Build()
 
 	opener := &fakeOpener{
-		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
-			return &sourceEntry{infoStr: "info-1"}, nil
+		openFn: func(string, fabrics.Provider) (*sharedSource, error) {
+			return &sharedSource{}, nil
 		},
 	}
 	r := &SourceReconciler{
@@ -345,7 +347,7 @@ func TestRunFlusher_ReopensWedgedReader(t *testing.T) {
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
 		attempts: attemptTable[sourceAddInputs]{},
-		rebuilds: map[types.NamespacedName]uint32{},
+		rebuilds: map[sourceKey]uint32{},
 		rebuildFn: func(key types.NamespacedName) {
 			rebuilt <- key
 		},
@@ -357,7 +359,8 @@ func TestRunFlusher_ReopensWedgedReader(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan struct{})
-	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+	entry.key = key
+	go r.runFlusher(ctx, done, entry, time.Millisecond)
 
 	select {
 	case got := <-rebuilt:
@@ -372,7 +375,7 @@ func TestRunFlusher_ReopensWedgedReader(t *testing.T) {
 		t.Fatal("the flusher must return before the reopen tears the entry down")
 	}
 
-	assert.Equal(t, uint32(1), r.rebuilds[key],
+	assert.Equal(t, uint32(1), r.rebuilds[testFlowKey],
 		"the reopen must consume exactly one unit of budget")
 
 	var got mxlv1alpha1.MxlFlowMirror
@@ -404,7 +407,7 @@ func TestRunFlusher_ReopensReaderStuckOutsideTheRing(t *testing.T) {
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
 		attempts: attemptTable[sourceAddInputs]{},
-		rebuilds: map[types.NamespacedName]uint32{},
+		rebuilds: map[sourceKey]uint32{},
 		rebuildFn: func(key types.NamespacedName) {
 			rebuilt <- key
 		},
@@ -420,7 +423,8 @@ func TestRunFlusher_ReopensReaderStuckOutsideTheRing(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan struct{})
-	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+	entry.key = key
+	go r.runFlusher(ctx, done, entry, time.Millisecond)
 
 	select {
 	case got := <-rebuilt:
@@ -454,7 +458,7 @@ func TestRunFlusher_StopsReopeningAtCap(t *testing.T) {
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
 		attempts: attemptTable[sourceAddInputs]{},
-		rebuilds: map[types.NamespacedName]uint32{key: maxReaderRebuilds},
+		rebuilds: map[sourceKey]uint32{testFlowKey: maxReaderRebuilds},
 		rebuildFn: func(types.NamespacedName) {
 			t.Error("no reopen may be spawned once the budget is spent")
 		},
@@ -463,7 +467,8 @@ func TestRunFlusher_StopsReopeningAtCap(t *testing.T) {
 	entry := stalledEntry(42, ptrTime(time.Now().Add(-time.Minute)), 0, time.Time{})
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+	entry.key = key
+	go r.runFlusher(ctx, done, entry, time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		var got mxlv1alpha1.MxlFlowMirror
@@ -497,18 +502,19 @@ func TestRunFlusher_ClearsRebuildBudgetOnProgress(t *testing.T) {
 		NodeName: "node-a",
 		sources:  map[types.NamespacedName]*sourceEntry{},
 		attempts: attemptTable[sourceAddInputs]{},
-		rebuilds: map[types.NamespacedName]uint32{key: 3},
+		rebuilds: map[sourceKey]uint32{testFlowKey: 3},
 	}
 
 	entry := stalledEntry(42, ptrTime(time.Now()), 5, time.Now())
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+	entry.key = key
+	go r.runFlusher(ctx, done, entry, time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		_, still := r.rebuilds[key]
+		_, still := r.rebuilds[testFlowKey]
 		return !still
 	}, 5*time.Second, 10*time.Millisecond)
 

--- a/gateway/internal/mirror/source_test.go
+++ b/gateway/internal/mirror/source_test.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"errors"
+	"slices"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -492,19 +493,90 @@ func TestRunTransferLoop_TracksProgressAndLastSentAt(t *testing.T) {
 }
 
 // fakeOpener is the inline initiatorOpener used by the Reconcile
-// tests. openFn is whatever the scenario wants the call to return;
-// calls counts every invocation so tests can assert reopen / fast-
-// path branching without inspecting the entry. Mirrors the style of
-// the operator's fakeLeaseChecker - an inline test fake instead of
-// a mockery-generated mock.
+// tests. openFn and attachFn are whatever the scenario wants the calls
+// to return; the counters and the added / removed logs let a test
+// assert how much libmxl-fabrics work a reconcile did without
+// inspecting the entries. Mirrors the style of the operator's
+// fakeLeaseChecker - an inline test fake instead of a
+// mockery-generated mock.
+//
+// opens is the counter that answers "how many readers and initiators
+// does this node hold", which is the whole point of sharing them:
+// several mirrors of one flow must drive attaches without driving
+// opens.
 type fakeOpener struct {
-	openFn func(flowID, targetInfoStr string, provider fabrics.Provider) (*sourceEntry, error)
-	calls  atomic.Int32
+	openFn   func(flowID string, provider fabrics.Provider) (*sharedSource, error)
+	attachFn func(s *sharedSource, targetInfoStr string) (*fabrics.TargetInfo, error)
+
+	opens    atomic.Int32
+	attaches atomic.Int32
+	detaches atomic.Int32
+
+	mu      sync.Mutex
+	names   map[*fabrics.TargetInfo]string
+	added   []string
+	removed []string
 }
 
-func (f *fakeOpener) open(flowID, targetInfoStr string, provider fabrics.Provider) (*sourceEntry, error) {
-	f.calls.Add(1)
-	return f.openFn(flowID, targetInfoStr, provider)
+func (f *fakeOpener) open(flowID string, provider fabrics.Provider) (*sharedSource, error) {
+	f.opens.Add(1)
+	if f.openFn != nil {
+		return f.openFn(flowID, provider)
+	}
+	return &sharedSource{}, nil
+}
+
+func (f *fakeOpener) attach(s *sharedSource, targetInfoStr string) (*fabrics.TargetInfo, error) {
+	f.attaches.Add(1)
+	info := &fabrics.TargetInfo{}
+	if f.attachFn != nil {
+		var err error
+		if info, err = f.attachFn(s, targetInfoStr); err != nil {
+			return nil, err
+		}
+	}
+	// The pointer is the identity a detach is asserted against. A
+	// zero-valued handle is never dereferenced: nothing in these tests
+	// calls into libmxl-fabrics through it.
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.names == nil {
+		f.names = make(map[*fabrics.TargetInfo]string)
+	}
+	f.names[info] = targetInfoStr
+	f.added = append(f.added, targetInfoStr)
+	return info, nil
+}
+
+func (f *fakeOpener) detach(_ *sharedSource, info *fabrics.TargetInfo) {
+	f.detaches.Add(1)
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.removed = append(f.removed, f.names[info])
+}
+
+// addedTargets and removedTargets report the target infos AddTarget
+// and RemoveTarget were called with, in call order.
+func (f *fakeOpener) addedTargets() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.added)
+}
+
+func (f *fakeOpener) removedTargets() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return slices.Clone(f.removed)
+}
+
+// testFlowKey is the shared source the entry helpers below hang off,
+// for tests that need an entry attached to something without opening
+// libmxl handles.
+var testFlowKey = sourceKey{flowID: "flow-1", provider: fabrics.ProviderTCP}
+
+// testShared builds a sharedSource carrying no libmxl handles.
+func testShared(flowID string, provider fabrics.Provider) *sharedSource {
+	return &sharedSource{key: sourceKey{flowID: flowID, provider: provider}}
 }
 
 func newSourceTestScheme(t *testing.T) *runtime.Scheme {
@@ -560,7 +632,7 @@ func TestReconcile_AddTargetFailureSurfacesConditionAndCapsBackoffAt30s(t *testi
 		Scheme:   scheme,
 		NodeName: "node-a",
 		opener: &fakeOpener{
-			openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+			attachFn: func(*sharedSource, string) (*fabrics.TargetInfo, error) {
 				return nil, errors.Join(errAddTargetFailed, addErr)
 			},
 		},
@@ -639,12 +711,12 @@ func TestReconcile_FlowOriginRotationReopensReader(t *testing.T) {
 		Build()
 
 	opener := &fakeOpener{
-		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+		openFn: func(string, fabrics.Provider) (*sharedSource, error) {
 			// A real opener would spawn the transfer goroutine and
-			// hand it the entry as tracker. The test never wires that
-			// up, so the entry stays inert and closeSourceHandles
+			// hand it the source as tracker. The test never wires
+			// that up, so the source stays inert and closeShared
 			// below is a no-op.
-			return &sourceEntry{infoStr: "info-1"}, nil
+			return &sharedSource{}, nil
 		},
 	}
 
@@ -664,13 +736,13 @@ func TestReconcile_FlowOriginRotationReopensReader(t *testing.T) {
 	// First reconcile: opens the initiator, records the origin timestamp.
 	_, err := r.Reconcile(context.Background(), req)
 	require.NoError(t, err)
-	require.Equal(t, int32(1), opener.calls.Load())
+	require.Equal(t, int32(1), opener.opens.Load())
 	t.Cleanup(func() { r.closeEntry(key) })
 
 	// Same timestamp on the MxlFlow: no rotation, no reopen.
 	_, err = r.Reconcile(context.Background(), req)
 	require.NoError(t, err)
-	assert.Equal(t, int32(1), opener.calls.Load(),
+	assert.Equal(t, int32(1), opener.opens.Load(),
 		"a Reconcile with no origin rotation must hit the fast path; "+
 			"opening the initiator twice would tear down the live transfer "+
 			"goroutine every controller-runtime tick")
@@ -685,7 +757,7 @@ func TestReconcile_FlowOriginRotationReopensReader(t *testing.T) {
 
 	_, err = r.Reconcile(context.Background(), req)
 	require.NoError(t, err)
-	assert.Equal(t, int32(2), opener.calls.Load(),
+	assert.Equal(t, int32(2), opener.opens.Load(),
 		"a fresher Origin AppearedAt must reopen the FlowReader so the "+
 			"gateway tails the rebound writer instead of the stale handle")
 }
@@ -729,7 +801,7 @@ func TestReconcile_SourceNodeMutatedAwayClosesEntry(t *testing.T) {
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
 
 	// Pre-seed: a previous reconcile (when spec.sourceNode == selfNode)
-	// installed an entry on this node. closeSourceHandles is nil-safe
+	// installed an entry on this node. The teardown is nil-safe
 	// for every field, so a zero-value entry is enough to detect the
 	// removal without spinning up real fabrics handles.
 	r.sources[key] = &sourceEntry{}
@@ -768,7 +840,7 @@ func TestSource_SeedAttemptsFromStatus(t *testing.T) {
 		Scheme:   scheme,
 		NodeName: "node-a",
 		opener: &fakeOpener{
-			openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+			attachFn: func(*sharedSource, string) (*fabrics.TargetInfo, error) {
 				return nil, errors.Join(errAddTargetFailed, errors.New("offline"))
 			},
 		},
@@ -1127,7 +1199,7 @@ func TestSource_FlusherSuppressesIdenticalTicksAfterFirstTransfer(t *testing.T) 
 		attempts:      attemptTable[sourceAddInputs]{},
 	}
 
-	entry := &sourceEntry{}
+	entry := &sourceEntry{key: key, shared: testShared("flow-1", fabrics.ProviderTCP)}
 	entry.progress.Store(1)
 	transferAt := time.Now()
 	entry.lastSentAt.Store(&transferAt)
@@ -1135,7 +1207,7 @@ func TestSource_FlusherSuppressesIdenticalTicksAfterFirstTransfer(t *testing.T) 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan struct{})
-	go r.runFlusher(ctx, done, key, entry, 2*time.Millisecond)
+	go r.runFlusher(ctx, done, entry, 2*time.Millisecond)
 
 	// Wait for the first publish so the assertion has a known
 	// baseline ResourceVersion to compare against.

--- a/gateway/internal/mirror/source_writergone_test.go
+++ b/gateway/internal/mirror/source_writergone_test.go
@@ -24,7 +24,6 @@ import (
 func notLandingEntry() *sourceEntry {
 	e := stalledEntry(42, ptrTime(time.Now()), 0, time.Time{})
 	e.openedAt = time.Now().Add(-defaultReaderStallAfter - time.Second)
-	e.flowID = "flow-1"
 	return e
 }
 
@@ -54,13 +53,14 @@ func TestRunFlusher_ReleasesReaderWhenWriterGoneWithoutARebuildState(t *testing.
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
 	entry := notLandingEntry()
+	entry.key = key
 	r := &SourceReconciler{
 		Client:       c,
 		Scheme:       scheme,
 		NodeName:     "node-a",
 		sources:      map[types.NamespacedName]*sourceEntry{key: entry},
 		attempts:     attemptTable[sourceAddInputs]{},
-		rebuilds:     map[types.NamespacedName]uint32{},
+		rebuilds:     map[sourceKey]uint32{},
 		writerLiveFn: func(string) (bool, error) { return false, nil },
 		rebuildFn: func(types.NamespacedName) {
 			t.Error("a flow with no writer must be released, not reopened")
@@ -70,7 +70,7 @@ func TestRunFlusher_ReleasesReaderWhenWriterGoneWithoutARebuildState(t *testing.
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan struct{})
-	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+	go r.runFlusher(ctx, done, entry, time.Millisecond)
 
 	select {
 	case <-done:
@@ -104,19 +104,20 @@ func TestRunFlusher_KeepsReaderWhileTheWriterIsLive(t *testing.T) {
 
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
 	entry := notLandingEntry()
+	entry.key = key
 	r := &SourceReconciler{
 		Client:       c,
 		Scheme:       scheme,
 		NodeName:     "node-a",
 		sources:      map[types.NamespacedName]*sourceEntry{key: entry},
 		attempts:     attemptTable[sourceAddInputs]{},
-		rebuilds:     map[types.NamespacedName]uint32{},
+		rebuilds:     map[sourceKey]uint32{},
 		writerLiveFn: func(string) (bool, error) { return true, nil },
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go r.runFlusher(ctx, done, key, entry, time.Millisecond)
+	go r.runFlusher(ctx, done, entry, time.Millisecond)
 
 	require.Eventually(t, func() bool {
 		var m mxlv1alpha1.MxlFlowMirror
@@ -150,9 +151,9 @@ func TestReconcile_DoesNotOpenAReaderWhileTheWriterIsGone(t *testing.T) {
 		Build()
 
 	opener := &fakeOpener{
-		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+		openFn: func(string, fabrics.Provider) (*sharedSource, error) {
 			t.Error("no reader may be opened on a flow with no writer")
-			return &sourceEntry{infoStr: "info-1"}, nil
+			return &sharedSource{}, nil
 		},
 	}
 	events := record.NewFakeRecorder(10)
@@ -173,7 +174,7 @@ func TestReconcile_DoesNotOpenAReaderWhileTheWriterIsGone(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, writerAbsentRetry, res.RequeueAfter,
 		"the mirror has to ask again, because a writer that re-attaches to a surviving flow directory rotates nothing")
-	assert.Zero(t, opener.calls.Load())
+	assert.Zero(t, opener.opens.Load())
 
 	var got mxlv1alpha1.MxlFlowMirror
 	require.NoError(t, c.Get(context.Background(), key, &got))
@@ -197,8 +198,8 @@ func TestReconcile_OpensAReaderOnceTheWriterIsBack(t *testing.T) {
 		Build()
 
 	opener := &fakeOpener{
-		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
-			return &sourceEntry{infoStr: "info-1"}, nil
+		openFn: func(string, fabrics.Provider) (*sharedSource, error) {
+			return &sharedSource{}, nil
 		},
 	}
 	live := false
@@ -216,13 +217,13 @@ func TestReconcile_OpensAReaderOnceTheWriterIsBack(t *testing.T) {
 	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
 	_, err := r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
 	require.NoError(t, err)
-	require.Zero(t, opener.calls.Load())
+	require.Zero(t, opener.opens.Load())
 
 	live = true
 	_, err = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
 	require.NoError(t, err)
 	t.Cleanup(func() { r.closeEntry(key) })
-	assert.Equal(t, int32(1), opener.calls.Load(),
+	assert.Equal(t, int32(1), opener.opens.Load(),
 		"a returning producer must get its mirror back without an operator")
 }
 
@@ -249,7 +250,7 @@ func TestReconcile_ParksAMirrorWhoseFlowIsNotInTheDomain(t *testing.T) {
 	// What libmxl answers on both paths for a flow that is not in the
 	// domain, wrapped the way the production callers wrap it.
 	opener := &fakeOpener{
-		openFn: func(string, string, fabrics.Provider) (*sourceEntry, error) {
+		openFn: func(string, fabrics.Provider) (*sharedSource, error) {
 			return nil, fmt.Errorf("NewReader: %w", mxl.ErrFlowNotFound)
 		},
 	}
@@ -274,7 +275,7 @@ func TestReconcile_ParksAMirrorWhoseFlowIsNotInTheDomain(t *testing.T) {
 		"a flow that is not here is a state to report, not a failure to retry")
 	assert.Equal(t, writerAbsentRetry, res.RequeueAfter,
 		"the mirror has to ask again: a producer landing on this node fires no event here")
-	assert.Zero(t, opener.calls.Load(),
+	assert.Zero(t, opener.opens.Load(),
 		"opening a reader on a flow libmxl cannot find can only fail")
 
 	var got mxlv1alpha1.MxlFlowMirror
@@ -287,6 +288,6 @@ func TestReconcile_ParksAMirrorWhoseFlowIsNotInTheDomain(t *testing.T) {
 	res, err = r.Reconcile(context.Background(), reconcile.Request{NamespacedName: key})
 	require.NoError(t, err)
 	assert.Equal(t, writerAbsentRetry, res.RequeueAfter)
-	assert.Zero(t, opener.calls.Load())
+	assert.Zero(t, opener.opens.Load())
 	assert.Len(t, events.Events, 1, "a parked mirror must emit one event, not one per retry")
 }

--- a/gateway/internal/mirror/throughput.go
+++ b/gateway/internal/mirror/throughput.go
@@ -75,15 +75,21 @@ func (c *ThroughputCollector) Collect(ch chan<- prometheus.Metric) {
 
 // Throughput reports what each mirror this node sources has put on the
 // fabric.
+//
+// Still one entry per mirror although the mirrors of one flow share an
+// initiator: a transfer is enqueued to every target that initiator
+// holds, so the bytes really did go to each peer, and folding them
+// onto the flow would drop the peer_node label the series are told
+// apart by.
 func (r *SourceReconciler) Throughput() []Throughput {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	out := make([]Throughput, 0, len(r.sources))
 	for _, e := range r.sources {
 		out = append(out, Throughput{
-			FlowID:   e.flowID,
+			FlowID:   e.flowID(),
 			PeerNode: e.peerNode,
-			Provider: e.provider.String(),
+			Provider: e.provider().String(),
 			Bytes:    e.bytes.Load(),
 		})
 	}

--- a/gateway/internal/mirror/throughput_test.go
+++ b/gateway/internal/mirror/throughput_test.go
@@ -17,7 +17,7 @@ func TestThroughputCollectorReportsBothDirections(t *testing.T) {
 	// "what is this node pushing over verbs" by aggregation rather
 	// than by a second metric.
 	src := &SourceReconciler{sources: map[types.NamespacedName]*sourceEntry{}}
-	sent := &sourceEntry{flowID: "flow-a", peerNode: "n02", provider: fabrics.ProviderVerbs}
+	sent := &sourceEntry{shared: testShared("flow-a", fabrics.ProviderVerbs), peerNode: "n02"}
 	sent.bytes.Store(5529600)
 	src.sources[types.NamespacedName{Namespace: "p", Name: "a"}] = sent
 
@@ -47,7 +47,7 @@ func TestThroughputCollectorForgetsClosedMirrors(t *testing.T) {
 	// than one that is gone.
 	src := &SourceReconciler{sources: map[types.NamespacedName]*sourceEntry{}}
 	key := types.NamespacedName{Namespace: "p", Name: "a"}
-	e := &sourceEntry{flowID: "flow-a", peerNode: "n02", provider: fabrics.ProviderVerbs}
+	e := &sourceEntry{shared: testShared("flow-a", fabrics.ProviderVerbs), peerNode: "n02"}
 	e.bytes.Store(1024)
 	src.sources[key] = e
 
@@ -68,7 +68,7 @@ func TestThroughputCollectorSurvivesOneFlowMirroredTwice(t *testing.T) {
 	// scraped at all.
 	src := &SourceReconciler{sources: map[types.NamespacedName]*sourceEntry{}}
 	for _, peer := range []string{"n02", "n03"} {
-		e := &sourceEntry{flowID: "flow-a", peerNode: peer, provider: fabrics.ProviderVerbs}
+		e := &sourceEntry{shared: testShared("flow-a", fabrics.ProviderVerbs), peerNode: peer}
 		e.bytes.Store(1000)
 		src.sources[types.NamespacedName{Namespace: "p", Name: "flow-a--" + peer}] = e
 	}
@@ -82,7 +82,7 @@ mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node
 
 	// Same flow and same peer in two namespaces cannot be separated by
 	// labels at all, so the fold has to carry it.
-	dup := &sourceEntry{flowID: "flow-a", peerNode: "n02", provider: fabrics.ProviderVerbs}
+	dup := &sourceEntry{shared: testShared("flow-a", fabrics.ProviderVerbs), peerNode: "n02"}
 	dup.bytes.Store(500)
 	src.sources[types.NamespacedName{Namespace: "other", Name: "flow-a--n02"}] = dup
 	require.Equal(t, 2, testutil.CollectAndCount(c),

--- a/gateway/internal/mirror/wedge_test.go
+++ b/gateway/internal/mirror/wedge_test.go
@@ -7,6 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	"github.com/qvest-digital/go-mxl/fabrics"
+
 	mxlv1alpha1 "github.com/qvest-digital/mxl-k8s/api/v1alpha1"
 )
 
@@ -17,7 +19,7 @@ func TestObservedStateReportsTransfersNotLanding(t *testing.T) {
 	// healthy and leaves the mirror there for good.
 	const stall = 20 * time.Second
 
-	entry := &sourceEntry{openedAt: time.Now().Add(-time.Minute)}
+	entry := &sourceEntry{shared: testShared("flow-1", fabrics.ProviderTCP), openedAt: time.Now().Add(-time.Minute)}
 	entry.lastHead.Store(4242)
 	advanced := time.Now()
 	entry.headAdvancedAt.Store(&advanced)
@@ -30,7 +32,7 @@ func TestObservedStateReportsTransfersNotLanding(t *testing.T) {
 
 	// A mirror still inside the window has legitimately delivered
 	// nothing yet and must not be called wedged.
-	fresh := &sourceEntry{openedAt: time.Now()}
+	fresh := &sourceEntry{shared: testShared("flow-1", fabrics.ProviderTCP), openedAt: time.Now()}
 	fresh.lastHead.Store(7)
 	fresh.headAdvancedAt.Store(&advanced)
 	require.Equal(t, mxlv1alpha1.ReasonHandshakeComplete,
@@ -38,7 +40,7 @@ func TestObservedStateReportsTransfersNotLanding(t *testing.T) {
 
 	// Once a transfer lands after the open, the wedge reading has to
 	// clear on its own.
-	delivered := &sourceEntry{openedAt: time.Now().Add(-time.Minute)}
+	delivered := &sourceEntry{shared: testShared("flow-1", fabrics.ProviderTCP), openedAt: time.Now().Add(-time.Minute)}
 	delivered.lastHead.Store(4242)
 	delivered.headAdvancedAt.Store(&advanced)
 	sent := time.Now().Add(-time.Second)


### PR DESCRIPTION
A libmxl-fabrics initiator enqueues every `TransferGrain` and
`TransferSamples` call to all of the targets added to it, so one flow
mirrored from this node to N others needs one `FlowReader`, one
`Initiator` and one transfer goroutine, with one `AddTarget` per
mirror. The source reconciler keyed its live state by MxlFlowMirror and
opened all of it per mirror instead: N readers of the same ring, N
endpoints, N transfer loops, and N copies of every grain posted to the
NIC. The work grew with fan-out for no payload that reached a peer any
sooner.

The reader, the initiator, the transfer goroutine and the head
observations the stall watchdog judges now hang off a source keyed by
(flow, provider). The provider is half the key because an initiator is
set up against one interface and that interface is chosen per provider,
so mirrors of one flow asking for different providers cannot share one.

Per mirror there remains the fabrics target, the status flusher, the
AddTarget attempt counter and the byte and progress counters. Those
counters are fanned out from the shared transfer loop rather than
collapsed onto the flow: a transfer really is enqueued to every added
target, so every attached mirror really did move those bytes and really
is at that index, and `mxl_gateway_mirror_transmitted_bytes_total`
keeps its per-peer series. `SourceProgress`, `ReaderNotAdvancing`,
`ReaderAgedOut` and `ReaderRebuildCapReached` are published per mirror
exactly as before.

Attaching a mirror to a live source is `ParseTargetInfo` plus
`AddTarget`, and detaching one is `RemoveTarget`; the reader and the
loop close only when the last mirror leaves. A rotated target info
swaps that one target rather than rebuilding everything. An origin
rotation and the reader-stall rebuild still tear the reader down, which
now costs every attached mirror its target, so both paths drive the
evicted mirrors back through Reconcile instead of leaving them to a
watch that goes quiet exactly when the producer is in trouble.

The reader rebuild budget moves with the reader it bounds, from per
mirror to per shared source. Left per mirror it would grant a flow
mirrored to N nodes N times `maxReaderRebuilds` reopens of the single
reader they share.

Two visible changes fall out of the shape. The grain pacer's phase
offset is seeded from (flow, provider) rather than (flow, target
info), because there is now one transfer stream per flow whatever its
fan-out. Every mirror of a flow observes the same head index and the
same aged-out skip at the same moment, where before each had its own
reader and could differ.
