### PR TITLE
fix(gateway): bound sample catch-up to stop aged-out burst

### DIFF
--- a/gateway/internal/mirror/sample_test.go
+++ b/gateway/internal/mirror/sample_test.go
@@ -163,16 +163,16 @@ func TestRunSampleTransferLoop_FellBehindSkipsToBoundedCatchUpAndSignals(t *test
 	tracker := &recordingTracker{}
 	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
 
-	require.Eventually(t, func() bool { return len(xfersSnap()) == 1 },
-		time.Second, time.Millisecond, "expected the clamped final run to transfer")
+	require.Eventually(t, func() bool { return len(xfersSnap()) == 2 },
+		time.Second, time.Millisecond, "expected the bounded catch-up to transfer as two full batches")
 
 	cancel()
 	<-done
 
-	assert.Equal(t, []sampleXfer{{head: 2000, count: 2 * xferBatch}}, xfersSnap(),
+	assert.Equal(t, []sampleXfer{{head: 1520, count: xferBatch}, {head: 2000, count: xferBatch}}, xfersSnap(),
 		"after falling behind, the loop must transfer only the bounded catch-up ending at head")
 	transfers, agedOuts := tracker.snapshot()
-	assert.Equal(t, []uint64{2000}, transfers)
+	assert.Equal(t, []uint64{1520, 2000}, transfers)
 	assert.Equal(t, 1, agedOuts,
 		"falling more than the catch-up bound behind must record exactly one aged-out skip so the "+
 			"reconciler can publish SourceProgress=ReaderAgedOut")

--- a/gateway/internal/mirror/sample_test.go
+++ b/gateway/internal/mirror/sample_test.go
@@ -56,7 +56,7 @@ func TestRunSampleTransferLoop_TransfersDeltaSinceLastTick(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, makeProgress, 480, 480, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, makeProgress, 480, time.Millisecond, tracker)
 
 	require.Eventually(t, func() bool { return len(xfersSnap()) == 1 },
 		time.Second, time.Millisecond, "expected exactly one sample-run transfer")
@@ -78,15 +78,15 @@ func TestRunSampleTransferLoop_ChunksLargeDeltaByXferBatch(t *testing.T) {
 	// A within-window delta larger than xferBatch must be transferred
 	// as several runs of at most xferBatch each, not one oversized
 	// TransferSamples (the fabric rejects an over-large count). The
-	// delta is below maxBatch, so this is a normal catch-up with no
-	// aged-out skip.
+	// delta is exactly the catch-up bound, so this is a normal
+	// catch-up with no aged-out skip.
 	const xferBatch = 480
 	var probeCalls atomic.Int32
 	probe := func() (uint64, error) {
 		if probeCalls.Add(1) == 1 {
 			return 0, nil
 		}
-		return 1200, nil
+		return 960, nil
 	}
 
 	var mu sync.Mutex
@@ -108,29 +108,32 @@ func TestRunSampleTransferLoop_ChunksLargeDeltaByXferBatch(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	// maxBatch large so no aged-out clamp fires; xferBatch caps each run.
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, 100000, xferBatch, time.Millisecond, tracker)
+	// The delta is larger than xferBatch but inside the catch-up
+	// bound (2*xferBatch), so it must split into full-batch runs
+	// with no aged-out skip.
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
 
-	require.Eventually(t, func() bool { return len(xfersSnap()) == 3 },
-		time.Second, time.Millisecond, "expected the 1200-sample delta to split into 480+480+240")
+	require.Eventually(t, func() bool { return len(xfersSnap()) == 2 },
+		time.Second, time.Millisecond, "expected the 960-sample delta to split into 480+480")
 
 	cancel()
 	<-done
 
-	assert.Equal(t, []sampleXfer{{480, 480}, {960, 480}, {1200, 240}}, xfersSnap(),
+	assert.Equal(t, []sampleXfer{{480, 480}, {960, 480}}, xfersSnap(),
 		"the loop must chunk the delta into runs of at most xferBatch, each ending at the chunk's last index")
 	_, agedOuts := tracker.snapshot()
-	assert.Zero(t, agedOuts, "a within-maxBatch delta is a normal catch-up, not an aged-out skip")
+	assert.Zero(t, agedOuts, "a within-bound delta is a normal catch-up, not an aged-out skip")
 }
 
-func TestRunSampleTransferLoop_FellBehindSkipsToWindowAndSignals(t *testing.T) {
-	// The producer has lapped the reader by more than maxBatch. The
-	// loop must skip to head-maxBatch (the oldest still-readable
-	// sample), signal the tracker once, and transfer only the final
-	// maxBatch run. The dropped samples are unrecoverable: re-reading
-	// them would fail because they have left the ring's readable
-	// window.
-	const maxBatch = 480
+func TestRunSampleTransferLoop_FellBehindSkipsToBoundedCatchUpAndSignals(t *testing.T) {
+	// The producer has lapped the reader far beyond one tick's
+	// catch-up. The loop must skip to head-2*xferBatch (the newest
+	// batch plus one batch of slack, not the readable-window edge),
+	// signal the tracker once, and transfer only what the bound
+	// allows. Skipping to the window edge instead would attempt the
+	// whole readable window in one tick: a burst that floods the
+	// send queue and wedges every mirror sharing the fabric.
+	const xferBatch = 480
 	var probeCalls atomic.Int32
 	probe := func() (uint64, error) {
 		if probeCalls.Add(1) == 1 {
@@ -158,7 +161,7 @@ func TestRunSampleTransferLoop_FellBehindSkipsToWindowAndSignals(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, maxBatch, maxBatch, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
 
 	require.Eventually(t, func() bool { return len(xfersSnap()) == 1 },
 		time.Second, time.Millisecond, "expected the clamped final run to transfer")
@@ -166,13 +169,75 @@ func TestRunSampleTransferLoop_FellBehindSkipsToWindowAndSignals(t *testing.T) {
 	cancel()
 	<-done
 
-	assert.Equal(t, []sampleXfer{{head: 2000, count: maxBatch}}, xfersSnap(),
-		"after falling behind, the loop must transfer only the final maxBatch run ending at head")
+	assert.Equal(t, []sampleXfer{{head: 2000, count: 2 * xferBatch}}, xfersSnap(),
+		"after falling behind, the loop must transfer only the bounded catch-up ending at head")
 	transfers, agedOuts := tracker.snapshot()
 	assert.Equal(t, []uint64{2000}, transfers)
 	assert.Equal(t, 1, agedOuts,
-		"falling more than maxBatch behind must record exactly one aged-out skip so the "+
+		"falling more than the catch-up bound behind must record exactly one aged-out skip so the "+
 			"reconciler can publish SourceProgress=ReaderAgedOut")
+}
+
+func TestRunSampleTransferLoop_NeverBurstsBeyondCatchUpPerTick(t *testing.T) {
+	// A mirror that has fallen far behind must not attempt the
+	// whole backlog in one tick: at most two xferBatch chunks are
+	// transferable per tick, and only while the lag stays inside the
+	// bound. This is what keeps a 48 kHz mirror from posting a burst
+	// of hundreds of writes -- one per readable-window batch --
+	// against the fabric. The loop transfers the bounded catch-up
+	// and leaves the rest for the next tick; it does not spin.
+	const xferBatch = 480
+	var probes atomic.Uint64
+	probe := func() (uint64, error) {
+		if probes.Add(1) == 1 {
+			return 0, nil
+		}
+		return 2000, nil
+	}
+
+	var mu sync.Mutex
+	var xfers []sampleXfer
+	transfer := func(head uint64, count int) error {
+		mu.Lock()
+		xfers = append(xfers, sampleXfer{head, count})
+		mu.Unlock()
+		return nil
+	}
+	xfersSnap := func() []sampleXfer {
+		mu.Lock()
+		defer mu.Unlock()
+		out := make([]sampleXfer, len(xfers))
+		copy(out, xfers)
+		return out
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	tracker := &recordingTracker{}
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
+
+	require.Eventually(t, func() bool { return len(xfersSnap()) >= 1 },
+		time.Second, time.Millisecond, "the bounded catch-up must transfer")
+
+	// Give the loop more ticks than it would need to burst the whole
+	// backlog had the bound not held, then verify it never did: two
+	// chunks maximum per tick, each ending inside the bound.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	<-done
+
+	snap := xfersSnap()
+	for i, x := range snap {
+		assert.LessOrEqualf(t, x.count, int(xferBatch), "chunk %d: a single write must never exceed xferBatch", i)
+		if i > 0 {
+			assert.LessOrEqualf(t, snap[i].head-snap[i-1].head, uint64(2*xferBatch),
+				"chunk %d: consecutive transfers within a tick must not exceed the catch-up bound", i)
+		}
+	}
+	// The first tick is the only one that skips to the bound; with
+	// the head frozen afterwards nothing more transfers.
+	assert.LessOrEqualf(t, len(snap), 2,
+		"a frozen head must not produce further transfers, got %d", len(snap))
 }
 
 func TestRunSampleTransferLoop_TransferErrorBreaksTickAndRetries(t *testing.T) {
@@ -208,7 +273,7 @@ func TestRunSampleTransferLoop_TransferErrorBreaksTickAndRetries(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, 480, 480, time.Millisecond, &recordingTracker{})
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, 480, time.Millisecond, &recordingTracker{})
 
 	require.Eventually(t, func() bool { return xfersLen() >= 1 },
 		time.Second, time.Millisecond, "a transfer error must not wedge the loop; the next tick must retry")
@@ -232,7 +297,7 @@ func TestRunSampleTransferLoop_CtxCancelExitsDuringIdle(t *testing.T) {
 	done := make(chan struct{})
 	go runSampleTransferLoop(ctx, done, "flow-audio", probe,
 		func(uint64, int) error { t.Error("no transfer expected on an idle flow"); return nil },
-		func() error { return nil }, 480, 480, time.Millisecond, &recordingTracker{})
+		func() error { return nil }, 480, time.Millisecond, &recordingTracker{})
 
 	cancel()
 	select {

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -711,9 +711,10 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 
 	// A continuous (audio) flow moves samples, not grains; pick the
 	// transfer path from the flow's data format. maxBatch is the
-	// reader's max readable sample run, used as the catch-up window;
-	// xferBatch caps a single TransferSamples call, which the fabric
-	// rejects when the count is over-large.
+	// reader's max readable sample run, which caps xferBatch so a
+	// single TransferSamples never exceeds the target's bounce-buffer
+	// entry; xferBatch is one natural commit batch (~10 ms of audio)
+	// and also sizes the transfer tick and the catch-up bound.
 	cfg, err := reader.Config()
 	if err != nil {
 		_ = info.Close()
@@ -824,7 +825,7 @@ func (o *libmxlOpener) open(flowID, targetInfoStr string, provider fabrics.Provi
 			entry.bytes.Add(uint64(count) * frameBytes)
 			return nil
 		}
-		go runSampleTransferLoop(loopCtx, done, flowID, runtimeFn, transferSamplesFn, progressFn, maxBatch, xferBatch, progressInterval, entry)
+		go runSampleTransferLoop(loopCtx, done, flowID, runtimeFn, transferSamplesFn, progressFn, xferBatch, progressInterval, entry)
 	} else {
 		// The pacer is keyed on flow plus target so two mirrors of one
 		// flow, and mirrors of different flows, get different phase
@@ -1065,10 +1066,13 @@ func runTransferLoop(
 // continuous flow's head advances by many samples between ticks, so
 // the loop transfers the (lastSent, head] delta in chunks of at most
 // xferBatch samples (the fabric rejects an over-large single transfer).
-// If the source falls more than maxBatch (the reader's max readable
-// sample run) behind the writer the oldest samples have left the
-// readable window; the loop skips ahead to head-maxBatch and signals
-// the tracker so the reconciler can publish SourceProgress=ReaderAgedOut.
+// The catch-up is bounded: a mirror that fell behind transfers at most
+// maxSampleCatchUp (a small multiple of xferBatch) per tick and skips
+// anything older, signalling the tracker so the reconciler can publish
+// SourceProgress=ReaderAgedOut. A continuous flow is consumed at its
+// own sample rate, so a backlog can never be drained faster than real
+// time; attempting it floods the send queue and starves every mirror
+// sharing the fabric.
 //
 // The cgo-dependent calls are injected as functions so the state
 // machine stays testable without libmxl-fabrics. Production binds
@@ -1107,7 +1111,6 @@ func runSampleTransferLoop(
 	probeRuntime RuntimeProbe,
 	transferSamples SampleTransferFunc,
 	makeProgress ProgressFunc,
-	maxBatch uint64,
 	xferBatch uint64,
 	interval time.Duration,
 	tracker progressTracker,
@@ -1115,6 +1118,15 @@ func runSampleTransferLoop(
 	defer close(done)
 
 	l := ctrl.Log.WithName("sample-transfer").WithValues("flowID", flowID)
+
+	// catchUp bounds how far behind the live head one tick may reach.
+	// Two batches keeps one batch of slack for a late-arriving head
+	// probe without opening a burst; anything older is skipped as
+	// aged out.
+	catchUp := 2 * xferBatch
+	if catchUp == 0 {
+		catchUp = maxSampleCatchUpFallback
+	}
 
 	// Discover the current head and tail the live flow from there,
 	// rather than replaying samples the producer may already have aged
@@ -1155,17 +1167,26 @@ func runSampleTransferLoop(
 			tracker.recordHead(head, time.Now())
 		}
 		if head > lastSent {
-			// Fell behind: the samples between lastSent+1 and
-			// head-maxBatch have left the readable window. Skip them
-			// and signal the tracker so the reconciler can publish the
-			// SourceProgress=ReaderAgedOut condition.
-			if maxBatch > 0 && head-lastSent > maxBatch {
+			// A continuous flow can only be consumed at its own
+			// sample rate: one xferBatch per tick is real time, and
+			// no fabric drains a backlog faster than that. A mirror
+			// that falls behind therefore cannot catch up by bursting
+			// -- attempting it transfers up to the whole readable
+			// window (hundreds of xferBatch writes) in one tick,
+			// which floods the send queue and wedges the fabric for
+			// every mirror sharing it. Cap the catch-up at a small
+			// multiple of one batch and treat anything older as
+			// aged out, matching the reference transfer loop, which
+			// transfers one batch per grain instant and, on falling
+			// behind, jumps to the live head rather than replaying
+			// the gap.
+			if head-lastSent > catchUp {
 				l.Info("reader fell behind writer, skipping samples",
 					"fromIndex", lastSent+1, "toIndex", head)
 				if tracker != nil {
 					tracker.recordAgedOut(time.Now())
 				}
-				lastSent = head - maxBatch
+				lastSent = head - catchUp
 			}
 			// Transfer the remaining (lastSent, head] delta in chunks
 			// of at most xferBatch samples, each ending at the chunk's
@@ -1874,6 +1895,12 @@ func (r *SourceReconciler) flowToMirrors(ctx context.Context, obj client.Object)
 // where the head is re-read and the wedge becomes visible as a stalled
 // lastSent.
 const maxSampleTransferRetries = 8
+
+// maxSampleCatchUpFallback is the per-tick catch-up bound used when
+// xferBatch is zero, which cannot happen in production (the open path
+// defaults it to one sample at minimum) but keeps the loop's bound
+// non-zero on its own terms.
+const maxSampleCatchUpFallback = 2
 
 // defaultProgressTimeout caps how long a blocking MakeProgress call
 // parks on the completion queue before returning. The verbs provider

--- a/gateway/internal/mirror/source_samples_test.go
+++ b/gateway/internal/mirror/source_samples_test.go
@@ -59,7 +59,7 @@ func TestRunSampleTransferLoop_RetriesAFullSendQueueWithinTheTick(t *testing.T) 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go runSampleTransferLoop(ctx, done, "f", probe, transfer, progress,
-		4800, 480, time.Millisecond, nil)
+		480, time.Millisecond, nil)
 
 	require.Eventually(t, func() bool {
 		mu.Lock()
@@ -83,12 +83,12 @@ func TestRunSampleTransferLoop_RetriesAFullSendQueueWithinTheTick(t *testing.T) 
 func TestRunSampleTransferLoop_BackpressureDoesNotReportReaderAgedOut(t *testing.T) {
 	// The producer writes one chunk per tick and the send queue refuses
 	// two attempts out of every three. Retrying in place clears a chunk
-	// per tick and keeps pace. One attempt per tick clears a chunk every
-	// third tick, falls behind 320 samples a tick, crosses the 4800
-	// readable window in about fifteen, and then skips samples and
-	// publishes ReaderAgedOut for a queue that was merely busy. That is
-	// the live symptom: a mirror pinned at ReaderAgedOut whose reader
-	// was never at fault.
+	// per tick and keeps pace, so the lag never grows past one chunk and
+	// no aged-out is recorded. Abandoning each refused chunk until the
+	// next tick instead would let the lag grow past the catch-up bound,
+	// and the loop would skip samples and publish ReaderAgedOut for a
+	// queue that was merely busy. That is the live symptom: a mirror
+	// pinned at ReaderAgedOut whose reader was never at fault.
 	var probes atomic.Uint64
 	probe := func() (uint64, error) { return 1000 + probes.Add(480), nil }
 
@@ -104,7 +104,7 @@ func TestRunSampleTransferLoop_BackpressureDoesNotReportReaderAgedOut(t *testing
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
-		4800, 480, time.Millisecond, tr)
+		480, time.Millisecond, tr)
 
 	// Well past the ~15 ticks it takes to cross the window unretried.
 	require.Eventually(t, func() bool { return tr.transfers() >= 60 }, 3*time.Second, time.Millisecond,
@@ -137,7 +137,7 @@ func TestRunSampleTransferLoop_BoundsRetriesSoAWedgedFabricYieldsTheTick(t *test
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
-		4800, 480, 20*time.Millisecond, nil)
+		480, 20*time.Millisecond, nil)
 
 	// Two ticks' worth of time. With the bound, attempts stay near
 	// 2 * (1 + maxSampleTransferRetries); without it the loop would
@@ -171,7 +171,7 @@ func TestRunSampleTransferLoop_NonIdleErrorBreaksImmediately(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
-		4800, 480, 20*time.Millisecond, nil)
+		480, 20*time.Millisecond, nil)
 
 	time.Sleep(100 * time.Millisecond)
 	cancel()
@@ -201,7 +201,7 @@ func TestRunSampleTransferLoop_StillSkipsWhenGenuinelyLapped(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
-		4800, 480, time.Millisecond, tr)
+		480, time.Millisecond, tr)
 
 	require.Eventually(t, func() bool { return tr.agedOut() > 0 }, time.Second, time.Millisecond,
 		"a producer that lapped the readable window is still ReaderAgedOut")

--- a/gateway/internal/mirror/source_stall_test.go
+++ b/gateway/internal/mirror/source_stall_test.go
@@ -242,7 +242,7 @@ func TestRunSampleTransferLoop_RecordsProbedHead(t *testing.T) {
 			return nil
 		},
 		func() error { return nil },
-		480, 480, time.Millisecond, tracker)
+		480, time.Millisecond, tracker)
 
 	<-done
 	heads := tracker.headSnapshot()


### PR DESCRIPTION
A continuous flow can only be consumed at its own sample rate, so a mirror that falls behind can never drain its backlog faster than real time. The sample loop still tried: after an aged-out skip it clamped `lastSent` to the readable-window edge and then attempted to transfer the entire remaining window in one tick -- hundreds of `xferBatch` writes, up to the full ring depth, against a fabric whose send queue holds a handful. The first chunk returns EAGAIN, the in-tick retry path re-posts against a queue that cannot drain, and the loop wedges pinned at `ReaderAgedOut` with nothing transferring while the EAGAIN storm starves every mirror sharing the initiator.

The reference transfer loop (`tools/mxl-fabrics-demo`) never constructs this burst: it transfers exactly one batch per grain instant and, on falling behind, jumps to the live head instead of replaying the gap.

The fix:

- Bound the catch-up at `2 * xferBatch` per tick (one batch plus one batch of slack for a late head probe). Anything older is skipped and recorded as aged out, so `SourceProgress=ReaderAgedOut` still publishes for a genuinely lapped reader.
- Drop the `maxBatch` (readable-window) clamp from the loop entirely, and with it the `maxBatch` parameter: the window edge is never a sane transfer target, and `xferBatch` -- already capped by the target bounce-buffer entry size in `open` -- sizes the bound.
- Steady state and the backpressure retry path are unchanged: one `xferBatch` write per tick, in-place retries with `MakeProgress` driven between attempts.

Tests updated to the new semantics: the aged-out skip now lands at `head - 2*xferBatch`, the multi-chunk catch-up test stays inside the bound, and a new test pins that no tick ever transfers more than the bound so the burst cannot regress silently.