### PR TITLE
deps(go-mxl): update to v1.1.0-rc.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,7 +131,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.3
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.4
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -163,7 +163,7 @@ jobs:
     if: needs.changes.outputs.exporter == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.3
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.4
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -308,7 +308,7 @@ jobs:
     if: needs.changes.outputs.gateway == 'true' || needs.changes.outputs.workflow == 'true'
     runs-on: ubuntu-24.04
     container:
-      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.3
+      image: ghcr.io/qvest-digital/go-mxl-builder:1.1.0-rc.4
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7

--- a/exporter/go.mod
+++ b/exporter/go.mod
@@ -4,7 +4,7 @@ go 1.26.0
 
 require (
 	github.com/prometheus/client_golang v1.24.1
-	github.com/qvest-digital/go-mxl v1.1.0-rc.3
+	github.com/qvest-digital/go-mxl v1.1.0-rc.4
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.14 // x-release-please-version
 	golang.org/x/sys v0.47.0
 	k8s.io/apimachinery v0.37.0

--- a/exporter/go.sum
+++ b/exporter/go.sum
@@ -100,8 +100,8 @@ github.com/prometheus/common v0.70.1 h1:1HvjP4D5oL3t8RsPlwxA9onvvStjtIHYE5XuuwOi
 github.com/prometheus/common v0.70.1/go.mod h1:VdFUQDMZK3VLkurFUVhia6uys/0suUp86TJz5qbJRhc=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
-github.com/qvest-digital/go-mxl v1.1.0-rc.3 h1:9iPCZ+gjdPoBAavR02X2FuVA5wdiAhoRDe3+ht9MG98=
-github.com/qvest-digital/go-mxl v1.1.0-rc.3/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.1.0-rc.4 h1:qgOGSIv53HYQLTB06m39c6WE2xqMceObViZy5A3rZlA=
+github.com/qvest-digital/go-mxl v1.1.0-rc.4/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -3,7 +3,7 @@ module github.com/qvest-digital/mxl-k8s/gateway
 go 1.26.0
 
 require (
-	github.com/qvest-digital/go-mxl v1.1.0-rc.3
+	github.com/qvest-digital/go-mxl v1.1.0-rc.4
 	github.com/qvest-digital/mxl-k8s/api v1.0.0-rc.14 // x-release-please-version
 	github.com/stretchr/testify v1.12.1
 	go.uber.org/goleak v1.3.0

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -100,8 +100,8 @@ github.com/prometheus/common v0.70.1 h1:1HvjP4D5oL3t8RsPlwxA9onvvStjtIHYE5XuuwOi
 github.com/prometheus/common v0.70.1/go.mod h1:VdFUQDMZK3VLkurFUVhia6uys/0suUp86TJz5qbJRhc=
 github.com/prometheus/procfs v0.21.1 h1:GljZCt+zSTS+NZq88cyQ1LjZ+RCHp3uVuabBWA5+OJI=
 github.com/prometheus/procfs v0.21.1/go.mod h1:aB55Cww9pdSJVHk0hUf0inxWyyjPogFIjmHKYgMKmtY=
-github.com/qvest-digital/go-mxl v1.1.0-rc.3 h1:9iPCZ+gjdPoBAavR02X2FuVA5wdiAhoRDe3+ht9MG98=
-github.com/qvest-digital/go-mxl v1.1.0-rc.3/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
+github.com/qvest-digital/go-mxl v1.1.0-rc.4 h1:qgOGSIv53HYQLTB06m39c6WE2xqMceObViZy5A3rZlA=
+github.com/qvest-digital/go-mxl v1.1.0-rc.4/go.mod h1:cYzyT+S/AONytsKr/DozzFQP2OrNrg/JsQOSjvwn+Rk=
 github.com/spf13/pflag v1.0.10 h1:4EBh2KAYBwaONj6b2Ye1GiHfwjqyROoF4RwYO+vPwFk=
 github.com/spf13/pflag v1.0.10/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/hack/flow-probe.sh
+++ b/hack/flow-probe.sh
@@ -19,7 +19,7 @@ set -euo pipefail
 
 NS=${NS:-mxl-system}
 KEEP=${KEEP:-1}
-GO_MXL_TAG=${GO_MXL_TAG:-1.1.0-rc.2}
+GO_MXL_TAG=${GO_MXL_TAG:-1.1.0-rc.4}
 BUILDER=ghcr.io/qvest-digital/go-mxl-builder:${GO_MXL_TAG}
 RUNTIME=ghcr.io/qvest-digital/go-mxl-runtime:${GO_MXL_TAG}
 DOMAIN=${DOMAIN:-/run/mxl/domain}


### PR DESCRIPTION
Carries the libmxl fix that sizes a connectionless initiator's completion
queue to what its transmit queue accepts.

An EFA initiator posts against a transmit queue the provider reports as 4096
deep while holding a completion queue of 8. A provider stops accepting work
once the completion queue cannot hold a completion for it, so the ninth write
fails with `EAGAIN` and every write after it, with nothing completing to free
the space again. `RCInitiator` already sized its queue this way; only the
connectionless path was missed.

To be accurate about scope: cross-node EFA on AWS dev was blocked by two other
things, an EFA driver conftest that silently compiled a NULL ucontext path and
a security group missing the outbound rule EFA requires. Both are fixed and
deployed, and the released gateway already delivers 3000 of 3000 grains at
100% of real time across EFA without this. This is a latent defect found on
the way, worth shipping on its own terms.

`hack/flow-probe.sh` still defaulted to `1.1.0-rc.2`. It builds against the
same runtime the gateway does, so it moves with it.