### PR TITLE
fix(gateway): recover sample-mirror wedges instead of pinning them

### DIFF
--- a/gateway/internal/mirror/sample_test.go
+++ b/gateway/internal/mirror/sample_test.go
@@ -240,6 +240,89 @@ func TestRunSampleTransferLoop_NeverBurstsBeyondCatchUpPerTick(t *testing.T) {
 		"a frozen head must not produce further transfers, got %d", len(snap))
 }
 
+func TestRunSampleTransferLoop_ExitsAfterSustainedRefusal(t *testing.T) {
+	// A send queue that refuses every chunk while the writer keeps
+	// producing is a connection that will not drain on its own. The
+	// loop must stop after maxSampleRefusedTicks consecutive
+	// refusing ticks rather than skip-retrying forever: a live loop
+	// keeps probing the head, so the flusher's stale-head watchdog
+	// never fires and nothing else on the source side breaks the
+	// state. Exiting stops the head probes, which the flusher reads
+	// as ReaderNotAdvancing and rebuilds the source end to end.
+	const xferBatch = 480
+	var probes atomic.Uint64
+	probe := func() (uint64, error) {
+		// The head advances one batch per tick so every tick finds
+		// new samples to refuse.
+		return probes.Add(xferBatch), nil
+	}
+	transfer := func(uint64, int) error {
+		return fabrics.ErrNotReady
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	tracker := &recordingTracker{}
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
+
+	select {
+	case <-done:
+		// The loop exited on its own: the sustained-refusal bound fired.
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not exit under sustained refusal; the wedge would persist forever")
+	}
+
+	// Every tick refused, so nothing landed and the loop kept
+	// skipping: the exit must not have recorded a transfer.
+	transfers, _ := tracker.snapshot()
+	assert.Empty(t, transfers, "a refused queue must never be recorded as delivered")
+	// The head probes ran for at least the bound's worth of ticks
+	// before the exit, proving the loop tolerated the full window
+	// before giving up rather than exiting on the first refusal.
+	assert.GreaterOrEqual(t, probes.Load(), uint64(maxSampleRefusedTicks*xferBatch),
+		"the loop must tolerate the whole refusal window before exiting")
+}
+
+func TestRunSampleTransferLoop_RefusalCountResetsOnDelivery(t *testing.T) {
+	// A busy queue that intermittently refuses but delivers before
+	// the refusal window elapses must run forever: the exit bound
+	// counts only *consecutive* refusing ticks, and clearing it on
+	// delivery keeps a healthy backpressure episode from being
+	// mistaken for a dead connection.
+	const xferBatch = 480
+	var probes atomic.Uint64
+	var calls atomic.Int32
+	probe := func() (uint64, error) {
+		return probes.Add(xferBatch), nil
+	}
+	transfer := func(uint64, int) error {
+		// Refuse heavily, but land every few attempts.
+		if calls.Add(1)%10 != 0 {
+			return fabrics.ErrNotReady
+		}
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	tracker := &recordingTracker{}
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
+
+	// Far longer than the refusal window: if the counter were not
+	// reset by deliveries the loop would have exited inside it.
+	time.Sleep(2 * time.Second)
+	select {
+	case <-done:
+		t.Fatal("loop exited despite regular deliveries; the refusal counter is not reset on delivery")
+	default:
+	}
+	cancel()
+	<-done
+	transfers, _ := tracker.snapshot()
+	assert.NotEmpty(t, transfers, "an intermittently delivering queue must have landed chunks")
+}
+
 func TestRunSampleTransferLoop_TransferErrorBreaksTickAndRetries(t *testing.T) {
 	// A transferSamples error (e.g. the fabric briefly not ready) must
 	// not exit the loop or advance lastSent past the failed run: the

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -1451,6 +1451,19 @@ func runSampleTransferLoop(
 	defer t.Stop()
 	// Throttles MakeProgress while it keeps failing; see progress.go.
 	var progress progressThrottle
+	// refusals counts consecutive ticks in which the writer produced
+	// new samples but not one chunk landed. MakeProgress is blocking
+	// for the verbs provider, so every retry parks on the completion
+	// queue; a queue that never yields a completion parks forever,
+	// and the loop degrades into an aged-out skip every tick -- real
+	// time in, nothing out -- while the fabric slot it holds never
+	// recovers on its own. Bounded here because no other part of the
+	// source side will break the state: the reader is healthy (the
+	// head advances), so the stall watchdog that reopens wedged
+	// readers never fires. Exiting lets headAdvancedAt go stale,
+	// which the flusher reads as ReaderNotAdvancing and rebuilds
+	// the source end to end -- fresh initiator, fresh connection.
+	refusals := 0
 
 	for {
 		select {
@@ -1509,6 +1522,7 @@ func runSampleTransferLoop(
 			// samples and published ReaderAgedOut for what was really a
 			// momentarily full queue.
 			retries := 0
+			landed := false
 			for lastSent < head {
 				count := head - lastSent
 				if xferBatch > 0 && count > xferBatch {
@@ -1526,10 +1540,22 @@ func runSampleTransferLoop(
 					break
 				}
 				retries = 0
+				landed = true
 				if tracker != nil {
 					tracker.recordTransfer(end, time.Now())
 				}
 				lastSent = end
+			}
+			if !landed {
+				refusals++
+				if refusals >= maxSampleRefusedTicks {
+					l.Error(nil, "sample transfers refused across ticks; exiting so the source is rebuilt",
+						"refusedTicks", refusals,
+						"lastSent", lastSent, "head", head)
+					return
+				}
+			} else {
+				refusals = 0
 			}
 		}
 
@@ -2314,6 +2340,17 @@ func (r *SourceReconciler) flowToMirrors(ctx context.Context, obj client.Object)
 // where the head is re-read and the wedge becomes visible as a stalled
 // lastSent.
 const maxSampleTransferRetries = 8
+
+// maxSampleRefusedTicks bounds how many consecutive ticks the sample
+// loop may find new samples but land none. A send queue that refuses
+// every chunk while MakeProgress parks on an empty completion queue
+// is a connection that will not recover on its own, and the loop's
+// per-tick retry bound alone would keep it alive forever. At the
+// default grain-rate interval one tick is ~10 ms of audio, so the
+// window is a few seconds of absolute refusal: far longer than any
+// healthy backpressure episode and short enough that the rebuild the
+// exit triggers outruns an operator noticing.
+const maxSampleRefusedTicks = 200
 
 // maxSampleCatchUpFallback is the per-tick catch-up bound used when
 // xferBatch is zero, which cannot happen in production (the open path

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -1278,6 +1278,14 @@ func (r *TargetReconciler) dispatchRecovery(key types.NamespacedName) {
 // TargetInfo is published to mirror.status so the source side picks
 // up the rotation through its existing watch.
 //
+// The TargetInfo publish is part of the rebuild's success criteria,
+// not an afterthought: a source initiator holding the pre-rebuild
+// address keeps posting against an endpoint nobody answers, which
+// wedges its send queue until it is reopened. A publish that cannot
+// be completed therefore drops the entry rather than returning with
+// a live fabric side the source will never reach, and the next
+// Reconcile rebuilds target and publish together.
+//
 // Must be invoked from a goroutine other than the progress loop
 // itself: we wait on the loop's done channel before touching the
 // entry's resources.
@@ -1288,6 +1296,18 @@ func (r *TargetReconciler) recoverFromFatalError(key types.NamespacedName) {
 	entry := r.targets[key]
 	r.mu.Unlock()
 	if entry == nil {
+		return
+	}
+
+	// One recovery is one attempt against the shared budget, whoever
+	// spawned it: the watchdog adds nothing of its own, so a loop that
+	// dies fatally on every rebuild runs out here rather than cycling
+	// forever. recordCommit resets the budget once a fresh commit
+	// lands, so only consecutive failures accumulate.
+	if attempts := entry.recoveryAttempts.Add(1); attempts > maxStuckRebuilds {
+		l.Info("fatal recovery cap reached; dropping entry",
+			"attempts", attempts)
+		r.dropFailedEntry(key, entry)
 		return
 	}
 
@@ -1390,19 +1410,73 @@ func (r *TargetReconciler) recoverFromFatalError(key types.NamespacedName) {
 		if !apierrors.IsNotFound(err) {
 			l.Error(err, "get mirror during recovery")
 		}
+		// The mirror is gone or unreadable: nothing to publish the
+		// fresh TargetInfo to, so the fabric side just opened will
+		// never be dialed. Drop the entry rather than stranding it.
+		r.dropFailedEntry(key, entry)
 		return
 	}
 	// The rebuilt fabric side has a fresh descriptor; the source side
-	// picks the rotation up through its watch on this field.
+	// picks the rotation up through its watch on this field. A source
+	// still holding the pre-rebuild address posts against an endpoint
+	// nobody answers and its send queue never drains, so the publish
+	// is the rebuild's success criteria: on failure the entry drops
+	// and the next Reconcile rebuilds fabric side and publish together.
 	if err := r.applyTargetInfo(ctx, mirror, s); err != nil {
 		l.Error(err, "publish rebuilt TargetInfo")
+		r.dropFailedEntry(key, entry)
 		return
 	}
 	if err := r.applyTargetStatus(ctx, mirror, mxlv1alpha1.MxlFlowMirrorReady, nil, nil); err != nil {
-		l.Error(err, "publish rebuilt TargetInfo")
+		l.Error(err, "publish rebuilt status")
+		r.dropFailedEntry(key, entry)
 		return
 	}
-	l.Info("rebuilt fabric side after fatal ReadGrain")
+	l.Info("rebuilt fabric side after fatal read")
+}
+
+// dropFailedEntry removes an entry whose fabric side cannot serve its
+// mirror: the recovery cap is spent, the rebuild failed, or the
+// rebuilt TargetInfo could not be published. It publishes Failed so
+// an operator sees a dead state instead of whatever the flusher last
+// wrote, tears the entry down the way the recovery failure path does
+// (the writer closes too, invalidating consumer FlowReaders), and
+// wakes the next Reconcile through the status write so the whole
+// target side is rebuilt from scratch rather than left in memory
+// with nothing driving it.
+//
+// Not closeEntry: the flusher must not be waited on from here when
+// this runs on the flusher goroutine's own spawn chain. The
+// flusher's cap branch already tears down without waiting; this path
+// matches it for every other caller.
+func (r *TargetReconciler) dropFailedEntry(key types.NamespacedName, entry *targetEntry) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	if mirror, err := r.fetchMirror(ctx, key); err == nil {
+		_ = r.applyTargetStatus(ctx, mirror, mxlv1alpha1.MxlFlowMirrorFailed, nil, &metav1.Condition{
+			Type:               mxlv1alpha1.ConditionTypeTargetProgress,
+			Status:             metav1.ConditionFalse,
+			Reason:             ReasonStuckHandshakeCapReached,
+			Message:            fmt.Sprintf("fabric side unrecoverable after %d attempts", maxStuckRebuilds),
+			LastTransitionTime: metav1.Now(),
+		})
+	}
+	r.mu.Lock()
+	if r.targets[key] == entry {
+		delete(r.targets, key)
+	}
+	r.mu.Unlock()
+	// The progress loop must release its libmxl handles before the
+	// writer closes underneath it. A loop parked inside libmxl-fabrics
+	// never returns, so the wait is bounded and a loop that outlasts
+	// the grace keeps the writer: an orphaned handle beats a double
+	// free.
+	if !entry.stopProgressLoop(r.teardownGrace()) {
+		return
+	}
+	if writer := entry.abandon(); writer != nil {
+		_ = writer.Close()
+	}
 }
 
 // fetchMirror reads the freshest cached MxlFlowMirror so the SSA
@@ -1872,9 +1946,12 @@ func (r *TargetReconciler) runFlusher(ctx context.Context, done chan struct{}, k
 					entry.recovering.Store(false)
 					continue
 				}
-				attempt := entry.recoveryAttempts.Add(1)
+				// recoverFromFatalError counts the attempt: it owns
+				// the budget so the watchdog and a fatally-exited
+				// loop's onFatal spawn count against one shared cap
+				// instead of each other.
 				log.FromContext(ctx).Info("stuck handshake; triggering recovery",
-					"mirror", key, "attempt", attempt)
+					"mirror", key, "attempt", entry.recoveryAttempts.Load()+1)
 				go r.dispatchRecovery(key)
 			}
 			// Skip the Degraded write this tick: publishing it would

--- a/gateway/internal/mirror/target_test.go
+++ b/gateway/internal/mirror/target_test.go
@@ -14,6 +14,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/qvest-digital/go-mxl/fabrics"
@@ -929,6 +930,11 @@ func newTargetWatchdogFixture(t *testing.T, spawnBufLen int) *targetWatchdogFixt
 		targets:             map[types.NamespacedName]*targetEntry{key: entry},
 		recoverFn: func(types.NamespacedName) {
 			spawnCh <- struct{}{}
+			// Count the attempt the way the real recoverFromFatalError
+			// does as its first action: the budget lives in the
+			// recovery, so the watchdog and a fatally-exited loop's
+			// onFatal spawn share one cap.
+			entry.recoveryAttempts.Add(1)
 			// Re-arm the watchdog for the next tick: clear recovering
 			// so CompareAndSwap can succeed again, and stamp
 			// fabricOpenedAt back into the past so the wedge condition
@@ -1208,6 +1214,9 @@ func TestRunFlusher_CapResetsAfterCommit(t *testing.T) {
 	// test injects the commit in between bursts.
 	f.r.recoverFn = func(types.NamespacedName) {
 		f.spawnCh <- struct{}{}
+		// Count the attempt the way the real recoverFromFatalError
+		// does as its first action.
+		f.entry.recoveryAttempts.Add(1)
 		past := time.Now().Add(-time.Hour)
 		f.entry.fabricOpenedAt.Store(&past)
 		f.entry.recovering.Store(false)
@@ -1481,6 +1490,9 @@ func TestRunFlusher_PostHandshakeWedge_RespectsCapAndPublishesFailed(t *testing.
 	// would race the flusher's fetchMirror on the fake client).
 	f.r.recoverFn = func(types.NamespacedName) {
 		f.spawnCh <- struct{}{}
+		// Count the attempt the way the real recoverFromFatalError
+		// does as its first action.
+		f.entry.recoveryAttempts.Add(1)
 		now := time.Now()
 		openedAt := now.Add(-100 * time.Millisecond)
 		f.entry.fabricOpenedAt.Store(&openedAt)
@@ -1528,4 +1540,153 @@ func TestRunFlusher_PostHandshakeWedge_RespectsCapAndPublishesFailed(t *testing.
 		"post-handshake cap must carry reason StuckHandshakeCapReached so "+
 			"operators see the same terminal signal whether the handshake "+
 			"never landed or only landed once before wedging")
+}
+
+func TestTarget_RecoveryCapsFatalDrivenRebuilds(t *testing.T) {
+	// A progress loop that dies fatally on every rebuild would cycle
+	// recoverFromFatalError forever: each rebuild succeeds, the new
+	// loop dies, onFatal spawns the next recovery. The recovery
+	// itself owns the budget now, so the (maxStuckRebuilds+1)th
+	// invocation drops the entry and publishes Failed rather than
+	// rebuilding again. The Failed phase is what wakes Reconcile and
+	// forces a full reopen with a fresh TargetInfo publish, which is
+	// the only path a source wedged against the old address recovers
+	// through.
+	scheme := newSourceTestScheme(t)
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-z", "flow-1", "info-1")
+	mirror.Spec.TargetNode = "node-a"
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		Build()
+
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	loopDone := make(chan struct{})
+	go func() {
+		defer close(loopDone)
+		<-loopCtx.Done()
+	}()
+	entry := &targetEntry{writer: &mxl.Writer{}}
+	entry.cancel = loopCancel
+	entry.done = loopDone
+	entry.recoveryAttempts.Store(maxStuckRebuilds)
+
+	rebuilt := make(chan struct{}, 1)
+	r := &TargetReconciler{
+		Client:        c,
+		Scheme:        scheme,
+		NodeName:      "node-a",
+		TeardownGrace: 2 * time.Second,
+		targets:       map[types.NamespacedName]*targetEntry{key: entry},
+		attempts:      attemptTable[targetOpenInputs]{},
+		openFabricSideFn: func(*mxl.Writer, fabrics.Provider) (*fabrics.Target, *fabrics.TargetInfo, string, error) {
+			rebuilt <- struct{}{}
+			return &fabrics.Target{}, nil, "info-2", nil
+		},
+	}
+
+	r.recoverFromFatalError(key)
+
+	select {
+	case <-rebuilt:
+		t.Fatal("a capped recovery must not rebuild the fabric side again")
+	default:
+	}
+
+	r.mu.Lock()
+	_, live := r.targets[key]
+	r.mu.Unlock()
+	assert.False(t, live,
+		"the capped recovery must drop the entry so the next Reconcile reopens it")
+
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &got))
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorFailed, got.Status.Phase,
+		"the capped recovery must publish Failed so the stale last state does not stand")
+	foundCond := false
+	for _, cond := range got.Status.Conditions {
+		if cond.Type == mxlv1alpha1.ConditionTypeTargetProgress &&
+			cond.Reason == ReasonStuckHandshakeCapReached {
+			foundCond = true
+			break
+		}
+	}
+	assert.True(t, foundCond,
+		"the terminal condition must say why the entry was dropped")
+
+	select {
+	case <-loopDone:
+	default:
+		t.Fatal("the dropped entry's progress loop must be cancelled and waited for")
+	}
+	assert.True(t, entry.closed,
+		"the dropped entry must be marked closed so no later rebuild installs handles on it")
+}
+
+func TestTarget_RecoveryDropsEntryWhenTargetInfoPublishFails(t *testing.T) {
+	// The TargetInfo publish is the rebuild's success criteria: a
+	// source initiator holding the pre-rebuild address posts against
+	// an endpoint nobody answers and its send queue never drains. A
+	// publish that fails must drop the entry -- publishing Failed and
+	// waking Reconcile -- rather than leave a live fabric side the
+	// source will never dial.
+	scheme := newSourceTestScheme(t)
+	key := types.NamespacedName{Namespace: "ns1", Name: "m1"}
+	mirror := mirrorWithFinalizer("m1", "ns1", "node-z", "flow-1", "info-1")
+	mirror.Spec.TargetNode = "node-a"
+
+	failInfoWrites := func(ctx context.Context, cl client.Client, sub string,
+		obj client.Object, patch client.Patch, opts ...client.SubResourcePatchOption,
+	) error {
+		o := &client.SubResourcePatchOptions{}
+		for _, opt := range opts {
+			opt.ApplyToSubResourcePatch(o)
+		}
+		if o.FieldManager == targetInfoFieldOwner {
+			return errors.New("apiserver rejected the field-manager write")
+		}
+		return cl.Status().Patch(ctx, obj, patch, opts...)
+	}
+	c := fake.NewClientBuilder().
+		WithScheme(scheme).
+		WithStatusSubresource(&mxlv1alpha1.MxlFlowMirror{}).
+		WithObjects(mirror).
+		WithInterceptorFuncs(interceptor.Funcs{SubResourcePatch: failInfoWrites}).
+		Build()
+
+	// An already-exited progress loop so the recovery passes its
+	// stop-and-wait and reaches the rebuild and its publish.
+	loopDone := make(chan struct{})
+	close(loopDone)
+	entry := &targetEntry{writer: &mxl.Writer{}}
+	entry.done = loopDone
+
+	r := &TargetReconciler{
+		Client:        c,
+		Scheme:        scheme,
+		NodeName:      "node-a",
+		TeardownGrace: 2 * time.Second,
+		targets:       map[types.NamespacedName]*targetEntry{key: entry},
+		attempts:      attemptTable[targetOpenInputs]{},
+		openFabricSideFn: func(*mxl.Writer, fabrics.Provider) (*fabrics.Target, *fabrics.TargetInfo, string, error) {
+			return &fabrics.Target{}, nil, "info-2", nil
+		},
+	}
+
+	r.recoverFromFatalError(key)
+
+	r.mu.Lock()
+	_, live := r.targets[key]
+	r.mu.Unlock()
+	assert.False(t, live,
+		"a rebuild whose TargetInfo cannot be published must drop the entry")
+	assert.True(t, entry.closed,
+		"the dropped entry must be marked closed so its handles are not reused")
+
+	var got mxlv1alpha1.MxlFlowMirror
+	require.NoError(t, c.Get(context.Background(), key, &got))
+	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorFailed, got.Status.Phase,
+		"the dropped entry must publish Failed so the stale prior state does not stand")
 }

--- a/gateway/internal/mirror/target_test.go
+++ b/gateway/internal/mirror/target_test.go
@@ -1348,6 +1348,9 @@ func TestRunFlusher_RecoveryGate_NoDoubleSpawnUnderRace(t *testing.T) {
 	// never runs again, regardless of how many ticks elapse.
 	f.r.recoverFn = func(types.NamespacedName) {
 		f.spawnCh <- struct{}{}
+		// Count the attempt the way the real recoverFromFatalError
+		// does as its first action; the budget lives in the recovery.
+		f.entry.recoveryAttempts.Add(1)
 		// Intentionally do NOT clear recovering: simulates a slow
 		// recovery still in flight when the next flusher tick fires.
 	}


### PR DESCRIPTION
A mirror whose fabric connection wedges stays wedged today because each side waits on a signal the other will never send.

**Source side.** A send queue that refuses every chunk while the writer keeps producing pins the sample loop in a skip-retry cycle: the per-tick retry bound returns the tick, the next tick skips to the bounded catch-up, and nothing ever lands. The loop keeps probing the head, so the flusher stale-head watchdog that reopens wedged readers never fires — the reader is healthy, the connection is not. The loop now exits after `maxSampleRefusedTicks` consecutive refusing ticks (a few seconds of absolute refusal at the default grain-rate interval): the stopped head probes let the watchdog see `ReaderNotAdvancing` and rebuild the source end to end, fresh initiator and fresh connection. Deliveries reset the counter, so a busy-but-healthy queue never trips the bound.

**Target side.** A rebuilt fabric side is only half the recovery: the source learns the new endpoint through the `TargetInfo` publish, and a publish that fails — or has no mirror left to publish to — left a live-but-unreached fabric side behind while the mirror status kept whatever the flusher last wrote. A publish failure now drops the entry and publishes `Failed`, and the recovery budget counts fatal-driven rebuilds the same as watchdog-driven ones, so a progress loop that dies on every rebuild runs out of attempts instead of cycling forever. Both drops tear the entry down (progress loop stopped, writer closed) and wake `Reconcile` through the status write, so the target side is rebuilt together with a publish the source can actually reach.

Tests: the sample loop exits after sustained refusal and keeps running under intermittent refusal with deliveries; the recovery caps fatal-driven rebuilds (entry dropped, `Failed` published, terminal condition set); the recovery drops the entry when the `TargetInfo` publish fails (interceptor-driven patch failure). The existing watchdog fixtures count the attempt where the real recovery now does.