### PR TITLE
feat(gateway): report how evenly a flow is delivered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ kind-diagnostics/
 
 # Graphify output, rebuilt from the tree it describes
 graphify-out/
+
+# local build output of hack/flow-probe.sh
+.probe-bin/

--- a/gateway/cmd/mxl-flow-probe/main.go
+++ b/gateway/cmd/mxl-flow-probe/main.go
@@ -1,0 +1,186 @@
+// mxl-flow-probe samples a flow's head index at high rate and reports
+// how evenly the flow is being delivered.
+//
+// Run it on the node that holds the flow. On the node a flow originates
+// from it measures what the producer writes; on a node the flow is
+// mirrored to it measures what the fabric delivered, and the difference
+// between the two runs is the fabric's contribution.
+//
+//	mxl-flow-probe -domain /run/mxl/domain -flow <uuid> -duration 30s
+//
+// The exit status is 0 for a SMOOTH verdict and 1 for any other, so the
+// probe can gate a change rather than only describe one.
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"time"
+
+	"github.com/qvest-digital/go-mxl/mxl"
+	"github.com/qvest-digital/mxl-k8s/gateway/internal/cadence"
+)
+
+func main() {
+	code, err := run(os.Args[1:], os.Stdout, os.Stderr)
+	if err != nil && !errors.Is(err, flag.ErrHelp) {
+		fmt.Fprintln(os.Stderr, "mxl-flow-probe:", err)
+		os.Exit(2)
+	}
+	os.Exit(code)
+}
+
+func run(args []string, stdout, stderr io.Writer) (int, error) {
+	fs := flag.NewFlagSet("mxl-flow-probe", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	var (
+		domain   = fs.String("domain", "/run/mxl/domain", "MXL domain directory")
+		flowID   = fs.String("flow", "", "flow UUID to probe")
+		duration = fs.Duration("duration", 30*time.Second, "how long to sample")
+		interval = fs.Duration("interval", 500*time.Microsecond, "polling interval")
+		window   = fs.Duration("window", cadence.DefaultWindow, "width of the windows delivery is scored over")
+		stall    = fs.Duration("stall", cadence.DefaultStallThreshold, "gap between advances that counts as a stall")
+		rateFlag = fs.Float64("rate", 0, "override the flow's own rate, in samples or grains per second")
+		label    = fs.String("label", "", "free-form label echoed into the report, e.g. the node name")
+		asJSON   = fs.Bool("json", false, "emit the report as JSON")
+	)
+	if err := fs.Parse(args); err != nil {
+		return 2, err
+	}
+	if *flowID == "" {
+		return 2, errors.New("missing -flow <uuid>")
+	}
+
+	inst, err := mxl.NewInstance(*domain, "")
+	if err != nil {
+		return 2, fmt.Errorf("NewInstance: %w", err)
+	}
+	defer inst.Close()
+
+	reader, err := inst.NewReader(*flowID)
+	if err != nil {
+		return 2, fmt.Errorf("NewReader: %w", err)
+	}
+	defer reader.Close()
+
+	info, err := reader.Info()
+	if err != nil {
+		return 2, fmt.Errorf("Info: %w", err)
+	}
+
+	rate := *rateFlag
+	if rate == 0 {
+		rate = info.Config.Common.GrainRate.Float64()
+	}
+	if rate <= 0 {
+		return 2, errors.New("flow rate is zero; pass -rate")
+	}
+
+	samples, err := poll(reader, *duration, *interval)
+	if err != nil {
+		return 2, err
+	}
+
+	report := cadence.Analyse(samples, cadence.Params{
+		SamplesPerSecond: rate,
+		Window:           *window,
+		StallThreshold:   *stall,
+	})
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(struct {
+			Label string `json:"label,omitempty"`
+			Flow  string `json:"flow"`
+			Rate  float64
+			cadence.Report
+		}{*label, *flowID, rate, report}); err != nil {
+			return 2, err
+		}
+	} else {
+		writeText(stdout, *label, *flowID, info, rate, report)
+	}
+
+	if report.Verdict == cadence.VerdictSmooth {
+		return 0, nil
+	}
+	return 1, nil
+}
+
+// poll reads the head index as fast as the requested interval allows.
+// Intervals below a millisecond are spun rather than slept: the runtime
+// cannot sleep that precisely, and undersampling the head would blunt
+// exactly the short gaps the probe exists to find.
+func poll(reader *mxl.Reader, duration, interval time.Duration) ([]cadence.Sample, error) {
+	out := make([]cadence.Sample, 0, int(duration/interval)+1)
+	start := time.Now()
+	deadline := start.Add(duration)
+	next := start
+	for {
+		now := time.Now()
+		if now.After(deadline) {
+			break
+		}
+		rt, err := reader.Runtime()
+		if err != nil {
+			return nil, fmt.Errorf("Runtime after %s: %w", time.Since(start).Round(time.Millisecond), err)
+		}
+		out = append(out, cadence.Sample{At: now.Sub(start), Head: rt.HeadIndex})
+
+		next = next.Add(interval)
+		if d := time.Until(next); d > time.Millisecond {
+			time.Sleep(d - 500*time.Microsecond)
+		}
+		for time.Now().Before(next) {
+		}
+	}
+	if len(out) < 2 {
+		return nil, errors.New("no samples collected")
+	}
+	return out, nil
+}
+
+func writeText(w io.Writer, label, flowID string, info mxl.FlowInfo, rate float64, r cadence.Report) {
+	cfg := info.Config
+	kind := "continuous"
+	unit := "samples"
+	if cfg.Common.Format.IsDiscrete() {
+		kind, unit = "discrete", "grains"
+	}
+	if label != "" {
+		fmt.Fprintf(w, "label      %s\n", label)
+	}
+	fmt.Fprintf(w, "flow       %s  %s  %.0f %s/s", flowID, kind, rate, unit)
+	if !cfg.Common.Format.IsDiscrete() {
+		fmt.Fprintf(w, "  channels=%d bufferLen=%d syncBatch=%d",
+			cfg.Continuous.ChannelCount, cfg.Continuous.BufferLength, cfg.Common.MaxSyncBatchSizeHint)
+	}
+	fmt.Fprintf(w, "\nwindow     %s over %s, polled every %s (%d polls)\n\n",
+		r.Duration.Round(time.Millisecond), time.Now().Format(time.RFC3339),
+		(r.Duration / time.Duration(max(r.Polls-1, 1))).Round(time.Microsecond), r.Polls)
+
+	fmt.Fprintf(w, "delivery\n")
+	fmt.Fprintf(w, "  delivered            %d %s  (%.1f%% of real time)\n", r.Delivered, unit, 100*r.RealtimeRatio)
+	fmt.Fprintf(w, "  advances             %d  (%.1f/s)", r.Advances, float64(r.Advances)/r.Duration.Seconds())
+	if r.Regressions > 0 {
+		fmt.Fprintf(w, "   head went backwards %d times", r.Regressions)
+	}
+	fmt.Fprintf(w, "\n  advance size         p50 %.0f  p90 %.0f  p99 %.0f  max %.0f\n",
+		r.AdvanceSamples.P50, r.AdvanceSamples.P90, r.AdvanceSamples.P99, r.AdvanceSamples.Max)
+	fmt.Fprintf(w, "  gap between them     p50 %.2fms  p90 %.2fms  p99 %.2fms  max %.2fms\n",
+		r.GapMillis.P50, r.GapMillis.P90, r.GapMillis.P99, r.GapMillis.Max)
+	fmt.Fprintf(w, "  stalls               %d  totalling %s  (%.1f%% of the window)\n",
+		r.Stalls, r.StalledFor.Round(time.Millisecond), 100*r.StalledFraction)
+
+	fmt.Fprintf(w, "\nsmoothness\n")
+	fmt.Fprintf(w, "  starved windows      %d of %d  (%.1f%%)\n", r.StarvedWindows, r.Windows, 100*r.StarvedRatio)
+	fmt.Fprintf(w, "  per-window variation %.2f\n", r.WindowCoV)
+	fmt.Fprintf(w, "  worst deficit        %s behind real time\n", r.WorstDeficit.Round(time.Millisecond))
+
+	fmt.Fprintf(w, "\nVERDICT: %s\n", r.Verdict)
+}

