### PR TITLE
fix(gateway): wake the sample loop twice per committed batch

### DIFF
--- a/gateway/internal/mirror/progress_mode_test.go
+++ b/gateway/internal/mirror/progress_mode_test.go
@@ -34,10 +34,40 @@ func TestProgressBlocking_PartitionsEFAFromEverythingElse(t *testing.T) {
 }
 
 func TestDefaultSampleProgressInterval_48kHz(t *testing.T) {
-	// 48000/1 with a 480-sample batch: 480/48000 s = 10 ms.
+	// 48000/1 with a 480-sample batch spans 10 ms, and the loop wakes
+	// twice within it.
 	got := defaultSampleProgressInterval(mxl.Rational{Num: 48000, Den: 1}, 480)
-	assert.Equal(t, 10*time.Millisecond, got,
-		"48 kHz with a 480-sample batch should yield a 10 ms interval")
+	assert.Equal(t, 5*time.Millisecond, got,
+		"48 kHz with a 480-sample batch should yield a 5 ms interval")
+}
+
+// A tick period equal to the batch period lets the two clocks drift
+// against each other, so one tick finds nothing and the next finds two
+// batches: every sample arrives, but in pairs at twice the interval,
+// which a reader sees as gaps. Measured across EFA that was 89.7
+// advances/s against a producer committing 100/s, with the 90th
+// percentile advance carrying two batches rather than one.
+func TestDefaultSampleProgressInterval_OversamplesTheCommitCadence(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		rate  mxl.Rational
+		batch uint64
+	}{
+		{"48kHz/480", mxl.Rational{Num: 48000, Den: 1}, 480},
+		{"48kHz/1024", mxl.Rational{Num: 48000, Den: 1}, 1024},
+		{"96kHz/480", mxl.Rational{Num: 96000, Den: 1}, 480},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			batchSpan := time.Duration(int64(time.Second) *
+				int64(tc.rate.Den) * int64(tc.batch) / int64(tc.rate.Num))
+			got := defaultSampleProgressInterval(tc.rate, tc.batch)
+
+			assert.Positive(t, got, "a usable rate and batch yield an interval")
+			assert.LessOrEqual(t, got*2, batchSpan,
+				"the loop must wake at least twice per committed batch, "+
+					"or it beats against the producer")
+		})
+	}
 }
 
 func TestDefaultSampleProgressInterval_ZeroBatchFallsBack(t *testing.T) {

--- a/gateway/internal/mirror/progress_mode_test.go
+++ b/gateway/internal/mirror/progress_mode_test.go
@@ -70,6 +70,24 @@ func TestDefaultSampleProgressInterval_OversamplesTheCommitCadence(t *testing.T)
 	}
 }
 
