### PR TITLE
fix(gateway): pace sample transfers and stop skipping live samples

### DIFF
--- a/gateway/internal/mirror/sample_test.go
+++ b/gateway/internal/mirror/sample_test.go
@@ -58,7 +58,7 @@ func TestRunSampleTransferLoop_TransfersDeltaSinceLastTick(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, makeProgress, 480, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, makeProgress, func() error { return nil }, 480, testReadableWindow, time.Millisecond, tracker)
 
 	require.Eventually(t, func() bool { return len(xfersSnap()) == 1 },
 		time.Second, time.Millisecond, "expected exactly one sample-run transfer")
@@ -113,7 +113,7 @@ func TestRunSampleTransferLoop_ChunksLargeDeltaByXferBatch(t *testing.T) {
 	// The delta is larger than xferBatch but inside the catch-up
 	// bound (2*xferBatch), so it must split into full-batch runs
 	// with no aged-out skip.
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, func() error { return nil }, xferBatch, testReadableWindow, time.Millisecond, tracker)
 
 	require.Eventually(t, func() bool { return len(xfersSnap()) == 2 },
 		time.Second, time.Millisecond, "expected the 960-sample delta to split into 480+480")
@@ -127,14 +127,16 @@ func TestRunSampleTransferLoop_ChunksLargeDeltaByXferBatch(t *testing.T) {
 	assert.Zero(t, agedOuts, "a within-bound delta is a normal catch-up, not an aged-out skip")
 }
 