--- a/gateway/internal/cadence/cadence.go
+++ b/gateway/internal/cadence/cadence.go
@@ -1,0 +1,307 @@
+// Package cadence turns a series of head-index observations into a
+// verdict about how evenly a flow is being delivered.
+//
+// Average throughput answers whether the bytes arrived, not whether
+// they arrived on time. A mirror that delivers a second of audio in one
+// burst every second reads as 100% of real time and is unusable. The
+// measures here separate the two: the realtime ratio is the average,
+// and the gap, window and deficit measures are the shape.
+package cadence
+
+import (
+	"math"
+	"sort"
+	"time"
+)
+
+// Sample is one observation of a flow's head index, taken at At after
+// the probe started.
+type Sample struct {
+	At   time.Duration
+	Head uint64
+}
+
+// Params configures the analysis. SamplesPerSecond is the flow's own
+// rate: the sample rate for a continuous flow, the grain rate for a
+// discrete one. It is what "real time" means for this flow.
+type Params struct {
+	SamplesPerSecond float64
+
+	// Window is the width of the fixed windows the delivery is scored
+	// over. Zero takes DefaultWindow.
+	Window time.Duration
+
+	// StallThreshold is the gap between two head advances above which
+	// delivery counts as stalled. Zero takes DefaultStallThreshold.
+	StallThreshold time.Duration
+
+	// StarvedFraction is the share of a window's expected samples below
+	// which the window counts as starved. Zero takes
+	// DefaultStarvedFraction.
+	StarvedFraction float64
+}
+
+const (
+	// DefaultWindow is short enough that a consumer buffering one video
+	// frame would already notice a window it missed.
+	DefaultWindow = 20 * time.Millisecond
+
+	// DefaultStallThreshold is the point past which a gap in delivery
+	// is audible rather than merely uneven.
+	DefaultStallThreshold = 50 * time.Millisecond
+
+	// DefaultStarvedFraction counts a window that received less than
+	// half of what real time owed it.
+	DefaultStarvedFraction = 0.5
+)
+
+// Quantiles summarises a distribution. Count is the number of
+// observations behind it.
+type Quantiles struct {
+	Count int     `json:"count"`
+	P50   float64 `json:"p50"`
+	P90   float64 `json:"p90"`
+	P99   float64 `json:"p99"`
+	Max   float64 `json:"max"`
+}
+
+// Report is the outcome of one probe run.
+type Report struct {
+	Duration time.Duration `json:"durationNs"`
+	Polls    int           `json:"polls"`
+
+	// Delivered is the total head advance over the run, and
+	// RealtimeRatio is that against what the flow's own rate owed.
+	Delivered     uint64  `json:"delivered"`
+	RealtimeRatio float64 `json:"realtimeRatio"`
+
+	// Advances counts the observations where the head moved forward.
+	// Regressions counts the ones where it moved back, which libmxl
+	// permits and which no delivery measure should be fooled by.
+	Advances    int `json:"advances"`
+	Regressions int `json:"regressions"`
+
+	// AdvanceSamples is the distribution of how much the head moved per
+	// advance; GapMillis the distribution of the interval between two
+	// advances. A smooth stream has a tight gap distribution centred on
+	// the producer's batch period.
+	AdvanceSamples Quantiles `json:"advanceSamples"`
+	GapMillis      Quantiles `json:"gapMillis"`
+
+	Stalls          int           `json:"stalls"`
+	StalledFor      time.Duration `json:"stalledForNs"`
+	StalledFraction float64       `json:"stalledFraction"`
+
+	Windows        int     `json:"windows"`
+	StarvedWindows int     `json:"starvedWindows"`
+	StarvedRatio   float64 `json:"starvedRatio"`
+	WindowCoV      float64 `json:"windowCoV"`
+
+	// WorstDeficit is how far behind real time the cumulative delivery
+	// ever fell, in time. It is the number a consumer feels: a deficit
+	// of 800ms is 800ms of audio that was not there when it was due.
+	WorstDeficit time.Duration `json:"worstDeficitNs"`
+
+	Verdict string `json:"verdict"`
+}
+
+// Verdicts. Smooth is the only one that means the flow is usable.
+const (
+	VerdictSmooth = "SMOOTH"
+	VerdictBursty = "BURSTY"
+	VerdictShort  = "SHORT"   // delivering under rate: samples are being lost
+	VerdictNoData = "NO-DATA" // the head never moved
+)
+
+// Analyse reduces a run of samples to a Report. Samples must be in
+// observation order; fewer than two leaves nothing to measure.
+func Analyse(samples []Sample, p Params) Report {
+	if p.Window <= 0 {
+		p.Window = DefaultWindow
+	}
+	if p.StallThreshold <= 0 {
+		p.StallThreshold = DefaultStallThreshold
+	}
+	if p.StarvedFraction <= 0 {
+		p.StarvedFraction = DefaultStarvedFraction
+	}
+
+	r := Report{Polls: len(samples), Verdict: VerdictNoData}
+	if len(samples) < 2 || p.SamplesPerSecond <= 0 {
+		return r
+	}
+
+	first, last := samples[0], samples[len(samples)-1]
+	r.Duration = last.At - first.At
+	if r.Duration <= 0 {
+		return r
+	}
+
+	// Head regressions are real: the writer can reset the index. They
+	// contribute nothing to delivery, so the running total only ever
+	// takes forward motion.
+	var advanceSizes []float64
+	var gaps []float64
+	prev := first
+	lastAdvanceAt := first.At
+	for _, s := range samples[1:] {
+		switch {
+		case s.Head > prev.Head:
+			advanceSizes = append(advanceSizes, float64(s.Head-prev.Head))
+			gaps = append(gaps, float64(s.At-lastAdvanceAt)/float64(time.Millisecond))
+			r.Delivered += s.Head - prev.Head
+			if s.At-lastAdvanceAt > p.StallThreshold {
+				r.Stalls++
+				r.StalledFor += s.At - lastAdvanceAt
+			}
+			lastAdvanceAt = s.At
+			r.Advances++
+		case s.Head < prev.Head:
+			r.Regressions++
+			// Treat the reset as a fresh starting point rather than
+			// letting it show up as a stall on the next advance.
+			lastAdvanceAt = s.At
+		}
+		prev = s
+	}
+	// A run that ends mid-stall would otherwise not count it.
+	if tail := last.At - lastAdvanceAt; tail > p.StallThreshold {
+		r.Stalls++
+		r.StalledFor += tail
+	}
+
+	owed := p.SamplesPerSecond * r.Duration.Seconds()
+	r.RealtimeRatio = float64(r.Delivered) / owed
+	r.StalledFraction = r.StalledFor.Seconds() / r.Duration.Seconds()
+	r.AdvanceSamples = quantiles(advanceSizes)
+	r.GapMillis = quantiles(gaps)
+
+	r.Windows, r.StarvedWindows, r.WindowCoV = windows(samples, p)
+	if r.Windows > 0 {
+		r.StarvedRatio = float64(r.StarvedWindows) / float64(r.Windows)
+	}
+	r.WorstDeficit = worstDeficit(samples, p.SamplesPerSecond)
+	r.Verdict = verdict(r, p)
+	return r
+}
+
+// windows scores delivery over fixed windows: how many received less
+// than their share, and how much the per-window totals vary. A stream
+// arriving in bursts has the same mean as a smooth one and a far larger
+// coefficient of variation.
+func windows(samples []Sample, p Params) (total, starved int, cov float64) {
+	start := samples[0].At
+	end := samples[len(samples)-1].At
+	expected := p.SamplesPerSecond * p.Window.Seconds()
+	if expected <= 0 {
+		return 0, 0, 0
+	}
+
+	// headAt walks the samples once, carrying the last observation at
+	// or before each window boundary.
+	idx := 0
+	headAt := func(t time.Duration) uint64 {
+		for idx+1 < len(samples) && samples[idx+1].At <= t {
+			idx++
+		}
+		return samples[idx].Head
+	}
+
+	var counts []float64
+	for w := start; w+p.Window <= end; w += p.Window {
+		lo := headAt(w)
+		hi := headAt(w + p.Window)
+		var got float64
+		if hi > lo {
+			got = float64(hi - lo)
+		}
+		counts = append(counts, got)
+		total++
+		if got < expected*p.StarvedFraction {
+			starved++
+		}
+	}
+	return total, starved, coefficientOfVariation(counts)
+}
+
+// worstDeficit is the largest amount by which cumulative delivery fell
+// behind what the flow's rate owed, converted to time. The baseline is
+// the best the run ever did, so a mirror that simply starts late is not
+// charged for the head start it never had.
+func worstDeficit(samples []Sample, rate float64) time.Duration {
+	base := samples[0]
+	var best, worst float64
+	for _, s := range samples {
+		owed := rate * (s.At - base.At).Seconds()
+		var got float64
+		if s.Head > base.Head {
+			got = float64(s.Head - base.Head)
+		}
+		surplus := got - owed
+		if surplus > best {
+			best = surplus
+		}
+		if d := best - surplus; d > worst {
+			worst = d
+		}
+	}
+	return time.Duration(worst / rate * float64(time.Second))
+}
+
+func verdict(r Report, p Params) string {
+	switch {
+	case r.Delivered == 0:
+		return VerdictNoData
+	case r.RealtimeRatio < 0.98:
+		return VerdictShort
+	case r.StarvedRatio > 0.01, r.Stalls > 0, r.WorstDeficit > 3*p.Window:
+		return VerdictBursty
+	default:
+		return VerdictSmooth
+	}
+}
+
+func quantiles(v []float64) Quantiles {
+	if len(v) == 0 {
+		return Quantiles{}
+	}
+	s := append([]float64(nil), v...)
+	sort.Float64s(s)
+	return Quantiles{
+		Count: len(s),
+		P50:   pick(s, 0.50),
+		P90:   pick(s, 0.90),
+		P99:   pick(s, 0.99),
+		Max:   s[len(s)-1],
+	}
+}
+
+func pick(sorted []float64, q float64) float64 {
+	i := int(math.Ceil(q*float64(len(sorted)))) - 1
+	if i < 0 {
+		i = 0
+	}
+	if i >= len(sorted) {
+		i = len(sorted) - 1
+	}
+	return sorted[i]
+}
+
+func coefficientOfVariation(v []float64) float64 {
+	if len(v) < 2 {
+		return 0
+	}
+	var sum float64
+	for _, x := range v {
+		sum += x
+	}
+	mean := sum / float64(len(v))
+	if mean == 0 {
+		return 0
+	}
+	var sq float64
+	for _, x := range v {
+		sq += (x - mean) * (x - mean)
+	}
+	return math.Sqrt(sq/float64(len(v))) / mean
+}

