### PR TITLE
fix(gateway): starve out trickle-delivering sample loops

### DIFF
--- a/gateway/internal/mirror/sample_test.go
+++ b/gateway/internal/mirror/sample_test.go
@@ -240,20 +240,21 @@ func TestRunSampleTransferLoop_NeverBurstsBeyondCatchUpPerTick(t *testing.T) {
 		"a frozen head must not produce further transfers, got %d", len(snap))
 }
 
-func TestRunSampleTransferLoop_ExitsAfterSustainedRefusal(t *testing.T) {
-	// A send queue that refuses every chunk while the writer keeps
-	// producing is a connection that will not drain on its own. The
-	// loop must stop after maxSampleRefusedTicks consecutive
-	// refusing ticks rather than skip-retrying forever: a live loop
-	// keeps probing the head, so the flusher's stale-head watchdog
-	// never fires and nothing else on the source side breaks the
-	// state. Exiting stops the head probes, which the flusher reads
-	// as ReaderNotAdvancing and rebuilds the source end to end.
+func TestRunSampleTransferLoop_ExitsAfterSustainedStarvation(t *testing.T) {
+	// A wedged fabric connection refuses most chunks while the writer
+	// keeps producing: a live loop keeps probing the head, so the
+	// flusher's stale-head watchdog never fires, and the occasional
+	// chunk that does land reads as delivery to every freshness-based
+	// signal. The loop must stop after maxSampleStarvedTicks
+	// consecutive ticks under a quarter of the produced samples
+	// rather than skip-retrying forever. Exiting stops the head
+	// probes, which the flusher reads as ReaderNotAdvancing and
+	// rebuilds the source end to end.
 	const xferBatch = 480
 	var probes atomic.Uint64
 	probe := func() (uint64, error) {
 		// The head advances one batch per tick so every tick finds
-		// new samples to refuse.
+		// new samples to starve.
 		return probes.Add(xferBatch), nil
 	}
 	transfer := func(uint64, int) error {
@@ -268,9 +269,9 @@ func TestRunSampleTransferLoop_ExitsAfterSustainedRefusal(t *testing.T) {
 
 	select {
 	case <-done:
-		// The loop exited on its own: the sustained-refusal bound fired.
+		// The loop exited on its own: the starvation bound fired.
 	case <-time.After(5 * time.Second):
-		t.Fatal("loop did not exit under sustained refusal; the wedge would persist forever")
+		t.Fatal("loop did not exit under sustained starvation; the wedge would persist forever")
 	}
 
 	// Every tick refused, so nothing landed and the loop kept
@@ -280,16 +281,15 @@ func TestRunSampleTransferLoop_ExitsAfterSustainedRefusal(t *testing.T) {
 	// The head probes ran for at least the bound's worth of ticks
 	// before the exit, proving the loop tolerated the full window
 	// before giving up rather than exiting on the first refusal.
-	assert.GreaterOrEqual(t, probes.Load(), uint64(maxSampleRefusedTicks*xferBatch),
-		"the loop must tolerate the whole refusal window before exiting")
+	assert.GreaterOrEqual(t, probes.Load(), uint64(maxSampleStarvedTicks*xferBatch),
+		"the loop must tolerate the whole starvation window before exiting")
 }
 
-func TestRunSampleTransferLoop_RefusalCountResetsOnDelivery(t *testing.T) {
-	// A busy queue that intermittently refuses but delivers before
-	// the refusal window elapses must run forever: the exit bound
-	// counts only *consecutive* refusing ticks, and clearing it on
-	// delivery keeps a healthy backpressure episode from being
-	// mistaken for a dead connection.
+func TestRunSampleTransferLoop_StarvationResetsOnDelivery(t *testing.T) {
+	// A busy queue that intermittently refuses but delivers most of
+	// what the writer produces must run forever: the exit bound
+	// counts only consecutive starved ticks, and a tick that lands
+	// at least a quarter of the produced samples is not starved.
 	const xferBatch = 480
 	var probes atomic.Uint64
 	var calls atomic.Int32
@@ -297,7 +297,9 @@ func TestRunSampleTransferLoop_RefusalCountResetsOnDelivery(t *testing.T) {
 		return probes.Add(xferBatch), nil
 	}
 	transfer := func(uint64, int) error {
-		// Refuse heavily, but land every few attempts.
+		// Refuse heavily, but land every few attempts: each landed
+		// chunk empties the tick's delta, so the delivered fraction
+		// is far above the starvation threshold.
 		if calls.Add(1)%10 != 0 {
 			return fabrics.ErrNotReady
 		}
@@ -309,18 +311,64 @@ func TestRunSampleTransferLoop_RefusalCountResetsOnDelivery(t *testing.T) {
 	tracker := &recordingTracker{}
 	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
 
-	// Far longer than the refusal window: if the counter were not
+	// Far longer than the starvation window: if the counter were not
 	// reset by deliveries the loop would have exited inside it.
 	time.Sleep(2 * time.Second)
 	select {
 	case <-done:
-		t.Fatal("loop exited despite regular deliveries; the refusal counter is not reset on delivery")
+		t.Fatal("loop exited despite regular deliveries; the starvation counter is not reset on delivery")
 	default:
 	}
 	cancel()
 	<-done
 	transfers, _ := tracker.snapshot()
 	assert.NotEmpty(t, transfers, "an intermittently delivering queue must have landed chunks")
+}
+
+func TestRunSampleTransferLoop_TrickleDeliveryStillStarves(t *testing.T) {
+	// The wedge that defeats every freshness-based signal: the send
+	// queue drains one slot at a time, so a thin trickle of chunks
+	// lands while the bulk of each tick's production is aged out and
+	// skipped. A loop that exited only on total refusal -- or reset
+	// its bound on any delivery -- pins the wedge forever, because
+	// the trickle reads as delivery. The starvation ratio must count
+	// samples, not chunks: a tick landing under a quarter of the
+	// produced samples stays starved even though it landed something.
+	const xferBatch = 480
+	var probes atomic.Uint64
+	var calls atomic.Int32
+	probe := func() (uint64, error) {
+		// The head advances eight batches per tick, like a loop that
+		// spent the tick's budget retrying against a full queue.
+		return probes.Add(8 * xferBatch), nil
+	}
+	transfer := func(uint64, int) error {
+		// Land one chunk per tick out of eight produced: an eighth
+		// of production, above zero but far under the quarter.
+		if calls.Add(1) == 1 {
+			return nil
+		}
+		return fabrics.ErrNotReady
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan struct{})
+	tracker := &recordingTracker{}
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
+
+	select {
+	case <-done:
+		// The loop exited on its own: the trickle did not reset the
+		// starvation bound.
+	case <-time.After(5 * time.Second):
+		t.Fatal("loop did not exit under trickle delivery; the wedge would persist forever")
+	}
+
+	transfers, _ := tracker.snapshot()
+	assert.NotEmpty(t, transfers, "the trickle landed chunks before the exit")
+	assert.Less(t, len(transfers), maxSampleStarvedTicks,
+		"the loop must stop delivering the trickle once the bound fires")
 }
 
 func TestRunSampleTransferLoop_TransferErrorBreaksTickAndRetries(t *testing.T) {

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -1451,19 +1451,20 @@ func runSampleTransferLoop(
 	defer t.Stop()
 	// Throttles MakeProgress while it keeps failing; see progress.go.
 	var progress progressThrottle
-	// refusals counts consecutive ticks in which the writer produced
-	// new samples but not one chunk landed. MakeProgress is blocking
-	// for the verbs provider, so every retry parks on the completion
-	// queue; a queue that never yields a completion parks forever,
-	// and the loop degrades into an aged-out skip every tick -- real
-	// time in, nothing out -- while the fabric slot it holds never
-	// recovers on its own. Bounded here because no other part of the
-	// source side will break the state: the reader is healthy (the
-	// head advances), so the stall watchdog that reopens wedged
-	// readers never fires. Exiting lets headAdvancedAt go stale,
-	// which the flusher reads as ReaderNotAdvancing and rebuilds
-	// the source end to end -- fresh initiator, fresh connection.
-	refusals := 0
+	// starved counts consecutive ticks in which the writer produced
+	// new samples but only a fraction of them landed. A wedged fabric
+	// connection does not refuse every chunk: the send queue drains
+	// one slot at a time, a thin trickle of small chunks lands, and
+	// the trickle resets any "delivered recently" signal while the
+	// loop ages out and skips the bulk of the flow. The starvation
+	// ratio is the trickle-proof signal: produced counts the head
+	// advance, delivered the samples actually accepted, and a tick
+	// that lands under a quarter of what the producer wrote is
+	// starved regardless of any partial success. Exiting lets
+	// headAdvancedAt go stale, which the flusher reads as
+	// ReaderNotAdvancing and rebuilds the source end to end -- fresh
+	// initiator, fresh connection.
+	starved := 0
 
 	for {
 		select {
@@ -1521,8 +1522,9 @@ func runSampleTransferLoop(
 			// producer kept writing, at which point the loop skipped
 			// samples and published ReaderAgedOut for what was really a
 			// momentarily full queue.
+			produced := head - lastSent
 			retries := 0
-			landed := false
+			delivered := uint64(0)
 			for lastSent < head {
 				count := head - lastSent
 				if xferBatch > 0 && count > xferBatch {
@@ -1540,22 +1542,23 @@ func runSampleTransferLoop(
 					break
 				}
 				retries = 0
-				landed = true
+				delivered += count
 				if tracker != nil {
 					tracker.recordTransfer(end, time.Now())
 				}
 				lastSent = end
 			}
-			if !landed {
-				refusals++
-				if refusals >= maxSampleRefusedTicks {
-					l.Error(nil, "sample transfers refused across ticks; exiting so the source is rebuilt",
-						"refusedTicks", refusals,
+			if produced > 0 && delivered*4 < produced {
+				starved++
+				if starved >= maxSampleStarvedTicks {
+					l.Error(nil, "sample transfers starving; exiting so the source is rebuilt",
+						"starvedTicks", starved,
+						"produced", produced, "delivered", delivered,
 						"lastSent", lastSent, "head", head)
 					return
 				}
 			} else {
-				refusals = 0
+				starved = 0
 			}
 		}
 
@@ -2341,16 +2344,20 @@ func (r *SourceReconciler) flowToMirrors(ctx context.Context, obj client.Object)
 // lastSent.
 const maxSampleTransferRetries = 8
 
-// maxSampleRefusedTicks bounds how many consecutive ticks the sample
-// loop may find new samples but land none. A send queue that refuses
-// every chunk while MakeProgress parks on an empty completion queue
-// is a connection that will not recover on its own, and the loop's
-// per-tick retry bound alone would keep it alive forever. At the
-// default grain-rate interval one tick is ~10 ms of audio, so the
-// window is a few seconds of absolute refusal: far longer than any
-// healthy backpressure episode and short enough that the rebuild the
-// exit triggers outruns an operator noticing.
-const maxSampleRefusedTicks = 200
+// maxSampleStarvedTicks bounds how many consecutive ticks the sample
+// loop may land under a quarter of the samples the writer produced.
+// A wedged fabric connection does not refuse every chunk: its send
+// queue drains slowly enough that a trickle of chunks keeps landing,
+// which reads as delivery to every freshness-based signal while the
+// loop ages out and skips the bulk of the flow. A quarter is far
+// below anything a healthy mirror produces even under backpressure
+// -- the queue refutes whole chunks, not sample ranges within them --
+// so only a sustained trickle trips it. At the default grain-rate
+// interval one tick is ~10 ms of audio, so the window is a few
+// seconds of starvation: long enough to ride out a burst, short
+// enough that the rebuild the exit triggers outruns an operator
+// noticing.
+const maxSampleStarvedTicks = 200
 
 // maxSampleCatchUpFallback is the per-tick catch-up bound used when
 // xferBatch is zero, which cannot happen in production (the open path

--- a/gateway/internal/mirror/target_test.go
+++ b/gateway/internal/mirror/target_test.go
@@ -1700,4 +1700,4 @@ func TestTarget_RecoveryDropsEntryWhenTargetInfoPublishFails(t *testing.T) {
 		return got.Status.Phase == mxlv1alpha1.MxlFlowMirrorFailed
 	}, 5*time.Second, 50*time.Millisecond,
 		"the dropped entry must publish Failed so the stale prior state does not stand")
-	}
+}

--- a/gateway/internal/mirror/target_test.go
+++ b/gateway/internal/mirror/target_test.go
@@ -1688,8 +1688,16 @@ func TestTarget_RecoveryDropsEntryWhenTargetInfoPublishFails(t *testing.T) {
 	assert.True(t, entry.closed,
 		"the dropped entry must be marked closed so its handles are not reused")
 
+	// The rebuild installs a progress loop before the failing publish; a
+	// zero-value fabric target makes that loop fail fatally and spawn a
+	// competing background recovery whose own publish can transiently
+	// overwrite the terminal phase. Eventually rather than an immediate
+	// read: the drop's own publish has happened by the time the entry is
+	// gone, and the transient must lose to it.
 	var got mxlv1alpha1.MxlFlowMirror
-	require.NoError(t, c.Get(context.Background(), key, &got))
-	assert.Equal(t, mxlv1alpha1.MxlFlowMirrorFailed, got.Status.Phase,
+	require.Eventually(t, func() bool {
+		require.NoError(t, c.Get(context.Background(), key, &got))
+		return got.Status.Phase == mxlv1alpha1.MxlFlowMirrorFailed
+	}, 5*time.Second, 50*time.Millisecond,
 		"the dropped entry must publish Failed so the stale prior state does not stand")
-}
+	}

--- a/test/integration/kind/cases/46-audio-mirror-target-gateway-bounce.sh
+++ b/test/integration/kind/cases/46-audio-mirror-target-gateway-bounce.sh
@@ -61,19 +61,22 @@ echo "  bouncing ${gateway_pod} on ${reader_node} (target side of the audio mirr
 "${KUBECTL[@]}" -n "$NAMESPACE" delete "pod/${gateway_pod}" --wait=false \
   || fail "deleting ${gateway_pod} failed"
 
-# The DaemonSet replaces the pod immediately; wait for the
-# replacement to run on the same node before watching the index, so
-# the recovery clock starts from a live target side.
+# The DaemonSet replaces the pod, but until the old object is fully
+# gone it still reports phase=Running; wait for a *different* gateway
+# pod to run on the node before watching the index, so the recovery
+# clock starts from a live replacement rather than the dying original.
 deadline=$(( $(date +%s) + ROLLOUT_TIMEOUT_SECS ))
+replacement=""
 while [ "$(date +%s)" -lt "$deadline" ]; do
-  if [ -n "$(daemonset_pod_on gateway "$reader_node")" ]; then
+  replacement="$(daemonset_pod_on gateway "$reader_node")"
+  if [ -n "$replacement" ] && [ "$replacement" != "$gateway_pod" ]; then
     break
   fi
   sleep 2
 done
-[ -n "$(daemonset_pod_on gateway "$reader_node")" ] \
-  || fail "no gateway pod came back up on ${reader_node}"
-echo "  replacement gateway running on ${reader_node}"
+[ -n "$replacement" ] && [ "$replacement" != "$gateway_pod" ] \
+  || fail "no replacement gateway pod came up on ${reader_node}"
+echo "  replacement gateway ${replacement} running on ${reader_node}"
 
 # Poll until a full window delivers at rate. Sampling the index twice
 # per attempt bounds each check to WINDOW_SECS; the outer deadline

--- a/test/integration/kind/cases/46-audio-mirror-target-gateway-bounce.sh
+++ b/test/integration/kind/cases/46-audio-mirror-target-gateway-bounce.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Assert audio samples keep flowing across the fabric at delivery
+# rate after the target-side gateway pod bounces. Restarting the
+# gateway on the reader's node rebuilds the mirror's target fabric
+# side and rotates TargetInfo; the source initiator must reconnect
+# (or be rebuilt by the starvation watchdog) and resume delivering
+# continuous samples. A wedged initiator delivers a trickle: the
+# reader's batch index stalls or crawls while every freshness-based
+# signal on the mirror reports progress, which is the failure this
+# case exists to catch. Sits between 45-samples-flowing and the
+# reschedule cases so the cluster is still in its pristine two-node
+# demo state here.
+
+set -euo pipefail
+# shellcheck source=../lib.sh
+. "$KIND_TEST_LIB"
+
+READER_POD="${READER_POD:-mxl-tcp-demo-audio-reader}"
+GATEWAY_DS="${GATEWAY_DS:-mxl-k8s-gateway}"
+# Delivery window: two index samples this far apart must differ by at
+# least MIN_WINDOW_SAMPLES. The demo flow is 48 kHz, so a healthy
+# mirror delivers ~48000*WINDOW_SECS samples per window; the bound is
+# roughly 40% of that, far above any trickle and below any healthy
+# delivery once the resync settle is averaged in.
+WINDOW_SECS="${AUDIO_RATE_WINDOW_SECS:-5}"
+MIN_WINDOW_SAMPLES="${AUDIO_RATE_MIN_WINDOW_SAMPLES:-100000}"
+# Ceiling for the whole post-bounce recovery before the rate check
+# gives up: mirrors reconverge in ~15s normally; the starvation exit
+# adds its own bounded window before the rebuild.
+RECOVERY_TIMEOUT_SECS="${AUDIO_RATE_RECOVERY_TIMEOUT_SECS:-120}"
+
+# Most recent sample-batch index from the reader, as in
+# 45-samples-flowing: anchored on "frags=" lines so the resync log
+# lines do not shadow it. The tail is wide enough to span the whole
+# recovery window at 100 batches/s.
+sample_idx() {
+  "${KUBECTL[@]}" -n "$NAMESPACE" logs "pod/${READER_POD}" --tail=2000 2>/dev/null \
+    | awk '
+        /frags=/ && match($0, /idx=[0-9]+/) {
+          last = substr($0, RSTART + 4, RLENGTH - 4)
+        }
+        END { if (last != "") print last }
+      '
+}
+
+# The reader must already be flowing: 45-samples-flowing ran before
+# this case, so an empty index here is itself a failure.
+first_idx=$(sample_idx || true)
+[ -n "$first_idx" ] || fail "${READER_POD} has no sample-batch index; 45-samples-flowing must run first"
+
+# The reader's node is the mirror's target side; bounce only that
+# node's gateway pod so the source side stays up and has to recover
+# against the rotated endpoint.
+reader_node=$("${KUBECTL[@]}" -n "$NAMESPACE" get "pod/${READER_POD}" \
+                -o jsonpath='{.spec.nodeName}' 2>/dev/null || true)
+[ -n "$reader_node" ] || fail "could not resolve ${READER_POD}'s node"
+gateway_pod="$(daemonset_pod_on gateway "$reader_node")"
+[ -n "$gateway_pod" ] || fail "no running gateway pod on ${reader_node}"
+echo "  bouncing ${gateway_pod} on ${reader_node} (target side of the audio mirror)"
+
+"${KUBECTL[@]}" -n "$NAMESPACE" delete "pod/${gateway_pod}" --wait=false \
+  || fail "deleting ${gateway_pod} failed"
+
+# The DaemonSet replaces the pod immediately; wait for the
+# replacement to run on the same node before watching the index, so
+# the recovery clock starts from a live target side.
+deadline=$(( $(date +%s) + ROLLOUT_TIMEOUT_SECS ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  if [ -n "$(daemonset_pod_on gateway "$reader_node")" ]; then
+    break
+  fi
+  sleep 2
+done
+[ -n "$(daemonset_pod_on gateway "$reader_node")" ] \
+  || fail "no gateway pod came back up on ${reader_node}"
+echo "  replacement gateway running on ${reader_node}"
+
+# Poll until a full window delivers at rate. Sampling the index twice
+# per attempt bounds each check to WINDOW_SECS; the outer deadline
+# absorbs the mirror reconvergence and the starvation rebuild.
+deadline=$(( $(date +%s) + RECOVERY_TIMEOUT_SECS ))
+attempt=0
+while [ "$(date +%s)" -lt "$deadline" ]; do
+  attempt=$(( attempt + 1 ))
+  a=$(sample_idx || true)
+  [ -n "$a" ] || { sleep 2; continue; }
+  sleep "$WINDOW_SECS"
+  b=$(sample_idx || true)
+  [ -n "$b" ] || { sleep 2; continue; }
+  if [ "$b" -gt "$a" ] && [ $(( b - a )) -ge "$MIN_WINDOW_SAMPLES" ]; then
+    echo "  samples resumed at rate after gateway bounce: idx ${a} -> ${b} over ${WINDOW_SECS}s (attempt ${attempt})"
+    exit 0
+  fi
+  echo "  attempt ${attempt}: idx ${a:-?} -> ${b:-?} over ${WINDOW_SECS}s, below ${MIN_WINDOW_SAMPLES}; retrying"
+  sleep 2
+done
+
+echo "  last reader logs:" >&2
+"${KUBECTL[@]}" -n "$NAMESPACE" logs "pod/${READER_POD}" --tail=30 >&2 2>/dev/null || true
+echo "  gateway pods on ${reader_node}:" >&2
+"${KUBECTL[@]}" -n "$NAMESPACE" get pods -o wide --field-selector "spec.nodeName=${reader_node}" >&2 2>/dev/null || true
+fail "audio samples did not resume at rate within ${RECOVERY_TIMEOUT_SECS}s of the target gateway bounce"


### PR DESCRIPTION
A wedged fabric connection does not refuse every chunk. Its send queue drains one slot at a time, a thin trickle of chunks keeps landing, and the trickle defeats every bound that counts anything other than samples:

- a landed chunk resets the consecutive-refusal exit added in #319, so the loop runs forever;
- a landed chunk refreshes `lastSentAt`, so the flusher keeps reading the mirror as delivering and never reopens the reader;
- the target side sees an idle producer and declines to rebuild.

The loop ages out and skips the bulk of the flow forever while every freshness-based signal on both sides reports progress.

**Fix.** Count samples instead. Per tick, `produced` is the head advance and `delivered` the samples actually accepted; a tick landing under a quarter of production is *starved* regardless of any partial success. 200 consecutive starved ticks exit the transfer loop, which stops the head probes the flusher reads as `ReaderNotAdvancing`, and the existing reader-rebuild path replaces the whole shared source -- fresh reader, fresh initiator, fresh connection. A quarter is far below anything a healthy mirror delivers (a full queue refutes whole chunks, not sample ranges within them), so backpressure and a one-off lag do not trip it; the existing reader-rebuild cap bounds the churn if the wedge is permanent.

**Tests.** The refusal tests move to starvation semantics: sustained starvation exits, delivery resets the bound, and a new trickle test reproduces the wedge shape (eight batches produced per tick, one lands) and asserts the loop still exits. Kind case 46 bounces the target-node gateway pod behind an established audio mirror and requires the reader sample index to resume at delivery rate within a bounded window -- the state a trickle wedge fakes and this change ends.