+// The starvation watchdog counts ticks, so its window is a tick count
+// times a tick period. Oversampling shortens the period, and if the
+// count does not grow to match, the loop stops riding out a peer
+// restart and tears itself down partway through one instead.
+func TestSampleStarvationWindow_IsIndependentOfTheTickRate(t *testing.T) {
+	rate := mxl.Rational{Num: 48000, Den: 1}
+	const batch = 480
+
+	batchSpan := time.Duration(int64(time.Second) * int64(rate.Den) * batch / int64(rate.Num))
+	window := time.Duration(maxSampleStarvedTicks) * defaultSampleProgressInterval(rate, batch)
+
+	assert.Equal(t, time.Duration(maxSampleStarvedBatches)*batchSpan, window,
+		"the starvation window must stay the same wall-clock span "+
+			"however often the loop wakes within a batch")
+	assert.Equal(t, 2*time.Second, window,
+		"48 kHz in 480-sample batches: 200 batch periods is two seconds")
+}
+
 func TestDefaultSampleProgressInterval_ZeroBatchFallsBack(t *testing.T) {
 	assert.Zero(t, defaultSampleProgressInterval(mxl.Rational{Num: 48000, Den: 1}, 0),
 		"a zero batch leaves the interval to the caller's fallback")

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -2494,18 +2494,26 @@ const maxSampleCatchUpFallback = 2
 // slow completion landed, and the queue would fill anyway.
 const defaultProgressTimeout = 10 * time.Millisecond
 
+// sampleProgressOversample is how many times per xferBatch the sample
+// loop wakes. Ticking once per batch is two free-running clocks of the
+// same rate: they drift against each other, so one tick finds nothing
+// and the next finds two batches. Every sample still arrives, but in
+// pairs at twice the interval, which a reader sees as gaps. Waking
+// twice per batch keeps each commit in a tick of its own.
+const sampleProgressOversample = 2
+
 // defaultSampleProgressInterval returns the progress interval a
 // continuous (audio) flow uses when the operator has not configured
 // one. It is the time spanned by one xferBatch of samples at the
-// flow's grain (sample) rate: ~10 ms at 48 kHz with a 480-sample
-// batch, matching the natural commit cadence the reference transfer
-// loop uses. Zero when the rate or batch is unusable, so the caller
-// falls back to the 2 ms video default.
+// flow's grain (sample) rate, divided by sampleProgressOversample: 5 ms
+// at 48 kHz with a 480-sample batch. Zero when the rate or batch is
+// unusable, so the caller falls back to the 2 ms video default.
 func defaultSampleProgressInterval(rate mxl.Rational, xferBatch uint64) time.Duration {
 	if xferBatch == 0 || rate.Den <= 0 || rate.Num <= 0 {
 		return 0
 	}
-	return time.Duration(int64(time.Second) * int64(rate.Den) * int64(xferBatch) / int64(rate.Num))
+	batch := time.Duration(int64(time.Second) * int64(rate.Den) * int64(xferBatch) / int64(rate.Num))
+	return batch / sampleProgressOversample
 }
 
 // progressBlocking reports whether the provider's completion queue

--- a/gateway/internal/mirror/source.go
+++ b/gateway/internal/mirror/source.go
@@ -2461,12 +2461,18 @@ const maxSampleTransferRetries = 8
 // loop ages out and skips the bulk of the flow. A quarter is far
 // below anything a healthy mirror produces even under backpressure
 // -- the queue refutes whole chunks, not sample ranges within them --
-// so only a sustained trickle trips it. At the default grain-rate
-// interval one tick is ~10 ms of audio, so the window is a few
-// seconds of starvation: long enough to ride out a burst, short
-// enough that the rebuild the exit triggers outruns an operator
-// noticing.
-const maxSampleStarvedTicks = 200
+// so only a sustained trickle trips it. One batch period is ~10 ms of
+// audio, so the window is a few seconds of starvation: long enough to
+// ride out a burst, or a peer restarting, short enough that the
+// rebuild the exit triggers outruns an operator noticing.
+const maxSampleStarvedBatches = 200
+
+// maxSampleStarvedTicks is that same window counted in ticks. The loop
+// wakes sampleProgressOversample times per batch period, so the tick
+// bound has to scale with it: left as a bare count, shortening the tick
+// shortens the window with it, and the loop tears itself down partway
+// through a peer restart it was meant to ride out.
+const maxSampleStarvedTicks = maxSampleStarvedBatches * sampleProgressOversample
 
 // sampleCatchUpBatches is how many batches one tick may transfer. One
 // batch is real time, so four lets a mirror that fell behind close the


### PR DESCRIPTION
The progress interval for a continuous flow was one `xferBatch` of samples,
which is the same period the producer commits on. Two free-running clocks of
equal rate drift against each other, so one tick finds nothing and the next
finds two batches. Every sample still arrives, but in pairs at twice the
interval, which a reader sees as gaps.

Measured on a mirror across EFA, producer committing 480 samples every 10 ms,
90 s at both ends:

| | source | target before | target after |
| --- | --- | --- | --- |
| delivered | 4,320,000 (100.0%) | 4,320,000 (100.0%) | 4,319,520 (100.0%) |
| advances | 9000 (100.0/s) | 8069 (89.7/s) | 8999 (100.0/s) |
| advance size p90 / max | 480 / 480 | 960 / 960 | 480 / 480 |
| gap p90 / max | 10.0 / 11.5 ms | 20.5 / 22.5 ms | 15.0 / 16.0 ms |
| starved windows | 0 (0.0%) | 84 (1.9%) | 0 (0.0%) |
| verdict | SMOOTH | BURSTY | SMOOTH |

No samples were ever lost -- the ratio to real time was 100% throughout. What
changed is that they arrive one batch at a time, as the producer emits them,
instead of two batches at twice the spacing.

This never showed on the connected fabric because the producer there commits
irregularly, between 33 and 100 ms, which a 10 ms tick already oversamples. It
takes a producer on an exactly regular batch period to beat against.

The second commit is the coupling that came with it, and is why
`46-audio-mirror-target-gateway-bounce` failed on the first push. The
starvation watchdog counts consecutive *ticks*, so its window is a tick count
times a tick period: halving the period halved the window from two seconds to
one, and a source that should ride out the target gateway restarting instead
tore itself down partway through. The bound is now expressed in batch periods
and scaled by the oversample, so the window stays two seconds however often
the loop wakes.

Both tests assert the property rather than the constant, and both fail if
their change is reverted.