### PR TITLE
fix(gateway): count true production and drop duplicate sample arrivals

### DIFF
--- a/gateway/internal/mirror/sample_test.go
+++ b/gateway/internal/mirror/sample_test.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -12,6 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/qvest-digital/go-mxl/fabrics"
+	"github.com/qvest-digital/go-mxl/mxl"
 )
 
 // sampleXfer records one transferSamples(headIndex, count) call so the
@@ -332,8 +334,9 @@ func TestRunSampleTransferLoop_TrickleDeliveryStillStarves(t *testing.T) {
 	// skipped. A loop that exited only on total refusal -- or reset
 	// its bound on any delivery -- pins the wedge forever, because
 	// the trickle reads as delivery. The starvation ratio must count
-	// samples, not chunks: a tick landing under a quarter of the
-	// produced samples stays starved even though it landed something.
+	// the samples the writer produced, before the skip folds the
+	// delta: one landing in eight is a starvation even though the
+	// folded delta is half delivered.
 	const xferBatch = 480
 	var probes atomic.Uint64
 	var calls atomic.Int32
@@ -343,9 +346,11 @@ func TestRunSampleTransferLoop_TrickleDeliveryStillStarves(t *testing.T) {
 		return probes.Add(8 * xferBatch), nil
 	}
 	transfer := func(uint64, int) error {
-		// Land one chunk per tick out of eight produced: an eighth
-		// of production, above zero but far under the quarter.
-		if calls.Add(1) == 1 {
+		// Land one call in ten -- the first chunk of a tick plus
+		// never a retry -- so every tick delivers one batch of the
+		// eight produced and every retry is refused, the shape of a
+		// send queue that frees a single slot per tick.
+		if calls.Add(1)%10 == 1 {
 			return nil
 		}
 		return fabrics.ErrNotReady
@@ -359,15 +364,15 @@ func TestRunSampleTransferLoop_TrickleDeliveryStillStarves(t *testing.T) {
 
 	select {
 	case <-done:
-		// The loop exited on its own: the trickle did not reset the
-		// starvation bound.
+		// The loop exited on its own: the trickle did not read as
+		// healthy against the true production.
 	case <-time.After(5 * time.Second):
 		t.Fatal("loop did not exit under trickle delivery; the wedge would persist forever")
 	}
 
 	transfers, _ := tracker.snapshot()
 	assert.NotEmpty(t, transfers, "the trickle landed chunks before the exit")
-	assert.Less(t, len(transfers), maxSampleStarvedTicks,
+	assert.LessOrEqual(t, len(transfers), maxSampleStarvedTicks,
 		"the loop must stop delivering the trickle once the bound fires")
 }
 
@@ -547,6 +552,60 @@ func TestRunTargetSampleProgressLoop_CommitErrorIsLoggedButLoopContinues(t *test
 		time.Second, time.Millisecond)
 	cancel()
 	<-done
+}
+
+func TestRunTargetSampleProgressLoop_DuplicateArrivalIsDroppedNotRetried(t *testing.T) {
+	// A source that retransmits or overlaps a range produces an
+	// arrival whose index does not strictly advance the writer's
+	// last committed index; libmxl rejects the OpenSamples with
+	// invalid argument, and the arrival's bytes are already in the
+	// ring. Parking on that arrival -- retrying a commit that can
+	// never succeed -- stalls the ingress and starves the
+	// initiator's send queue to the rate at which the loop gives up
+	// on one entry. The loop must drop the arrival and keep reading:
+	// the next arrival is the one that moves the flow.
+	var seq atomic.Int32
+	read := func() (uint64, int, error) {
+		switch seq.Add(1) {
+		case 1:
+			return 480, 480, nil // committed normally
+		case 2:
+			return 480, 480, nil // retransmission of the same range
+		case 3:
+			return 960, 480, nil // the next range: must still be read
+		default:
+			return 0, 0, fabrics.ErrNotReady
+		}
+	}
+	committed := make(chan uint64, 3)
+	commit := func(head uint64, _ int) error {
+		if head == 480 && len(committed) > 0 {
+			// The second arrival for the same range is the
+			// already-committed one: wrap the real error shape.
+			return fmt.Errorf("OpenSamples(%d,480): %w: %w", head, errSamplesAlreadyCommitted, mxl.ErrInvalidArg)
+		}
+		committed <- head
+		return nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go runTargetSampleProgressLoop(ctx, done, read, commit,
+		func() { t.Error("a duplicate arrival must not be reported as fatal") }, nil)
+
+	// The first and third arrivals commit; the duplicate between
+	// them is consumed without a commit and without exiting.
+	require.Eventually(t, func() bool { return len(committed) == 2 },
+		2*time.Second, time.Millisecond)
+	select {
+	case <-done:
+		t.Fatal("loop exited on a duplicate arrival")
+	default:
+	}
+	cancel()
+	<-done
+	assert.Equal(t, uint64(480), <-committed)
+	assert.Equal(t, uint64(960), <-committed)
 }
 
 func TestRunTargetSampleProgressLoop_CtxCancelExitsDuringIdle(t *testing.T) {

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -1500,6 +1500,13 @@ func runSampleTransferLoop(
 			// transfers one batch per grain instant and, on falling
 			// behind, jumps to the live head rather than replaying
 			// the gap.
+			// produced is the whole delta since the last tick,
+			// measured before the skip below folds the gap: the
+			// starvation bound must see what the writer produced,
+			// not the two batches the skip leaves behind, or a
+			// one-chunk-per-tick trickle lands a quarter of the
+			// folded delta and reads as healthy.
+			produced := head - lastSent
 			if head-lastSent > catchUp {
 				l.Info("reader fell behind writer, skipping samples",
 					"fromIndex", lastSent+1, "toIndex", head)
@@ -1522,7 +1529,6 @@ func runSampleTransferLoop(
 			// producer kept writing, at which point the loop skipped
 			// samples and published ReaderAgedOut for what was really a
 			// momentarily full queue.
-			produced := head - lastSent
 			retries := 0
 			delivered := uint64(0)
 			for lastSent < head {

--- a/gateway/internal/mirror/target.go
+++ b/gateway/internal/mirror/target.go
@@ -1161,6 +1161,19 @@ func runTargetSampleProgressLoop(
 		switch kind := classifyFabricError(err); {
 		case err == nil:
 			if err := commit(head, count); err != nil {
+				if errors.Is(err, errSamplesAlreadyCommitted) {
+					// The arrival's range is already in the ring and
+					// the writer's head is past it: a retransmitted
+					// or overlapping chunk from the source. Dropping
+					// it is the only correct move -- retrying the
+					// commit can never succeed, and parking on the
+					// arrival stalls the ingress, which is what
+					// starves the initiator's send queue down to the
+					// rate at which this loop gives up on one entry.
+					l.V(1).Info("dropping already-committed sample arrival",
+						"headIndex", head, "count", count, "error", err.Error())
+					break
+				}
 				l.Error(err, "commit received samples", "headIndex", head, "count", count)
 				break
 			}
@@ -1203,9 +1216,21 @@ func runTargetSampleProgressLoop(
 // libmxl publishes no per-sample width, but the write access carries
 // the stride between two channels' ring buffers, which is the word
 // size times the buffer length the flow config states.
+// errSamplesAlreadyCommitted reports an arrival whose sample range
+// the writer has already committed: libmxl rejects an OpenSamples
+// whose index does not strictly advance the last committed index.
+// The remote write carrying it has already landed in the ring, so
+// the range is stale, not lost -- the mirror's source retransmitted
+// or overlapped it, and the only work left is to consume the
+// arrival so the ingress can move on.
+var errSamplesAlreadyCommitted = errors.New("samples already committed")
+
 func commitArrivedSamples(writer *mxl.Writer, head uint64, count int) (uint64, error) {
 	sa, err := writer.OpenSamples(head, count)
 	if err != nil {
+		if errors.Is(err, mxl.ErrInvalidArg) {
+			return 0, fmt.Errorf("OpenSamples(%d,%d): %w: %w", head, count, errSamplesAlreadyCommitted, err)
+		}
 		return 0, fmt.Errorf("OpenSamples(%d,%d): %w", head, count, err)
 	}
 	if err := sa.Commit(); err != nil {


### PR DESCRIPTION
Two defects kept a continuous-flow mirror delivering a trickle while every watchdog read it as healthy.

**Starvation bound measured the folded delta.** The bound added in #321 computed `produced` after the skip had folded the delta to the catch-up bound (two batches). A wedged send queue that frees exactly one slot per tick lands one chunk of those two -- half the measured production -- so the bound read the mirror as healthy forever. `produced` is now the whole delta since the last tick, measured **before** the skip: one landing in eight is a starvation, the bound fires, and the loop exits for the existing reader-rebuild path. The trickle test now models the observed wedge shape (one chunk landing every tick against eight produced).

**The target loop parked on already-committed arrivals.** libmxl rejects an `OpenSamples` whose index does not strictly advance the writer's last committed index; a retransmitted or overlapping range therefore fails with `invalid argument`, and its bytes are already in the ring. Retrying that commit can never succeed -- parking on the arrival stalls the ingress, which starves the initiator's send queue down to the rate at which the loop gives up on one entry (observed live: a mirror pinned at ~13 chunks/s, EAGAIN at the initiator, skips at the source, every freshness signal green). Such arrivals are now consumed and dropped with a debug log: the samples are stale, not lost, and the next arrival is the one that moves the flow. The loop keeps its fatal-error and watchdog semantics unchanged.

Tests: the duplicate-arrival test drives commit, retransmission, then a fresh range and asserts the loop neither exits nor skips the fresh range; the starvation tests move to true-production semantics; the full mirror suite passes under -race in the go-mxl builder container.