--- a/gateway/internal/cadence/cadence_test.go
+++ b/gateway/internal/cadence/cadence_test.go
@@ -1,0 +1,147 @@
+package cadence
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const rate48k = 48000.0
+
+// synth builds a poll series for a flow whose head advances by batch
+// samples every period, sampled every pollEvery, for total.
+func synth(total, period, pollEvery time.Duration, batch uint64) []Sample {
+	var out []Sample
+	var head uint64
+	nextAdvance := period
+	for t := time.Duration(0); t <= total; t += pollEvery {
+		for t >= nextAdvance {
+			head += batch
+			nextAdvance += period
+		}
+		out = append(out, Sample{At: t, Head: head})
+	}
+	return out
+}
+
+func TestSmoothStreamPasses(t *testing.T) {
+	// 480 samples every 10ms is exactly 48kHz.
+	s := synth(2*time.Second, 10*time.Millisecond, 250*time.Microsecond, 480)
+
+	r := Analyse(s, Params{SamplesPerSecond: rate48k})
+
+	assert.Equal(t, VerdictSmooth, r.Verdict)
+	assert.InDelta(t, 1.0, r.RealtimeRatio, 0.01)
+	assert.Zero(t, r.Stalls)
+	assert.Zero(t, r.StarvedWindows)
+	assert.Less(t, r.WorstDeficit, 20*time.Millisecond)
+}
+
+// The measure this package exists for. A flow that delivers a full
+// second of audio once per second averages 100% of real time and is
+// unusable. Average throughput cannot tell it apart from a smooth
+// stream; the window and deficit measures must.
+func TestBurstyStreamAtFullAverageRateIsRejected(t *testing.T) {
+	smooth := synth(4*time.Second, 10*time.Millisecond, 250*time.Microsecond, 480)
+	bursty := synth(4*time.Second, 1*time.Second, 250*time.Microsecond, 48000)
+
+	rs := Analyse(smooth, Params{SamplesPerSecond: rate48k})
+	rb := Analyse(bursty, Params{SamplesPerSecond: rate48k})
+
+	// Identical on the average, which is the whole point.
+	assert.InDelta(t, rs.RealtimeRatio, rb.RealtimeRatio, 0.02)
+
+	assert.Equal(t, VerdictSmooth, rs.Verdict)
+	assert.Equal(t, VerdictBursty, rb.Verdict)
+	assert.Greater(t, rb.StarvedWindows, rs.StarvedWindows)
+	assert.Greater(t, rb.WorstDeficit, 500*time.Millisecond)
+	assert.Positive(t, rb.Stalls)
+}
+
+func TestShortDeliveryIsDistinguishedFromBurst(t *testing.T) {
+	// 240 samples every 10ms: evenly paced, but only half the rate.
+	s := synth(2*time.Second, 10*time.Millisecond, 250*time.Microsecond, 240)
+
+	r := Analyse(s, Params{SamplesPerSecond: rate48k})
+
+	assert.Equal(t, VerdictShort, r.Verdict)
+	assert.InDelta(t, 0.5, r.RealtimeRatio, 0.02)
+}
+
+// A mirror that wedges and then catches up delivers every sample it
+// owed, so the average clears. What it did to the consumer is the 300ms
+// hole, which only the stall and deficit measures see.
+func TestStallFollowedByCatchUpIsBurstyNotShort(t *testing.T) {
+	s := synth(time.Second, 10*time.Millisecond, 500*time.Microsecond, 480)
+	// Freeze the head from 400ms to 700ms; afterwards the original
+	// series resumes, so the catch-up arrives as one jump.
+	var frozen uint64
+	for i := range s {
+		if s[i].At == 400*time.Millisecond {
+			frozen = s[i].Head
+		}
+		if s[i].At > 400*time.Millisecond && s[i].At <= 700*time.Millisecond {
+			s[i].Head = frozen
+		}
+	}
+
+	r := Analyse(s, Params{SamplesPerSecond: rate48k})
+
+	assert.Equal(t, VerdictBursty, r.Verdict)
+	assert.InDelta(t, 1.0, r.RealtimeRatio, 0.01, "every owed sample did arrive")
+	assert.Equal(t, 1, r.Stalls)
+	assert.InDelta(t, 300.0, float64(r.StalledFor/time.Millisecond), 15)
+	assert.InDelta(t, 300.0, r.GapMillis.Max, 15)
+	assert.InDelta(t, 300.0, float64(r.WorstDeficit/time.Millisecond), 20)
+	// The catch-up arrives as a single outsized advance.
+	assert.Greater(t, r.AdvanceSamples.Max, 480.0*20)
+}
+
+// libmxl lets a writer move the head backwards. Delivery must not be
+// credited for the jump back, and the regression must not be billed as
+// a stall on the next advance.
+func TestHeadRegressionIsNotCountedAsDelivery(t *testing.T) {
+	s := []Sample{
+		{At: 0, Head: 1000},
+		{At: 10 * time.Millisecond, Head: 1480},
+		{At: 20 * time.Millisecond, Head: 200}, // reset
+		{At: 30 * time.Millisecond, Head: 680},
+	}
+
+	r := Analyse(s, Params{SamplesPerSecond: rate48k})
+
+	assert.Equal(t, 1, r.Regressions)
+	assert.Equal(t, uint64(480+480), r.Delivered)
+	assert.Zero(t, r.Stalls)
+}
+
+func TestNoDataWhenHeadNeverMoves(t *testing.T) {
+	var s []Sample
+	for t0 := time.Duration(0); t0 < time.Second; t0 += time.Millisecond {
+		s = append(s, Sample{At: t0, Head: 42})
+	}
+
+	r := Analyse(s, Params{SamplesPerSecond: rate48k})
+
+	assert.Equal(t, VerdictNoData, r.Verdict)
+	assert.Zero(t, r.Delivered)
+}
+
+func TestTooFewSamplesReportsNoData(t *testing.T) {
+	r := Analyse([]Sample{{At: 0, Head: 1}}, Params{SamplesPerSecond: rate48k})
+	assert.Equal(t, VerdictNoData, r.Verdict)
+}
+
+func TestQuantilesAndCoV(t *testing.T) {
+	q := quantiles([]float64{1, 2, 3, 4, 5, 6, 7, 8, 9, 10})
+	require.Equal(t, 10, q.Count)
+	assert.Equal(t, 5.0, q.P50)
+	assert.Equal(t, 9.0, q.P90)
+	assert.Equal(t, 10.0, q.Max)
+
+	// A constant series has no variation; a bursty one does.
+	assert.Equal(t, 0.0, coefficientOfVariation([]float64{5, 5, 5, 5}))
+	assert.Greater(t, coefficientOfVariation([]float64{0, 0, 0, 20}), 1.0)
+}