-func TestRunSampleTransferLoop_FellBehindSkipsToBoundedCatchUpAndSignals(t *testing.T) {
-	// The producer has lapped the reader far beyond one tick's
-	// catch-up. The loop must skip to head-2*xferBatch (the newest
-	// batch plus one batch of slack, not the readable-window edge),
-	// signal the tracker once, and transfer only what the bound
-	// allows. Skipping to the window edge instead would attempt the
-	// whole readable window in one tick: a burst that floods the
-	// send queue and wedges every mirror sharing the fabric.
+func TestRunSampleTransferLoop_CatchesUpInsideTheWindowRatherThanSkipping(t *testing.T) {
+	// A backlog that is still on the ring is owed to the target and
+	// must be sent, not passed over.
+	//
+	// Skipping is not the cheap option it is on the grain path. The
+	// next transfer commits at its own index, so the target's head
+	// moves across the skipped range and republishes whatever its ring
+	// already held there. Every skipped sample is a hole filled with
+	// stale audio, which is why only the readable window may end a
+	// catch-up.
 	const xferBatch = 480
 	var probeCalls atomic.Int32
 	probe := func() (uint64, error) {
@@ -163,31 +165,166 @@ func TestRunSampleTransferLoop_FellBehindSkipsToBoundedCatchUpAndSignals(t *test
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, func() error { return nil }, xferBatch, testReadableWindow, time.Millisecond, tracker)
 
-	require.Eventually(t, func() bool { return len(xfersSnap()) == 2 },
-		time.Second, time.Millisecond, "expected the bounded catch-up to transfer as two full batches")
+	require.Eventually(t, func() bool { return len(xfersSnap()) == 5 },
+		time.Second, time.Millisecond, "the whole 2000-sample backlog must be transferred")
 
 	cancel()
 	<-done
 
-	assert.Equal(t, []sampleXfer{{head: 1520, count: xferBatch}, {head: 2000, count: xferBatch}}, xfersSnap(),
-		"after falling behind, the loop must transfer only the bounded catch-up ending at head")
+	// Four batches in the first tick, the 80-sample remainder in the
+	// next: contiguous from zero, nothing passed over.
+	assert.Equal(t, []sampleXfer{
+		{head: 480, count: 480},
+		{head: 960, count: 480},
+		{head: 1440, count: 480},
+		{head: 1920, count: 480},
+		{head: 2000, count: 80},
+	}, xfersSnap())
 	transfers, agedOuts := tracker.snapshot()
-	assert.Equal(t, []uint64{1520, 2000}, transfers)
-	assert.Equal(t, 1, agedOuts,
-		"falling more than the catch-up bound behind must record exactly one aged-out skip so the "+
-			"reconciler can publish SourceProgress=ReaderAgedOut")
+	assert.Equal(t, []uint64{480, 960, 1440, 1920, 2000}, transfers)
+	assert.Zero(t, agedOuts, "a backlog inside the readable window is not aged out")
+	assert.Zero(t, tracker.skippedSnapshot(), "and nothing may be recorded as skipped")
+}
+
+// The pacing that keeps a multi-chunk tick from putting its writes on
+// the wire back to back. libmxl-fabrics gives an initiator an
+// eight-entry completion queue with no way to raise it, and the sample
+// ingress protocol keeps one posted receive, so a backlog drained
+// without reaping between chunks outruns both.
+//
+// The reap has to be the non-blocking call. The blocking one parks for
+// its whole timeout when nothing has landed, and that timeout is the
+// tick: pacing with it costs a tick per chunk, so the loop delivers one
+// batch per two ticks -- half real time -- and falls permanently behind
+// a live producer. That regression is what the timing assertion here
+// catches; the blocking stub sleeps like the real one.
+func TestRunSampleTransferLoop_ReapsBetweenChunksWithoutBlocking(t *testing.T) {
+	const xferBatch = 480
+	const tick = 5 * time.Millisecond
+	var probeCalls atomic.Int32
+	probe := func() (uint64, error) {
+		if probeCalls.Add(1) == 1 {
+			return 0, nil
+		}
+		return 1920, nil
+	}
+
+	var mu sync.Mutex
+	var seq []string
+	note := func(what string) {
+		mu.Lock()
+		seq = append(seq, what)
+		mu.Unlock()
+	}
+	transfer := func(uint64, int) error { note("xfer"); return nil }
+	// Blocking, exactly like progressFuncFor returns for verbs.
+	blocking := func() error { note("block"); time.Sleep(tick); return nil }
+	reap := func() error { note("reap"); return nil }
+	seqSnap := func() []string {
+		mu.Lock()
+		defer mu.Unlock()
+		return append([]string(nil), seq...)
+	}
+	countXfer := func() int {
+		n := 0
+		for _, s := range seqSnap() {
+			if s == "xfer" {
+				n++
+			}
+		}
+		return n
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	started := time.Now()
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, blocking, reap,
+		xferBatch, testReadableWindow, tick, &recordingTracker{})
+
+	require.Eventually(t, func() bool { return countXfer() >= 4 }, 2*time.Second, time.Millisecond,
+		"the four-batch backlog must be transferred")
+	elapsed := time.Since(started)
+	cancel()
+	<-done
+
+	// Four chunks paced with the blocking call would cost at least four
+	// ticks of sleeping on top of the tick they start on.
+	assert.Less(t, elapsed, 4*tick,
+		"the backlog must clear inside a tick or two; pacing with the blocking call would take at least four")
+
+	// And no blocking call may appear between the first and the fourth
+	// chunk -- only reaps.
+	snap := seqSnap()
+	var first, fourth, seen int
+	for i, s := range snap {
+		if s == "xfer" {
+			seen++
+			if seen == 1 {
+				first = i
+			}
+			if seen == 4 {
+				fourth = i
+				break
+			}
+		}
+	}
+	require.Equal(t, 4, seen)
+	var reaps, blocks int
+	for _, s := range snap[first:fourth] {
+		switch s {
+		case "reap":
+			reaps++
+		case "block":
+			blocks++
+		}
+	}
+	assert.GreaterOrEqual(t, reaps, 3, "every chunk but the last must be followed by a reap")
+	assert.Zero(t, blocks, "the blocking MakeProgress must not be what paces the chunks")
+}
+
+func TestRunSampleTransferLoop_RecordsSkippedSamplesWhenLapped(t *testing.T) {
+	// The counter behind mxl_gateway_mirror_skipped_samples_total. It
+	// is the only signal separating "the target received this" from
+	// "the target's head moved over it", and those two are identical in
+	// every byte and freshness measure the gateway keeps.
+	const xferBatch = 480
+	const window = uint64(48000)
+	var probeCalls atomic.Int32
+	probe := func() (uint64, error) {
+		if probeCalls.Add(1) == 1 {
+			return 0, nil
+		}
+		return 100000, nil
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	tracker := &recordingTracker{}
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe,
+		func(uint64, int) error { return nil }, func() error { return nil }, func() error { return nil },
+		xferBatch, window, time.Millisecond, tracker)
+
+	require.Eventually(t, func() bool { return tracker.skippedSnapshot() > 0 },
+		time.Second, time.Millisecond)
+	cancel()
+	<-done
+
+	// The window less one batch of slack stays readable, so everything
+	// before head-(window-xferBatch) is abandoned.
+	assert.Equal(t, 100000-(window-xferBatch), tracker.skippedSnapshot())
+	_, agedOuts := tracker.snapshot()
+	assert.Positive(t, agedOuts)
 }
 
 func TestRunSampleTransferLoop_NeverBurstsBeyondCatchUpPerTick(t *testing.T) {
-	// A mirror that has fallen far behind must not attempt the
-	// whole backlog in one tick: at most two xferBatch chunks are
-	// transferable per tick, and only while the lag stays inside the
-	// bound. This is what keeps a 48 kHz mirror from posting a burst
-	// of hundreds of writes -- one per readable-window batch --
-	// against the fabric. The loop transfers the bounded catch-up
-	// and leaves the rest for the next tick; it does not spin.
+	// A mirror that has fallen far behind must not attempt the whole
+	// backlog in one tick: at most sampleCatchUpBatches chunks are
+	// transferable per tick. This is what keeps a 48 kHz mirror from
+	// posting a burst of hundreds of writes -- one per readable-window
+	// batch -- against the fabric. The loop transfers the bounded
+	// catch-up and leaves the rest for the next tick; it does not spin.
 	const xferBatch = 480
 	var probes atomic.Uint64
 	probe := func() (uint64, error) {
@@ -216,7 +353,7 @@ func TestRunSampleTransferLoop_NeverBurstsBeyondCatchUpPerTick(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, func() error { return nil }, xferBatch, testReadableWindow, time.Millisecond, tracker)
 
 	require.Eventually(t, func() bool { return len(xfersSnap()) >= 1 },
 		time.Second, time.Millisecond, "the bounded catch-up must transfer")
@@ -232,13 +369,13 @@ func TestRunSampleTransferLoop_NeverBurstsBeyondCatchUpPerTick(t *testing.T) {
 	for i, x := range snap {
 		assert.LessOrEqualf(t, x.count, int(xferBatch), "chunk %d: a single write must never exceed xferBatch", i)
 		if i > 0 {
-			assert.LessOrEqualf(t, snap[i].head-snap[i-1].head, uint64(2*xferBatch),
-				"chunk %d: consecutive transfers within a tick must not exceed the catch-up bound", i)
+			assert.LessOrEqualf(t, snap[i].head-snap[i-1].head, uint64(xferBatch),
+				"chunk %d: consecutive transfers must advance by at most one batch", i)
 		}
 	}
-	// The first tick is the only one that skips to the bound; with
-	// the head frozen afterwards nothing more transfers.
-	assert.LessOrEqualf(t, len(snap), 2,
+	// 2000 samples of backlog is five chunks; with the head frozen
+	// afterwards nothing more transfers.
+	assert.LessOrEqualf(t, len(snap), 5,
 		"a frozen head must not produce further transfers, got %d", len(snap))
 }
 
@@ -267,7 +404,7 @@ func TestRunSampleTransferLoop_ExitsAfterSustainedStarvation(t *testing.T) {
 	defer cancel()
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, func() error { return nil }, xferBatch, testReadableWindow, time.Millisecond, tracker)
 
 	select {
 	case <-done:
@@ -311,7 +448,7 @@ func TestRunSampleTransferLoop_StarvationResetsOnDelivery(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, func() error { return nil }, xferBatch, testReadableWindow, time.Millisecond, tracker)
 
 	// Far longer than the starvation window: if the counter were not
 	// reset by deliveries the loop would have exited inside it.
@@ -360,7 +497,7 @@ func TestRunSampleTransferLoop_TrickleDeliveryStillStarves(t *testing.T) {
 	defer cancel()
 	done := make(chan struct{})
 	tracker := &recordingTracker{}
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, xferBatch, time.Millisecond, tracker)
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, func() error { return nil }, xferBatch, testReadableWindow, time.Millisecond, tracker)
 
 	select {
 	case <-done:
@@ -409,7 +546,7 @@ func TestRunSampleTransferLoop_TransferErrorBreaksTickAndRetries(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, 480, time.Millisecond, &recordingTracker{})
+	go runSampleTransferLoop(ctx, done, "flow-audio", probe, transfer, func() error { return nil }, func() error { return nil }, 480, testReadableWindow, time.Millisecond, &recordingTracker{})
 
 	require.Eventually(t, func() bool { return xfersLen() >= 1 },
 		time.Second, time.Millisecond, "a transfer error must not wedge the loop; the next tick must retry")
@@ -433,7 +570,7 @@ func TestRunSampleTransferLoop_CtxCancelExitsDuringIdle(t *testing.T) {
 	done := make(chan struct{})
 	go runSampleTransferLoop(ctx, done, "flow-audio", probe,
 		func(uint64, int) error { t.Error("no transfer expected on an idle flow"); return nil },
-		func() error { return nil }, 480, time.Millisecond, &recordingTracker{})
+		func() error { return nil }, func() error { return nil }, 480, testReadableWindow, time.Millisecond, &recordingTracker{})
 
 	cancel()
 	select {

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -310,6 +310,13 @@ type sourceEntry struct {
 	// transfer loop's.
 	bytes atomic.Uint64
 
+	// skipped counts samples the transfer loop advanced past without
+	// sending, which happens only once they have left the readable
+	// window. It is not the same as loss on the wire: the target's head
+	// still moves over them, so each one is a hole its ring fills with
+	// whatever it already held. Zero is the only healthy value.
+	skipped atomic.Uint64
+
 	// agedOutAt records the wall-clock of the most recent
 	// reader-aged-out skip the transfer loop has had to perform.
 	// Used by the flusher to publish SourceProgress with reason
@@ -1059,7 +1066,7 @@ func (o *libmxlOpener) open(flowID string, provider fabrics.Provider) (*sharedSo
 			s.addBytes(uint64(count) * frameBytes)
 			return nil
 		}
-		go runSampleTransferLoop(loopCtx, done, flowID, runtimeFn, transferSamplesFn, progressFn, xferBatch, progressInterval, s)
+		go runSampleTransferLoop(loopCtx, done, flowID, runtimeFn, transferSamplesFn, progressFn, reapFuncFor(initiator), xferBatch, maxBatch, progressInterval, s)
 	} else {
 		// The pacer is keyed on flow plus provider so two shared
 		// sources -- of the same flow on different providers, or of
@@ -1182,6 +1189,7 @@ type progressTracker interface {
 	recordTransfer(idx uint64, at time.Time)
 	recordAgedOut(at time.Time)
 	recordHead(head uint64, at time.Time)
+	recordSkipped(samples uint64)
 }
 
 func (e *sourceEntry) recordTransfer(idx uint64, at time.Time) {
@@ -1216,6 +1224,16 @@ func (s *sharedSource) recordTransfer(idx uint64, at time.Time) {
 func (s *sharedSource) recordAgedOut(at time.Time) {
 	for _, e := range s.attached() {
 		e.recordAgedOut(at)
+	}
+}
+
+func (e *sourceEntry) recordSkipped(samples uint64) {
+	e.skipped.Add(samples)
+}
+
+func (s *sharedSource) recordSkipped(samples uint64) {
+	for _, e := range s.attached() {
+		e.recordSkipped(samples)
 	}
 }
 
@@ -1288,6 +1306,7 @@ func runTransferLoop(
 			l.Error(err, "Runtime")
 			continue
 		}
+
 		if tracker != nil {
 			tracker.recordHead(head, time.Now())
 		}
@@ -1417,7 +1436,9 @@ func runSampleTransferLoop(
 	probeRuntime RuntimeProbe,
 	transferSamples SampleTransferFunc,
 	makeProgress ProgressFunc,
+	reapProgress ProgressFunc,
 	xferBatch uint64,
+	maxReadable uint64,
 	interval time.Duration,
 	tracker progressTracker,
 ) {
@@ -1425,13 +1446,30 @@ func runSampleTransferLoop(
 
 	l := ctrl.Log.WithName("sample-transfer").WithValues("flowID", flowID)
 
-	// catchUp bounds how far behind the live head one tick may reach.
-	// Two batches keeps one batch of slack for a late-arriving head
-	// probe without opening a burst; anything older is skipped as
-	// aged out.
-	catchUp := 2 * xferBatch
+	// catchUp bounds how much one tick may transfer, so a backlog
+	// drains over several ticks instead of arriving as one burst of
+	// back-to-back writes. It is a pacing bound, not a skip bound:
+	// what a tick does not reach stays owed and is sent by the next
+	// one.
+	catchUp := sampleCatchUpBatches * xferBatch
 	if catchUp == 0 {
 		catchUp = maxSampleCatchUpFallback
+	}
+	// agedOut is the only distance at which samples are abandoned: the
+	// point past which the reader can no longer read them at all.
+	// Anything nearer is still on the ring and is owed to the target.
+	//
+	// Skipping is not free the way it is on the grain path. A grain the
+	// loop passes over is simply never mirrored, and the target's head
+	// stays where it was. A sample range the loop passes over still
+	// moves the target's head, because the next transfer commits at its
+	// own index -- so the target publishes whatever its ring already
+	// held between the two, as audio. Every skipped sample is a hole
+	// filled with stale content, which is why this bound is the ring
+	// and not a couple of batches.
+	agedOut := maxReadable
+	if agedOut > xferBatch {
+		agedOut -= xferBatch
 	}
 
 	// Discover the current head and tail the live flow from there,
@@ -1450,7 +1488,10 @@ func runSampleTransferLoop(
 	t := time.NewTicker(interval)
 	defer t.Stop()
 	// Throttles MakeProgress while it keeps failing; see progress.go.
-	var progress progressThrottle
+	// Two of them: one for the per-tick call, one for the call between
+	// chunks. They fire at different rates and a shared failure history
+	// would back the tick off for a chunk's sake.
+	var progress, chunkProgress progressThrottle
 	// starved counts consecutive ticks in which the writer produced
 	// new samples but only a fraction of them landed. A wedged fabric
 	// connection does not refuse every chunk: the send queue drains
@@ -1487,61 +1528,73 @@ func runSampleTransferLoop(
 			tracker.recordHead(head, time.Now())
 		}
 		if head > lastSent {
-			// A continuous flow can only be consumed at its own
-			// sample rate: one xferBatch per tick is real time, and
-			// no fabric drains a backlog faster than that. A mirror
-			// that falls behind therefore cannot catch up by bursting
-			// -- attempting it transfers up to the whole readable
-			// window (hundreds of xferBatch writes) in one tick,
-			// which floods the send queue and wedges the fabric for
-			// every mirror sharing it. Cap the catch-up at a small
-			// multiple of one batch and treat anything older as
-			// aged out, matching the reference transfer loop, which
-			// transfers one batch per grain instant and, on falling
-			// behind, jumps to the live head rather than replaying
-			// the gap.
-			// produced is the whole delta since the last tick,
-			// measured before the skip below folds the gap: the
-			// starvation bound must see what the writer produced,
-			// not the two batches the skip leaves behind, or a
-			// one-chunk-per-tick trickle lands a quarter of the
-			// folded delta and reads as healthy.
+			// produced is the whole delta since the last tick, taken
+			// before anything below narrows it. The starvation bound
+			// asks whether the loop is keeping up with the writer, so
+			// it has to see what the writer wrote -- not the smaller
+			// figure the per-tick pacing bound chose to attempt, which
+			// a trickle would satisfy while falling further behind
+			// every tick.
 			produced := head - lastSent
-			if head-lastSent > catchUp {
+
+			// Abandon samples only once they have left the readable
+			// window. Everything nearer is still on the ring, and a
+			// skipped sample range is not a gap the target can see: the
+			// next transfer commits at its own index, so the target's
+			// head moves over the skipped range and republishes stale
+			// ring content in its place.
+			if agedOut > 0 && head-lastSent > agedOut {
 				l.Info("reader fell behind writer, skipping samples",
 					"fromIndex", lastSent+1, "toIndex", head)
 				if tracker != nil {
 					tracker.recordAgedOut(time.Now())
 				}
-				lastSent = head - catchUp
+				if skipped := (head - agedOut) - lastSent; tracker != nil {
+					tracker.recordSkipped(skipped)
+				}
+				lastSent = head - agedOut
 			}
-			// Transfer the remaining (lastSent, head] delta in chunks
-			// of at most xferBatch samples, each ending at the chunk's
-			// last index.
-			//
+			// One tick transfers at most catchUp samples. A producer
+			// that commits in lumps -- an encoder emitting whole frames,
+			// say -- leaves a backlog on the ticks between its writes,
+			// and draining it in one pass puts that many writes on the
+			// wire back to back. Spreading it over ticks keeps the
+			// number in flight bounded whatever the producer does.
+			limit := head
+			if catchUp > 0 && head-lastSent > catchUp {
+				limit = lastSent + catchUp
+			}
 			// A chunk that comes back not-ready is backpressure, not a
 			// failure: libmxl-fabrics reports the initiator's send
 			// queue being full as EAGAIN, which surfaces here as
 			// fabrics.ErrNotReady. The queue drains on MakeProgress, so
 			// the chunk is retried after driving it rather than
-			// abandoned until the next tick. Abandoning it is what let
-			// the reader slide out of the readable window while the
-			// producer kept writing, at which point the loop skipped
-			// samples and published ReaderAgedOut for what was really a
-			// momentarily full queue.
+			// abandoned until the next tick.
+			//
+			// Retries reap, they do not park. Nothing that blocks
+			// belongs inside a tick that owes real time: the tick is one
+			// batch of audio, so a blocking MakeProgress inside it makes
+			// the loop take two ticks to deliver one, and a loop running
+			// at half real time falls behind a live producer for good.
+			// A completion that has crossed a microsecond of fabric is
+			// already there for a non-blocking poll, and one that is not
+			// will be by the next tick, with the samples still owed
+			// because lastSent did not move.
 			retries := 0
 			delivered := uint64(0)
-			for lastSent < head {
-				count := head - lastSent
+			deadline := time.Now().Add(interval)
+			for lastSent < limit {
+				count := limit - lastSent
 				if xferBatch > 0 && count > xferBatch {
 					count = xferBatch
 				}
 				end := lastSent + count
 				err := transferSamples(end, int(count))
 				if err != nil {
-					if classifyFabricError(err) == fabricIdle && retries < maxSampleTransferRetries {
+					if classifyFabricError(err) == fabricIdle && retries < maxSampleTransferRetries &&
+						time.Now().Before(deadline) {
 						retries++
-						progress.runProgress(makeProgress, func(perr error) { logProgressFailure(l, perr) })
+						chunkProgress.runProgress(reapProgress, func(perr error) { logProgressFailure(l, perr) })
 						continue
 					}
 					logSampleTransferFailure(l, err, end, count)
@@ -1553,6 +1606,30 @@ func runSampleTransferLoop(
 					tracker.recordTransfer(end, time.Now())
 				}
 				lastSent = end
+				// Settle the chunk before starting the next one.
+				//
+				// One write outstanding on the initiator is not the same
+				// as one the far side can absorb. The sample egress
+				// protocol writes RDMA_WRITE_WITH_IMM, which consumes a
+				// receive on the responder, and the ingress protocol
+				// keeps exactly one posted -- it re-posts from its own
+				// read loop, after it has processed the completion.
+				// There is no credit exchange between the two, so a
+				// second write issued before the far side has come round
+				// finds an empty receive queue and falls back on RNR
+				// retry, which libfabric configures as unbounded and
+				// which irdma leaves untimed on E810.
+				//
+				// Waiting for the transfer to report itself settled is
+				// the closest the API gets to that credit, and it is
+				// what the upstream reference loop does between batches.
+				// Bounded, because a wedge must surface as a stalled
+				// lastSent on the next tick rather than as a spin here.
+				if lastSent < limit {
+					if !drainChunk(reapProgress, chunkSettleBudget) || time.Now().After(deadline) {
+						break
+					}
+				}
 			}
 			if produced > 0 && delivered*4 < produced {
 				starved++
@@ -1568,7 +1645,39 @@ func runSampleTransferLoop(
 			}
 		}
 
-		progress.runProgress(makeProgress, func(err error) { logProgressFailure(l, err) })
+		// Park on the completion queue only when the loop owes nothing.
+		// Blocking is what lets an idle mirror notice a completion
+		// promptly without spinning, but with samples still owed it is
+		// simply a tick the loop spends not delivering.
+		if lastSent < head {
+			progress.runProgress(reapProgress, func(err error) { logProgressFailure(l, err) })
+		} else {
+			progress.runProgress(makeProgress, func(err error) { logProgressFailure(l, err) })
+		}
+	}
+}
+
+// chunkSettleBudget bounds the wait for one chunk to settle before the
+// next is issued. It is a small fraction of a tick: long enough for a
+// completion that has crossed the fabric, short enough that several
+// chunks still fit in the tick they are owed in.
+const chunkSettleBudget = 500 * time.Microsecond
+
+// drainChunk polls until the initiator reports no work outstanding or
+// the budget runs out. Reports whether it settled.
+func drainChunk(reap ProgressFunc, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for {
+		if err := reap(); err == nil {
+			return true
+		} else if classifyFabricError(err) != fabricIdle {
+			// A real failure, not "still working". Let the caller stop
+			// and the tick surface it.
+			return false
+		}
+		if !time.Now().Before(deadline) {
+			return false
+		}
 	}
 }
 
@@ -2365,6 +2474,12 @@ const maxSampleTransferRetries = 8
 // noticing.
 const maxSampleStarvedTicks = 200
 
+// sampleCatchUpBatches is how many batches one tick may transfer. One
+// batch is real time, so four lets a mirror that fell behind close the
+// gap at three times real time while keeping the number of writes a
+// single tick puts on the wire bounded and small.
+const sampleCatchUpBatches = 4
+
 // maxSampleCatchUpFallback is the per-tick catch-up bound used when
 // xferBatch is zero, which cannot happen in production (the open path
 // defaults it to one sample at minimum) but keeps the loop's bound
@@ -2410,6 +2525,21 @@ func defaultSampleProgressInterval(rate mxl.Rational, xferBatch uint64) time.Dur
 // to complete the write and free the send slot.
 func progressBlocking(provider fabrics.Provider) bool {
 	return provider != fabrics.ProviderEFA
+}
+
+// reapFuncFor selects the MakeProgress variant used between the chunks
+// of one tick. Always the non-blocking one, whatever the provider.
+//
+// The blocking variant parks on the completion queue for its whole
+// timeout when nothing has landed, and the timeout is the tick. Calling
+// it between chunks costs a tick per chunk, so a loop that paced with
+// it delivered one batch per two ticks -- half real time -- and fell
+// permanently behind a live producer. Reaping is all this call is for:
+// the completions of a write that has already crossed a microsecond of
+// fabric are there, and a chunk that still finds the queue full takes
+// the retry path, which does block.
+func reapFuncFor(initiator *fabrics.Initiator) ProgressFunc {
+	return initiator.MakeProgressNonBlocking
 }
 
 // progressFuncFor selects the MakeProgress variant the transfer loop

--- a/gateway/internal/mirror/source_samples_test.go
+++ b/gateway/internal/mirror/source_samples_test.go
@@ -58,8 +58,8 @@ func TestRunSampleTransferLoop_RetriesAFullSendQueueWithinTheTick(t *testing.T) 
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go runSampleTransferLoop(ctx, done, "f", probe, transfer, progress,
-		480, time.Millisecond, nil)
+	go runSampleTransferLoop(ctx, done, "f", probe, transfer, progress, func() error { return nil },
+		480, testReadableWindow, time.Millisecond, nil)
 
 	require.Eventually(t, func() bool {
 		mu.Lock()
@@ -103,8 +103,8 @@ func TestRunSampleTransferLoop_BackpressureDoesNotReportReaderAgedOut(t *testing
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
-		480, time.Millisecond, tr)
+	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil }, func() error { return nil },
+		480, testReadableWindow, time.Millisecond, tr)
 
 	// Well past the ~15 ticks it takes to cross the window unretried.
 	require.Eventually(t, func() bool { return tr.transfers() >= 60 }, 3*time.Second, time.Millisecond,
@@ -136,8 +136,8 @@ func TestRunSampleTransferLoop_BoundsRetriesSoAWedgedFabricYieldsTheTick(t *test
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
-		480, 20*time.Millisecond, nil)
+	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil }, func() error { return nil },
+		480, testReadableWindow, 20*time.Millisecond, nil)
 
 	// Two ticks' worth of time. With the bound, attempts stay near
 	// 2 * (1 + maxSampleTransferRetries); without it the loop would
@@ -170,8 +170,8 @@ func TestRunSampleTransferLoop_NonIdleErrorBreaksImmediately(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
-		480, 20*time.Millisecond, nil)
+	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil }, func() error { return nil },
+		480, testReadableWindow, 20*time.Millisecond, nil)
 
 	time.Sleep(100 * time.Millisecond)
 	cancel()
@@ -200,8 +200,10 @@ func TestRunSampleTransferLoop_StillSkipsWhenGenuinelyLapped(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	done := make(chan struct{})
-	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil },
-		480, time.Millisecond, tr)
+	// One second of 48 kHz audio as the readable window; the producer
+	// jumps two seconds past it.
+	go runSampleTransferLoop(ctx, done, "f", probe, transfer, func() error { return nil }, func() error { return nil },
+		480, 48000, time.Millisecond, tr)
 
 	require.Eventually(t, func() bool { return tr.agedOut() > 0 }, time.Second, time.Millisecond,
 		"a producer that lapped the readable window is still ReaderAgedOut")
@@ -221,6 +223,8 @@ func (r *recordingSampleTracker) recordTransfer(uint64, time.Time) {
 	r.xfers++
 	r.mu.Unlock()
 }
+
+func (r *recordingSampleTracker) recordSkipped(uint64) {}
 
 func (r *recordingSampleTracker) recordAgedOut(time.Time) {
 	r.mu.Lock()

--- a/gateway/internal/mirror/source_shared_test.go
+++ b/gateway/internal/mirror/source_shared_test.go
@@ -297,7 +297,8 @@ func TestSource_AccountingLandsPerMirrorAcrossTheFanout(t *testing.T) {
 # TYPE mxl_gateway_mirror_transmitted_bytes_total counter
 mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node="n02",provider="verbs"} 1000
 mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node="n03",provider="verbs"} 1000
-`)), "the shared transfer must still be attributed per peer")
+`), "mxl_gateway_mirror_transmitted_bytes_total"),
+		"the shared transfer must still be attributed per peer")
 }
 
 func TestSource_AgedOutSkipReachesEveryAttachedMirror(t *testing.T) {

--- a/gateway/internal/mirror/source_stall_test.go
+++ b/gateway/internal/mirror/source_stall_test.go
@@ -244,7 +244,8 @@ func TestRunSampleTransferLoop_RecordsProbedHead(t *testing.T) {
 			return nil
 		},
 		func() error { return nil },
-		480, time.Millisecond, tracker)
+		func() error { return nil },
+		480, testReadableWindow, time.Millisecond, tracker)
 
 	<-done
 	heads := tracker.headSnapshot()

--- a/gateway/internal/mirror/source_test.go
+++ b/gateway/internal/mirror/source_test.go
@@ -303,8 +303,14 @@ type recordingTracker struct {
 	mu        sync.Mutex
 	transfers []uint64
 	agedOuts  int
+	skipped   uint64
 	heads     []uint64
 }
+
+// testReadableWindow stands in for the reader's readable window in the
+// tests that are not about ageing out. It is larger than any head they
+// reach, so nothing in them is ever old enough to abandon.
+const testReadableWindow = 1 << 20
 
 func (rt *recordingTracker) recordTransfer(idx uint64, _ time.Time) {
 	rt.mu.Lock()
@@ -318,10 +324,22 @@ func (rt *recordingTracker) recordAgedOut(_ time.Time) {
 	rt.mu.Unlock()
 }
 
+func (rt *recordingTracker) recordSkipped(samples uint64) {
+	rt.mu.Lock()
+	rt.skipped += samples
+	rt.mu.Unlock()
+}
+
 func (rt *recordingTracker) recordHead(head uint64, _ time.Time) {
 	rt.mu.Lock()
 	rt.heads = append(rt.heads, head)
 	rt.mu.Unlock()
+}
+
+func (rt *recordingTracker) skippedSnapshot() uint64 {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.skipped
 }
 
 func (rt *recordingTracker) headSnapshot() []uint64 {

--- a/gateway/internal/mirror/throughput.go
+++ b/gateway/internal/mirror/throughput.go
@@ -10,6 +10,10 @@ type Throughput struct {
 	PeerNode string
 	Provider string
 	Bytes    uint64
+
+	// SkippedSamples is meaningful on the source half of a continuous
+	// flow only, and is zero everywhere else.
+	SkippedSamples uint64
 }
 
 var (
@@ -21,6 +25,12 @@ var (
 	descReceived = prometheus.NewDesc(
 		"mxl_gateway_mirror_received_bytes_total",
 		"Payload bytes committed to the local flow for a mirror this node is the target of.",
+		[]string{"flow_id", "node", "peer_node", "provider"}, nil)
+
+	descSkipped = prometheus.NewDesc(
+		"mxl_gateway_mirror_skipped_samples_total",
+		"Samples the source half advanced past without sending, having left the readable window. "+
+			"The target's head still moves over them, so each is published as stale ring content.",
 		[]string{"flow_id", "node", "peer_node", "provider"}, nil)
 )
 
@@ -45,6 +55,7 @@ type ThroughputCollector struct {
 func (c *ThroughputCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- descTransmitted
 	ch <- descReceived
+	ch <- descSkipped
 }
 
 // Collect folds the live entries onto their label set before emitting.
@@ -71,6 +82,17 @@ func (c *ThroughputCollector) Collect(ch chan<- prometheus.Metric) {
 	}
 	emit(descTransmitted, c.Source)
 	emit(descReceived, c.Target)
+
+	if c.Source != nil {
+		skipped := map[key]uint64{}
+		for _, t := range c.Source.Throughput() {
+			skipped[key{t.FlowID, t.PeerNode, t.Provider}] += t.SkippedSamples
+		}
+		for k, n := range skipped {
+			ch <- prometheus.MustNewConstMetric(descSkipped, prometheus.CounterValue,
+				float64(n), k.flowID, c.NodeName, k.peerNode, k.provider)
+		}
+	}
 }
 
 // Throughput reports what each mirror this node sources has put on the
@@ -91,6 +113,8 @@ func (r *SourceReconciler) Throughput() []Throughput {
 			PeerNode: e.peerNode,
 			Provider: e.provider().String(),
 			Bytes:    e.bytes.Load(),
+
+			SkippedSamples: e.skipped.Load(),
 		})
 	}
 	return out

--- a/gateway/internal/mirror/throughput_test.go
+++ b/gateway/internal/mirror/throughput_test.go
@@ -36,7 +36,8 @@ mxl_gateway_mirror_received_bytes_total{flow_id="flow-b",node="n01",peer_node="n
 # TYPE mxl_gateway_mirror_transmitted_bytes_total counter
 mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node="n02",provider="verbs"} 5529600
 `
-	require.NoError(t, testutil.CollectAndCompare(c, strings.NewReader(expected)))
+	require.NoError(t, testutil.CollectAndCompare(c, strings.NewReader(expected),
+		"mxl_gateway_mirror_received_bytes_total", "mxl_gateway_mirror_transmitted_bytes_total"))
 }
 
 func TestThroughputCollectorForgetsClosedMirrors(t *testing.T) {
@@ -52,10 +53,11 @@ func TestThroughputCollectorForgetsClosedMirrors(t *testing.T) {
 	src.sources[key] = e
 
 	c := &ThroughputCollector{NodeName: "n01", Source: src}
-	require.Equal(t, 1, testutil.CollectAndCount(c))
+	const transmitted = "mxl_gateway_mirror_transmitted_bytes_total"
+	require.Equal(t, 1, testutil.CollectAndCount(c, transmitted))
 
 	delete(src.sources, key)
-	require.Equal(t, 0, testutil.CollectAndCount(c),
+	require.Equal(t, 0, testutil.CollectAndCount(c, transmitted),
 		"a mirror that has been closed must leave no series behind")
 }
 
@@ -78,13 +80,33 @@ func TestThroughputCollectorSurvivesOneFlowMirroredTwice(t *testing.T) {
 # TYPE mxl_gateway_mirror_transmitted_bytes_total counter
 mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node="n02",provider="verbs"} 1000
 mxl_gateway_mirror_transmitted_bytes_total{flow_id="flow-a",node="n01",peer_node="n03",provider="verbs"} 1000
-`)), "one flow mirrored to two peers must yield two distinct series")
+`), "mxl_gateway_mirror_transmitted_bytes_total"),
+		"one flow mirrored to two peers must yield two distinct series")
 
 	// Same flow and same peer in two namespaces cannot be separated by
 	// labels at all, so the fold has to carry it.
 	dup := &sourceEntry{shared: testShared("flow-a", fabrics.ProviderVerbs), peerNode: "n02"}
 	dup.bytes.Store(500)
 	src.sources[types.NamespacedName{Namespace: "other", Name: "flow-a--n02"}] = dup
-	require.Equal(t, 2, testutil.CollectAndCount(c),
+	require.Equal(t, 2, testutil.CollectAndCount(c, "mxl_gateway_mirror_transmitted_bytes_total"),
 		"a label set that repeats must fold into one series, never a duplicate")
+}
+
+func TestThroughputCollectorReportsSkippedSamples(t *testing.T) {
+	// Skipped samples are invisible to every other counter the gateway
+	// keeps: the bytes it did send are counted as sent, the target's
+	// head still advances over the ones it did not, and both halves
+	// look fresh. This series is the only place the hole shows up.
+	src := &SourceReconciler{sources: map[types.NamespacedName]*sourceEntry{}}
+	e := &sourceEntry{shared: testShared("flow-a", fabrics.ProviderVerbs), peerNode: "n02"}
+	e.bytes.Store(1024)
+	e.skipped.Store(19200)
+	src.sources[types.NamespacedName{Namespace: "p", Name: "a"}] = e
+
+	c := &ThroughputCollector{NodeName: "n01", Source: src}
+	require.NoError(t, testutil.CollectAndCompare(c, strings.NewReader(`
+# HELP mxl_gateway_mirror_skipped_samples_total Samples the source half advanced past without sending, having left the readable window. The target's head still moves over them, so each is published as stale ring content.
+# TYPE mxl_gateway_mirror_skipped_samples_total counter
+mxl_gateway_mirror_skipped_samples_total{flow_id="flow-a",node="n01",peer_node="n02",provider="verbs"} 19200
+`), "mxl_gateway_mirror_skipped_samples_total"))
 }


### PR DESCRIPTION
A producer that commits in lumps rather than at a steady cadence leaves
the sample loop a backlog on the ticks between its writes. The loop
drained it as back-to-back TransferSamples calls with nothing reaping
completions in between, then abandoned anything more than two batches
behind the head.

Abandoning is not the cheap option it is on the grain path. A grain the
loop passes over is never mirrored and the target's head stays put. A
sample range it passes over still moves the target's head, because the
next transfer commits at its own index, so the target republishes
whatever its ring already held between the two. On the on-prem cluster
that reached 53,750 samples a second abandoned on a 48,000 sample per
second flow -- the flow arriving as stale ring content rather than as
audio, while every byte and freshness counter read healthy.

So: abandon only once samples have left the readable window, bound one
tick's work so a backlog drains over several ticks instead of one burst,
and reap completions between chunks.

Separately, nothing that blocks belongs inside a tick that owes real
time. The tick spans one batch of audio, so a blocking MakeProgress
inside it makes the loop take two ticks to deliver one, and at half real
time it falls behind a live producer permanently. That was measured: it
turned a healthy mirror bursty. Retries and between-chunk pacing now
reap without parking, and the tick parks only when it owes nothing. The
regression test fails against the blocking variant.

`mxl_gateway_mirror_skipped_samples_total` makes the abandoned samples
visible, which nothing else did.

Measured on the on-prem cluster with this and the libmxl-fabrics
receive-window fix deployed together: skipped samples and EAGAIN both
zero across five gateways, a multiviewer audio flow from 15.8% of real
time to 100%, and a mirrored flow tracking its own source to within 5ms
of worst deficit.