### PR TITLE
test(kind): report no DaemonSet pod without aborting

### DIFF
--- a/test/integration/kind/lib.sh
+++ b/test/integration/kind/lib.sh
@@ -206,9 +206,15 @@ mirrors_sourced_from() {
 
 # daemonset_pod_on <ds-label-value> <node> -- name of the running
 # DaemonSet pod for the component on the node, empty when none.
+#
+# "None" is an ordinary result, not an error: a pod being replaced
+# leaves a window in which the old one already reports Succeeded and
+# its replacement is still Pending. Every caller assigns this under
+# set -e, so awk rather than grep -- it consumes the whole list and
+# exits 0 whether or not a name matched.
 daemonset_pod_on() {
   "${KUBECTL[@]}" -n "$NAMESPACE" get pods \
     --field-selector "spec.nodeName=$2,status.phase=Running" -o \
     'jsonpath={range .items[*]}{.metadata.name}{"\n"}{end}' \
-  | grep "^mxl-k8s-$1-" | head -1
+  | awk -v prefix="mxl-k8s-$1-" 'index($0, prefix) == 1 && !seen++ { print }'
 }


### PR DESCRIPTION
46-audio-mirror-target-gateway-bounce has failed intermittently since
it was added, always with the same shape: a duration of 0s or 1s, no
FAIL line, and the case log ending at the two lines the delete
prints. None of the delivery assertions the case exists for ever ran,
so a red run said nothing about the change under it.

The cause is not in the case. daemonset_pod_on documents "empty when
none" but ends in `grep | head`, and grep exits 1 when nothing
matches. All five call sites assign the helper to a variable under
`set -e`, so "none" aborts the case at the assignment, before any
`[ -n ... ] || fail` guard can turn it into a message.

"None" is a state the cluster passes through on every DaemonSet pod
replacement: the deleted pod reports Succeeded before the object is
removed, and the replacement is Pending until it starts, so for a
moment the node has no pod for the component in phase Running.
Sampled continuously against a two-node kind cluster, that window
runs from 308ms to 733ms after the delete call returns. Case 46 polls
for the replacement immediately after deleting the pod and has no
sleep before the first poll, so a first poll slowed by kubectl
startup on a loaded runner lands inside it.

awk consumes the whole list and exits 0 whether or not a name
matched, which is the idiom 47-exporter-metrics already uses for its
own line selection.

Measured on kind against the demo, with a 400ms delay in front of
every kubectl call and nothing else altered: the current helper fails
the case 3 of 3 with the CI signature exactly, output stopping after
the delete; the helper here passes 3 of 3, samples back at rate on
the first attempt each time. The full suite is 22 of 22 green.