--- a/hack/flow-probe.sh
+++ b/hack/flow-probe.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Run mxl-flow-probe against a flow on a specific node.
+#
+#   hack/flow-probe.sh <node> <flow-uuid> [probe flags...]
+#   hack/flow-probe.sh n07 aea7b9e9-... -duration 30s
+#   hack/flow-probe.sh n06 aea7b9e9-... -json
+#
+# The probe needs libmxl, so it runs inside a scratch pod built from the
+# go-mxl runtime image with the node's MXL domain mounted. The pod is
+# created once per node and reused; it carries no state and is safe to
+# delete at any time. Set KEEP=0 to remove it when the probe finishes.
+#
+# The binary is compiled locally in the go-mxl builder image and piped
+# into the pod, so this works against any cluster without publishing an
+# image first.
+#
+# Exit status is the probe's: 0 only for a SMOOTH verdict.
+set -euo pipefail
+
+NS=${NS:-mxl-system}
+KEEP=${KEEP:-1}
+GO_MXL_TAG=${GO_MXL_TAG:-1.1.0-rc.2}
+BUILDER=ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG}
+RUNTIME=ghcr.io/qvest-digital/go-mxl-runtime:${GO_MXL_TAG}
+DOMAIN=${DOMAIN:-/run/mxl/domain}
+
+if [ $# -lt 2 ]; then
+    sed -n '2,18p' "$0" >&2
+    exit 2
+fi
+node=$1
+flow=$2
+shift 2
+
+repo=$(cd "$(dirname "$0")/.." && pwd)
+bin=${BIN:-$repo/.probe-bin/mxl-flow-probe}
+
+if [ ! -x "$bin" ]; then
+    echo "==> building mxl-flow-probe" >&2
+    mkdir -p "$(dirname "$bin")"
+    docker run --rm \
+        -v "$repo":/w -v "$(dirname "$bin")":/out \
+        -w /w/gateway -e GOWORK=off -e GOFLAGS=-buildvcs=false \
+        "$BUILDER" \
+        sh -c 'go build -trimpath -o /out/mxl-flow-probe ./cmd/mxl-flow-probe' >&2
+    chmod 0755 "$bin"
+fi
+
+pod=mxl-flow-probe-$node
+if ! kubectl -n "$NS" get pod "$pod" >/dev/null 2>&1; then
+    echo "==> creating $pod on $node" >&2
+    kubectl -n "$NS" apply -f - >&2 <<EOF
+apiVersion: v1
+kind: Pod
+metadata:
+  name: $pod
+  labels: {app.kubernetes.io/name: mxl-flow-probe}
+spec:
+  nodeName: $node
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0
+  containers:
+  - name: probe
+    image: $RUNTIME
+    command: ["sleep", "infinity"]
+    securityContext:
+      runAsNonRoot: false
+      allowPrivilegeEscalation: false
+      capabilities: {drop: ["ALL"], add: ["DAC_OVERRIDE", "FOWNER"]}
+    resources:
+      requests: {cpu: 100m, memory: 64Mi}
+    volumeMounts:
+    - {name: mxl-domain, mountPath: $DOMAIN}
+    - {name: work, mountPath: /work}
+  volumes:
+  - name: mxl-domain
+    hostPath: {path: $DOMAIN, type: DirectoryOrCreate}
+  - name: work
+    emptyDir: {}
+EOF
+    kubectl -n "$NS" wait --for=condition=Ready "pod/$pod" --timeout=120s >&2
+fi
+
+# Upload once; the emptyDir keeps it for the pod's lifetime.
+if ! kubectl -n "$NS" exec "$pod" -- test -x /work/mxl-flow-probe 2>/dev/null; then
+    kubectl -n "$NS" exec -i "$pod" -- \
+        sh -c 'cat > /work/mxl-flow-probe && chmod 0755 /work/mxl-flow-probe' < "$bin"
+fi
+
+set +e
+kubectl -n "$NS" exec "$pod" -- \
+    /work/mxl-flow-probe -domain "$DOMAIN" -flow "$flow" -label "$node" "$@"
+rc=$?
+set -e
+
+[ "$KEEP" = "0" ] && kubectl -n "$NS" delete pod "$pod" --wait=false >/dev/null 2>&1
+exit $rc


### PR DESCRIPTION
Average throughput answers whether the bytes arrived, not whether they
arrived on time. A mirror delivering a second of audio per second in one
burst reads as 100% of real time and is unusable, and every counter the
gateway keeps today is an average. That gap hid a mirror abandoning
53,750 samples a second on a 48,000 sample per second flow: the bytes it
did send were counted as sent, the target's head advanced over the ones
it did not, and both halves reported themselves fresh.

`mxl-flow-probe` samples a flow's head index and reports the shape of
delivery rather than its mean: the interval between advances, the share
of fixed windows that received less than their due, and how far behind
real time the cumulative delivery ever fell. Run at both ends of a
mirror, the difference between the two is the fabric's contribution,
which is what decides whether a fabric is implicated at all.

`hack/flow-probe.sh <node> <flow>` builds it in the pinned builder image
and runs it in a scratch pod on the named node, so it works against any
cluster without publishing an image first.

Exit status is zero only for a SMOOTH verdict, so it can gate a change
rather than only describe one.

Known limitation, documented in the flag help: the window and stall
thresholds default to values suited to audio. A discrete flow whose
grain period exceeds them needs both passed explicitly or the verdict is
meaningless.